### PR TITLE
feat(supabase): Supabaseプロジェクト作成・初期設定 (#5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Supabase
+EXPO_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/app.json
+++ b/app.json
@@ -1,0 +1,40 @@
+{
+  "expo": {
+    "name": "御朱印コレクション",
+    "slug": "goshuin-app",
+    "version": "0.1.0",
+    "scheme": "com.goshuin.app",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "userInterfaceStyle": "light",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "assetBundlePatterns": ["**/*"],
+    "ios": {
+      "supportsTablet": false,
+      "bundleIdentifier": "com.goshuin.app",
+      "infoPlist": {
+        "NSLocationWhenInUseUsageDescription": "周辺の神社仏閣を表示するために位置情報を使用します",
+        "NSCameraUsageDescription": "御朱印を撮影するためにカメラを使用します",
+        "NSPhotoLibraryUsageDescription": "御朱印の画像を選択するためにフォトライブラリを使用します"
+      }
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#ffffff"
+      },
+      "package": "com.goshuin.app",
+      "permissions": [
+        "ACCESS_FINE_LOCATION",
+        "ACCESS_COARSE_LOCATION",
+        "CAMERA",
+        "READ_EXTERNAL_STORAGE"
+      ]
+    },
+    "plugins": ["expo-location", "expo-image-picker", "expo-camera", "expo-asset"]
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'jest-expo',
   testEnvironment: 'node',
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@supabase/.*|react-native-url-polyfill)',
   ],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,27 @@
 // Jest setup file
 // Add any global test setup here
 
+// localStorage mock for Supabase session persistence
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: key => store[key] ?? null,
+    setItem: (key, value) => {
+      store[key] = String(value);
+    },
+    removeItem: key => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(global, 'localStorage', {
+  value: localStorageMock,
+});
+
 // Silence console during tests (optional)
 // global.console = {
 //   ...console,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "name": "goshuin-app",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.95.3",
         "expo": "~52.0.0",
+        "expo-sqlite": "~16.0.10",
         "expo-status-bar": "~2.0.0",
         "react": "18.3.1",
-        "react-native": "0.76.0"
+        "react-native": "0.76.0",
+        "react-native-url-polyfill": "^3.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.0",
@@ -4600,6 +4603,86 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.95.3.tgz",
+      "integrity": "sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.95.3.tgz",
+      "integrity": "sha512-uTuOAKzs9R/IovW1krO0ZbUHSJnsnyJElTXIRhjJTqymIVGcHzkAYnBCJqd7468Fs/Foz1BQ7Dv6DCl05lr7ig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.95.3.tgz",
+      "integrity": "sha512-LTrRBqU1gOovxRm1vRXPItSMPBmEFqrfTqdPTRtzOILV4jPSueFz6pES5hpb4LRlkFwCPRmv3nQJ5N625V2Xrg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.95.3.tgz",
+      "integrity": "sha512-D7EAtfU3w6BEUxDACjowWNJo/ZRo7sDIuhuOGKHIm9FHieGeoJV5R6GKTLtga/5l/6fDr2u+WcW/m8I9SYmaIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.95.3.tgz",
+      "integrity": "sha512-4GxkJiXI3HHWjxpC3sDx1BVrV87O0hfX+wvJdqGv67KeCu+g44SPnII8y0LL/Wr677jB7tpjAxKdtVWf+xhc9A==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.95.3.tgz",
+      "integrity": "sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.95.3",
+        "@supabase/functions-js": "2.95.3",
+        "@supabase/postgrest-js": "2.95.3",
+        "@supabase/realtime-js": "2.95.3",
+        "@supabase/storage-js": "2.95.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@testing-library/react-native": {
       "version": "12.9.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-12.9.0.tgz",
@@ -4804,6 +4887,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -4834,6 +4923,15 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -6137,6 +6235,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
     },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
@@ -9489,6 +9593,20 @@
         "invariant": "^2.2.4"
       }
     },
+    "node_modules/expo-sqlite": {
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-16.0.10.tgz",
+      "integrity": "sha512-tUOKxE9TpfneRG3eOfbNfhN9236SJ7IiUnP8gCqU7umd9DtgDGB/5PhYVVfl+U7KskgolgNoB9v9OZ9iwXN8Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "await-lock": "^2.2.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-status-bar": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-2.0.1.tgz",
@@ -10578,6 +10696,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -15784,6 +15911,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-url-polyfill": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-3.0.0.tgz",
+      "integrity": "sha512-aA5CiuUCUb/lbrliVCJ6lZ17/RpNJzvTO/C7gC/YmDQhTUoRD5q5HlJfwLWcxz4VgAhHwXKzhxH+wUN24tAdqg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url-without-unicode": "8.0.0-3"
+      },
+      "peerDependencies": {
+        "react-native": "*"
       }
     },
     "node_modules/react-native/node_modules/@react-native/codegen": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,13 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.95.3",
     "expo": "~52.0.0",
+    "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",
-    "react-native": "0.76.0"
+    "react-native": "0.76.0",
+    "react-native-url-polyfill": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",

--- a/src/services/__tests__/supabase.test.ts
+++ b/src/services/__tests__/supabase.test.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const mockCreateClient = jest.fn(() => ({
+  auth: {},
+  from: jest.fn(),
+  storage: {},
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: mockCreateClient,
+}));
+
+jest.mock('react-native-url-polyfill/auto', () => {});
+
+describe('Supabase client', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockCreateClient.mockClear();
+    process.env.EXPO_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
+  });
+
+  it('should export a supabase client', () => {
+    const { supabase } = require('../supabase');
+    expect(supabase).toBeDefined();
+  });
+
+  it('should call createClient with correct URL and key', () => {
+    require('../supabase');
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      'https://test.supabase.co',
+      'test-anon-key',
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          storage: globalThis.localStorage,
+          autoRefreshToken: true,
+          persistSession: true,
+          detectSessionInUrl: false,
+        }),
+      })
+    );
+  });
+
+  it('should call createClient exactly once (singleton)', () => {
+    require('../supabase');
+    require('../supabase');
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw when EXPO_PUBLIC_SUPABASE_URL is empty', () => {
+    process.env.EXPO_PUBLIC_SUPABASE_URL = '';
+    expect(() => require('../supabase')).toThrow('EXPO_PUBLIC_SUPABASE_URL is not set');
+  });
+
+  it('should throw when EXPO_PUBLIC_SUPABASE_ANON_KEY is empty', () => {
+    process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY = '';
+    expect(() => require('../supabase')).toThrow('EXPO_PUBLIC_SUPABASE_ANON_KEY is not set');
+  });
+});

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -1,0 +1,26 @@
+import 'react-native-url-polyfill/auto';
+
+import { createClient } from '@supabase/supabase-js';
+
+// babel-preset-expo は process.env.EXPO_PUBLIC_* をビルド時にインライン化する。
+// テスト環境では process.env から直接取得するためヘルパーを使用。
+const env = process.env;
+const supabaseUrl = env['EXPO_PUBLIC_SUPABASE_URL'];
+const supabaseAnonKey = env['EXPO_PUBLIC_SUPABASE_ANON_KEY'];
+
+if (!supabaseUrl) {
+  throw new Error('EXPO_PUBLIC_SUPABASE_URL is not set');
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('EXPO_PUBLIC_SUPABASE_ANON_KEY is not set');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    storage: globalThis.localStorage,
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false,
+  },
+});

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,51 @@
+// Supabase 型定義（プレースホルダー）
+// TODO: Supabase CLI の `supabase gen types typescript` で自動生成に置き換え
+
+export type SpotType = 'shrine' | 'temple';
+export type SpotStatus = 'active' | 'pending' | 'merged';
+
+export interface Profile {
+  id: string;
+  email: string | null;
+  display_name: string | null;
+  avatar_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Spot {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  type: SpotType;
+  address: string | null;
+  status: SpotStatus;
+  created_by_user_id: string | null;
+  merged_into_spot_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Stamp {
+  id: string;
+  user_id: string;
+  spot_id: string;
+  goshuincho_id: string | null;
+  visited_at: string;
+  image_path: string;
+  memo: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Goshuincho {
+  id: string;
+  user_id: string;
+  name: string;
+  cover_image_path: string | null;
+  started_at: string | null;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- Supabaseプロジェクト作成（ap-northeast-1リージョン）・DB/Storage/認証の基盤構築
- profiles, spots, stamps, goshuincho テーブル作成（RLS, トリガー, インデックス付き）
- goshuin-images Storageバケット作成（プライベート, 5MB上限, RLS付き）
- Expo側: Supabaseクライアント初期化、環境変数バリデーション、型定義

## Test plan
- [x] `npm test` — 5件パス（クライアント生成, パラメータ検証, シングルトン, バリデーション×2）
- [x] `npm run lint` — エラーなし
- [x] `npm run typecheck` — エラーなし
- [ ] Google OAuth: Dashboard設定済み、ログイン画面実装時に動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)