### PR TITLE
feat(ui): Stitch MCPデザインを参考にMVP全画面UIを実装 (#8)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
     '^@stores/(.*)$': '<rootDir>/src/stores/$1',
     '^@types/(.*)$': '<rootDir>/src/types/$1',
     '^@utils/(.*)$': '<rootDir>/src/utils/$1',
+    '^@theme/(.*)$': '<rootDir>/src/theme/$1',
   },
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts', '!src/**/__tests__/**'],
   testMatch: ['**/__tests__/**/*.test.{ts,tsx}', '**/*.test.{ts,tsx}'],

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -43,6 +43,15 @@ Object.defineProperty(global, 'localStorage', {
   value: localStorageMock,
 });
 
+// @expo/vector-icons mock
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const MockIcon = props => React.createElement('Text', props, props.name);
+  return {
+    MaterialIcons: MockIcon,
+  };
+});
+
 // Silence console during tests (optional)
 // global.console = {
 //   ...console,

--- a/src/components/__tests__/animated.test.tsx
+++ b/src/components/__tests__/animated.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { FABButton } from '@components/animated/FABButton';
+import { CheckmarkAnimation } from '@components/animated/CheckmarkAnimation';
+import { BadgeAnimation } from '@components/animated/BadgeAnimation';
+import { OnboardingIcon } from '@components/animated/OnboardingIcon';
+import { ErrorIcon } from '@components/animated/ErrorIcon';
+
+describe('Animated Components', () => {
+  describe('FABButton', () => {
+    it('renders', () => {
+      const { getByTestId } = render(<FABButton onPress={() => {}} />);
+      expect(getByTestId('fab-button')).toBeTruthy();
+    });
+  });
+
+  describe('CheckmarkAnimation', () => {
+    it('renders', () => {
+      const { getByTestId } = render(<CheckmarkAnimation />);
+      expect(getByTestId('checkmark-animation')).toBeTruthy();
+    });
+
+    it('renders with custom size', () => {
+      const { getByTestId } = render(<CheckmarkAnimation size={120} />);
+      expect(getByTestId('checkmark-animation')).toBeTruthy();
+    });
+  });
+
+  describe('BadgeAnimation', () => {
+    it('renders with badge name', () => {
+      const { getByTestId, getByText } = render(<BadgeAnimation badgeName="初めての参拝" />);
+      expect(getByTestId('badge-animation')).toBeTruthy();
+      expect(getByText('初めての参拝')).toBeTruthy();
+    });
+
+    it('renders with description', () => {
+      const { getByText } = render(
+        <BadgeAnimation badgeName="初めての参拝" description="最初の御朱印を記録しました" />
+      );
+      expect(getByText('最初の御朱印を記録しました')).toBeTruthy();
+    });
+  });
+
+  describe('OnboardingIcon', () => {
+    it('renders', () => {
+      const { getByTestId } = render(<OnboardingIcon name="map" backgroundColor="#F97316" />);
+      expect(getByTestId('onboarding-icon')).toBeTruthy();
+    });
+  });
+
+  describe('ErrorIcon', () => {
+    it('renders network error icon', () => {
+      const { getByTestId } = render(<ErrorIcon type="network" />);
+      expect(getByTestId('error-icon-network')).toBeTruthy();
+    });
+
+    it('renders location error icon', () => {
+      const { getByTestId } = render(<ErrorIcon type="location" />);
+      expect(getByTestId('error-icon-location')).toBeTruthy();
+    });
+
+    it('renders upload error icon', () => {
+      const { getByTestId } = render(<ErrorIcon type="upload" />);
+      expect(getByTestId('error-icon-upload')).toBeTruthy();
+    });
+  });
+});

--- a/src/components/__tests__/common.test.tsx
+++ b/src/components/__tests__/common.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { Button } from '@components/common/Button';
+import { Badge } from '@components/common/Badge';
+import { Card } from '@components/common/Card';
+import { SearchBar } from '@components/common/SearchBar';
+import { PageIndicator } from '@components/common/PageIndicator';
+import { Text } from 'react-native';
+
+describe('Common Components', () => {
+  describe('Button', () => {
+    it('renders with title', () => {
+      const { getByText } = render(<Button title="テスト" onPress={() => {}} />);
+      expect(getByText('テスト')).toBeTruthy();
+    });
+
+    it('renders primary variant by default', () => {
+      const { getByTestId } = render(<Button title="テスト" onPress={() => {}} />);
+      expect(getByTestId('button-primary')).toBeTruthy();
+    });
+
+    it('renders outline variant', () => {
+      const { getByTestId } = render(
+        <Button title="テスト" onPress={() => {}} variant="outline" />
+      );
+      expect(getByTestId('button-outline')).toBeTruthy();
+    });
+
+    it('renders secondary variant', () => {
+      const { getByTestId } = render(
+        <Button title="テスト" onPress={() => {}} variant="secondary" />
+      );
+      expect(getByTestId('button-secondary')).toBeTruthy();
+    });
+
+    it('renders ghost variant', () => {
+      const { getByTestId } = render(<Button title="テスト" onPress={() => {}} variant="ghost" />);
+      expect(getByTestId('button-ghost')).toBeTruthy();
+    });
+  });
+
+  describe('Badge', () => {
+    it('renders shrine badge', () => {
+      const { getByTestId, getByText } = render(<Badge type="shrine" />);
+      expect(getByTestId('badge-shrine')).toBeTruthy();
+      expect(getByText('神社')).toBeTruthy();
+    });
+
+    it('renders temple badge', () => {
+      const { getByTestId, getByText } = render(<Badge type="temple" />);
+      expect(getByTestId('badge-temple')).toBeTruthy();
+      expect(getByText('寺院')).toBeTruthy();
+    });
+
+    it('renders visited badge', () => {
+      const { getByTestId, getByText } = render(<Badge type="visited" />);
+      expect(getByTestId('badge-visited')).toBeTruthy();
+      expect(getByText('訪問済み')).toBeTruthy();
+    });
+
+    it('renders custom label', () => {
+      const { getByText } = render(<Badge type="shrine" label="カスタム" />);
+      expect(getByText('カスタム')).toBeTruthy();
+    });
+  });
+
+  describe('Card', () => {
+    it('renders children', () => {
+      const { getByText, getByTestId } = render(
+        <Card>
+          <Text>カード内容</Text>
+        </Card>
+      );
+      expect(getByTestId('card')).toBeTruthy();
+      expect(getByText('カード内容')).toBeTruthy();
+    });
+  });
+
+  describe('SearchBar', () => {
+    it('renders with default placeholder', () => {
+      const { getByTestId, getByPlaceholderText } = render(<SearchBar />);
+      expect(getByTestId('search-bar')).toBeTruthy();
+      expect(getByPlaceholderText('神社・寺院を検索')).toBeTruthy();
+    });
+
+    it('renders with custom placeholder', () => {
+      const { getByPlaceholderText } = render(<SearchBar placeholder="カスタム検索" />);
+      expect(getByPlaceholderText('カスタム検索')).toBeTruthy();
+    });
+  });
+
+  describe('PageIndicator', () => {
+    it('renders correct number of dots', () => {
+      const { getByTestId, getAllByTestId } = render(<PageIndicator total={4} current={0} />);
+      expect(getByTestId('page-indicator')).toBeTruthy();
+      expect(getAllByTestId('dot-active')).toHaveLength(1);
+      expect(getAllByTestId('dot-inactive')).toHaveLength(3);
+    });
+
+    it('highlights correct dot', () => {
+      const { getAllByTestId } = render(<PageIndicator total={4} current={2} />);
+      expect(getAllByTestId('dot-active')).toHaveLength(1);
+      expect(getAllByTestId('dot-inactive')).toHaveLength(3);
+    });
+  });
+});

--- a/src/components/animated/BadgeAnimation.tsx
+++ b/src/components/animated/BadgeAnimation.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
+
+interface BadgeAnimationProps {
+  badgeName: string;
+  description?: string;
+}
+
+export const BadgeAnimation: React.FC<BadgeAnimationProps> = ({ badgeName, description }) => {
+  return (
+    <View style={styles.container} testID="badge-animation">
+      <View style={styles.iconContainer}>
+        <MaterialIcons name="military-tech" size={40} color={colors.warning} />
+      </View>
+      <Text style={styles.name}>{badgeName}</Text>
+      {description && <Text style={styles.description}>{description}</Text>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  iconContainer: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  name: {
+    ...typography.h3,
+    color: colors.white,
+  },
+  description: {
+    ...typography.bodySmall,
+    color: 'rgba(255,255,255,0.8)',
+    textAlign: 'center',
+  },
+});

--- a/src/components/animated/CheckmarkAnimation.tsx
+++ b/src/components/animated/CheckmarkAnimation.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { colors } from '@theme/colors';
+
+interface CheckmarkAnimationProps {
+  size?: number;
+}
+
+export const CheckmarkAnimation: React.FC<CheckmarkAnimationProps> = ({ size = 80 }) => {
+  return (
+    <View
+      style={[styles.container, { width: size, height: size, borderRadius: size / 2 }]}
+      testID="checkmark-animation"
+    >
+      <MaterialIcons name="check" size={size * 0.6} color={colors.white} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.white,
+    alignItems: 'center',
+    justifyContent: 'center',
+    opacity: 0.3,
+  },
+});

--- a/src/components/animated/ErrorIcon.tsx
+++ b/src/components/animated/ErrorIcon.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { colors } from '@theme/colors';
+
+type ErrorType = 'network' | 'location' | 'upload';
+
+const errorIconConfig: Record<
+  ErrorType,
+  { icon: keyof typeof MaterialIcons.glyphMap; color: string }
+> = {
+  network: { icon: 'wifi-off', color: colors.gray[400] },
+  location: { icon: 'location-off', color: colors.primary[500] },
+  upload: { icon: 'cloud-off', color: colors.error },
+};
+
+interface ErrorIconProps {
+  type: ErrorType;
+  size?: number;
+}
+
+export const ErrorIcon: React.FC<ErrorIconProps> = ({ type, size = 64 }) => {
+  const config = errorIconConfig[type];
+
+  return (
+    <View style={styles.container} testID={`error-icon-${type}`}>
+      <MaterialIcons
+        name={config.icon as keyof typeof MaterialIcons.glyphMap}
+        size={size}
+        color={config.color}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/components/animated/FABButton.tsx
+++ b/src/components/animated/FABButton.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { TouchableOpacity, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { colors } from '@theme/colors';
+import { shadows } from '@theme/shadows';
+
+interface FABButtonProps {
+  onPress: () => void;
+}
+
+export const FABButton: React.FC<FABButtonProps> = ({ onPress }) => {
+  return (
+    <TouchableOpacity style={styles.fab} onPress={onPress} activeOpacity={0.8} testID="fab-button">
+      <MaterialIcons name="add" size={32} color={colors.white} />
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  fab: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: colors.primary[500],
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.lg,
+  },
+});

--- a/src/components/animated/OnboardingIcon.tsx
+++ b/src/components/animated/OnboardingIcon.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { borderRadius } from '@theme/spacing';
+import { shadows } from '@theme/shadows';
+import { colors } from '@theme/colors';
+
+type IconName = 'map' | 'camera-alt' | 'emoji-events' | 'place';
+
+interface OnboardingIconProps {
+  name: IconName;
+  backgroundColor: string;
+}
+
+export const OnboardingIcon: React.FC<OnboardingIconProps> = ({ name, backgroundColor }) => {
+  return (
+    <View style={[styles.container, { backgroundColor }]} testID="onboarding-icon">
+      <MaterialIcons name={name} size={48} color={colors.white} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: 96,
+    height: 96,
+    borderRadius: borderRadius['3xl'],
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.lg,
+  },
+});

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { borderRadius, spacing } from '@theme/spacing';
+
+type BadgeType = 'shrine' | 'temple' | 'visited';
+
+interface BadgeProps {
+  type: BadgeType;
+  label?: string;
+}
+
+const badgeConfig: Record<BadgeType, { bg: string; text: string; defaultLabel: string }> = {
+  shrine: {
+    bg: colors.shrine[100],
+    text: colors.shrine[600],
+    defaultLabel: '神社',
+  },
+  temple: {
+    bg: colors.temple[100],
+    text: colors.temple[600],
+    defaultLabel: '寺院',
+  },
+  visited: {
+    bg: colors.primary[100],
+    text: colors.primary[600],
+    defaultLabel: '訪問済み',
+  },
+};
+
+export const Badge: React.FC<BadgeProps> = ({ type, label }) => {
+  const config = badgeConfig[type];
+
+  return (
+    <View style={[styles.badge, { backgroundColor: config.bg }]} testID={`badge-${type}`}>
+      <Text style={[styles.text, { color: config.text }]}>{label ?? config.defaultLabel}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  badge: {
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderRadius: borderRadius.full,
+    alignSelf: 'flex-start',
+  },
+  text: {
+    ...typography.label,
+    fontWeight: '600',
+  },
+});

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet, ViewStyle, TextStyle } from 'react-native';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { borderRadius, spacing } from '@theme/spacing';
+
+type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost';
+
+interface ButtonProps {
+  title: string;
+  onPress: () => void;
+  variant?: ButtonVariant;
+  disabled?: boolean;
+  style?: ViewStyle;
+  textStyle?: TextStyle;
+}
+
+export const Button: React.FC<ButtonProps> = ({
+  title,
+  onPress,
+  variant = 'primary',
+  disabled = false,
+  style,
+  textStyle,
+}) => {
+  return (
+    <TouchableOpacity
+      style={[styles.base, variantStyles[variant], disabled && styles.disabled, style]}
+      onPress={onPress}
+      disabled={disabled}
+      activeOpacity={0.7}
+      testID={`button-${variant}`}
+    >
+      <Text
+        style={[
+          styles.text,
+          variantTextStyles[variant],
+          disabled && styles.disabledText,
+          textStyle,
+        ]}
+      >
+        {title}
+      </Text>
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  base: {
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing['2xl'],
+    borderRadius: borderRadius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    ...typography.button,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  disabledText: {
+    opacity: 0.7,
+  },
+});
+
+const variantStyles: Record<ButtonVariant, ViewStyle> = {
+  primary: {
+    backgroundColor: colors.primary[500],
+  },
+  secondary: {
+    backgroundColor: colors.gray[100],
+  },
+  outline: {
+    backgroundColor: colors.transparent,
+    borderWidth: 1,
+    borderColor: colors.primary[500],
+  },
+  ghost: {
+    backgroundColor: colors.transparent,
+  },
+};
+
+const variantTextStyles: Record<ButtonVariant, TextStyle> = {
+  primary: {
+    color: colors.white,
+  },
+  secondary: {
+    color: colors.gray[800],
+  },
+  outline: {
+    color: colors.primary[500],
+  },
+  ghost: {
+    color: colors.primary[500],
+  },
+};

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View, StyleSheet, ViewStyle } from 'react-native';
+import { colors } from '@theme/colors';
+import { borderRadius, spacing } from '@theme/spacing';
+import { shadows } from '@theme/shadows';
+
+interface CardProps {
+  children: React.ReactNode;
+  style?: ViewStyle;
+}
+
+export const Card: React.FC<CardProps> = ({ children, style }) => {
+  return (
+    <View style={[styles.card, style]} testID="card">
+      {children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.white,
+    borderRadius: borderRadius.lg,
+    padding: spacing.lg,
+    ...shadows.md,
+  },
+});

--- a/src/components/common/PageIndicator.tsx
+++ b/src/components/common/PageIndicator.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { colors } from '@theme/colors';
+import { spacing } from '@theme/spacing';
+
+interface PageIndicatorProps {
+  total: number;
+  current: number;
+}
+
+export const PageIndicator: React.FC<PageIndicatorProps> = ({ total, current }) => {
+  return (
+    <View style={styles.container} testID="page-indicator">
+      {Array.from({ length: total }, (_, i) => (
+        <View
+          key={i}
+          style={[styles.dot, i === current ? styles.activeDot : styles.inactiveDot]}
+          testID={i === current ? 'dot-active' : 'dot-inactive'}
+        />
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+  },
+  dot: {
+    height: 8,
+    borderRadius: 4,
+  },
+  activeDot: {
+    width: 24,
+    backgroundColor: colors.primary[500],
+  },
+  inactiveDot: {
+    width: 8,
+    backgroundColor: colors.gray[300],
+  },
+});

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, TextInput, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { borderRadius, spacing } from '@theme/spacing';
+import { shadows } from '@theme/shadows';
+
+interface SearchBarProps {
+  placeholder?: string;
+  value?: string;
+  onChangeText?: (text: string) => void;
+  onFocus?: () => void;
+}
+
+export const SearchBar: React.FC<SearchBarProps> = ({
+  placeholder = '神社・寺院を検索',
+  value,
+  onChangeText,
+  onFocus,
+}) => {
+  return (
+    <View style={styles.container} testID="search-bar">
+      <MaterialIcons name="search" size={20} color={colors.gray[400]} />
+      <TextInput
+        style={styles.input}
+        placeholder={placeholder}
+        placeholderTextColor={colors.gray[400]}
+        value={value}
+        onChangeText={onChangeText}
+        onFocus={onFocus}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.white,
+    borderRadius: borderRadius.xl,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  input: {
+    flex: 1,
+    ...typography.body,
+    color: colors.gray[800],
+    padding: 0,
+  },
+});

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,7 +1,7 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { Text } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
 
 import { MapStack } from '@/navigation/MapStack';
 import { GalleryStack } from '@/navigation/GalleryStack';
@@ -30,7 +30,7 @@ export function TabNavigator() {
         component={MapStack}
         options={{
           title: '地図',
-          tabBarIcon: ({ color }) => <Text style={{ color }}>🗺</Text>,
+          tabBarIcon: ({ color }) => <MaterialIcons name="explore" size={24} color={color} />,
         }}
       />
       <Tab.Screen
@@ -38,7 +38,7 @@ export function TabNavigator() {
         component={GalleryStack}
         options={{
           title: 'ギャラリー',
-          tabBarIcon: ({ color }) => <Text style={{ color }}>📷</Text>,
+          tabBarIcon: ({ color }) => <MaterialIcons name="photo-library" size={24} color={color} />,
         }}
         listeners={() => ({
           tabPress: e => {
@@ -54,7 +54,7 @@ export function TabNavigator() {
         component={CollectionScreen}
         options={{
           title: 'コレクション',
-          tabBarIcon: ({ color }) => <Text style={{ color }}>🏆</Text>,
+          tabBarIcon: ({ color }) => <MaterialIcons name="emoji-events" size={24} color={color} />,
         }}
         listeners={() => ({
           tabPress: e => {
@@ -70,7 +70,7 @@ export function TabNavigator() {
         component={SettingsScreen}
         options={{
           title: '設定',
-          tabBarIcon: ({ color }) => <Text style={{ color }}>⚙</Text>,
+          tabBarIcon: ({ color }) => <MaterialIcons name="settings" size={24} color={color} />,
         }}
       />
     </Tab.Navigator>

--- a/src/navigation/__tests__/RootNavigator.test.tsx
+++ b/src/navigation/__tests__/RootNavigator.test.tsx
@@ -44,10 +44,10 @@ describe('RootNavigator', () => {
       completeOnboarding: jest.fn(),
     });
 
-    const { queryByText } = renderWithNavigation();
+    const { queryByTestId } = renderWithNavigation();
 
-    expect(queryByText('Onboarding')).toBeNull();
-    expect(queryByText('Map')).toBeNull();
+    expect(queryByTestId('onboarding-screen')).toBeNull();
+    expect(queryByTestId('map-screen')).toBeNull();
   });
 
   it('shows Onboarding screen when onboarding is not completed', async () => {
@@ -57,10 +57,10 @@ describe('RootNavigator', () => {
       completeOnboarding: jest.fn(),
     });
 
-    const { getByText } = renderWithNavigation();
+    const { getByTestId } = renderWithNavigation();
 
     await waitFor(() => {
-      expect(getByText('Onboarding')).toBeTruthy();
+      expect(getByTestId('onboarding-screen')).toBeTruthy();
     });
   });
 
@@ -71,10 +71,10 @@ describe('RootNavigator', () => {
       completeOnboarding: jest.fn(),
     });
 
-    const { getByText } = renderWithNavigation();
+    const { getByTestId } = renderWithNavigation();
 
     await waitFor(() => {
-      expect(getByText('Map')).toBeTruthy();
+      expect(getByTestId('map-screen')).toBeTruthy();
     });
   });
 });

--- a/src/navigation/__tests__/TabNavigator.test.tsx
+++ b/src/navigation/__tests__/TabNavigator.test.tsx
@@ -121,7 +121,7 @@ describe('TabNavigator', () => {
       isAuthenticated: true,
     });
 
-    const { getByText, queryByText } = renderTabNavigator();
+    const { getByText, queryByText, getByTestId } = renderTabNavigator();
 
     await waitFor(() => {
       expect(getByText('ギャラリー')).toBeTruthy();
@@ -130,7 +130,7 @@ describe('TabNavigator', () => {
     fireEvent.press(getByText('ギャラリー'));
 
     await waitFor(() => {
-      expect(getByText('Gallery')).toBeTruthy();
+      expect(getByTestId('gallery-list')).toBeTruthy();
     });
 
     expect(queryByText('Login Screen')).toBeNull();

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -10,6 +10,7 @@ export type RootStackParamList = {
   Record: undefined;
   RecordComplete: undefined;
   Login: undefined;
+  Error: { type: 'network' | 'location' | 'upload' };
 };
 
 export type MainTabParamList = {

--- a/src/screens/CollectionScreen.tsx
+++ b/src/screens/CollectionScreen.tsx
@@ -1,25 +1,242 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { Card } from '@components/common/Card';
+import { colors } from '@theme/colors';
+import { borderRadius, spacing } from '@theme/spacing';
+import { typography } from '@theme/typography';
 import type { MainTabScreenProps } from '@/navigation/types';
 
 type Props = MainTabScreenProps<'Collection'>;
 
+const REGION_DATA = [
+  { name: '東京都', count: 15, total: 50 },
+  { name: '京都府', count: 8, total: 40 },
+  { name: '宮城県', count: 5, total: 30 },
+];
+
+const CHALLENGE_DATA = [
+  { name: '四国八十八ヶ所', progress: 12, total: 88 },
+  { name: '西国三十三所', progress: 5, total: 33 },
+];
+
+const BADGE_DATA = [
+  { name: '初参拝', earned: true },
+  { name: '10箇所達成', earned: true },
+  { name: '御朱印マスター', earned: true },
+  { name: '巡礼者', earned: false },
+  { name: '全国制覇', earned: false },
+  { name: '伝説', earned: false },
+];
+
 export function CollectionScreen(_props: Props) {
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Collection</Text>
-    </View>
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.header}>コレクション</Text>
+
+        {/* Achievement Summary */}
+        <View style={styles.summaryRow}>
+          <Card style={styles.summaryCard}>
+            <MaterialIcons name="place" size={28} color={colors.primary[500]} />
+            <Text style={styles.summaryNumber}>33</Text>
+            <Text style={styles.summaryLabel}>箇所</Text>
+          </Card>
+          <Card style={styles.summaryCard}>
+            <MaterialIcons name="collections" size={28} color={colors.primary[500]} />
+            <Text style={styles.summaryNumber}>45</Text>
+            <Text style={styles.summaryLabel}>枚</Text>
+          </Card>
+        </View>
+
+        {/* Region Section */}
+        <Text style={styles.sectionTitle}>地域別</Text>
+        <Card style={styles.sectionCard}>
+          {REGION_DATA.map(region => (
+            <View key={region.name} style={styles.regionRow}>
+              <Text style={styles.regionName}>{region.name}</Text>
+              <View style={styles.progressBarContainer}>
+                <View style={styles.progressBarBg}>
+                  <View
+                    style={[
+                      styles.progressBarFill,
+                      { width: `${(region.count / region.total) * 100}%` },
+                    ]}
+                  />
+                </View>
+              </View>
+              <Text style={styles.regionCount}>{region.count}</Text>
+            </View>
+          ))}
+        </Card>
+
+        {/* Challenge Section */}
+        <Text style={styles.sectionTitle}>巡礼チャレンジ</Text>
+        {CHALLENGE_DATA.map(challenge => (
+          <Card key={challenge.name} style={styles.challengeCard}>
+            <Text style={styles.challengeName}>{challenge.name}</Text>
+            <View style={styles.progressBarBg}>
+              <View
+                style={[
+                  styles.progressBarFill,
+                  { width: `${(challenge.progress / challenge.total) * 100}%` },
+                ]}
+              />
+            </View>
+            <Text style={styles.challengeProgress}>
+              {challenge.progress}/{challenge.total}
+            </Text>
+          </Card>
+        ))}
+
+        {/* Badge Section */}
+        <Text style={styles.sectionTitle}>バッジ</Text>
+        <View style={styles.badgeGrid}>
+          {BADGE_DATA.map(badge => (
+            <View key={badge.name} style={styles.badgeItem}>
+              <View
+                style={[
+                  styles.badgeCircle,
+                  badge.earned ? styles.badgeEarned : styles.badgeUnearned,
+                ]}
+              >
+                <MaterialIcons
+                  name={badge.earned ? 'military-tech' : 'lock'}
+                  size={28}
+                  color={badge.earned ? colors.white : colors.gray[400]}
+                />
+              </View>
+              <Text style={styles.badgeName}>{badge.name}</Text>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: colors.background,
   },
-  text: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  scrollView: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing.lg,
+    paddingBottom: spacing['4xl'],
+  },
+  header: {
+    ...typography.h2,
+    color: colors.gray[900],
+    marginBottom: spacing.lg,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    marginBottom: spacing.xl,
+  },
+  summaryCard: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: spacing.xl,
+  },
+  summaryNumber: {
+    ...typography.h1,
+    color: colors.gray[900],
+    marginTop: spacing.sm,
+  },
+  summaryLabel: {
+    ...typography.caption,
+    color: colors.gray[500],
+    marginTop: spacing.xs,
+  },
+  sectionTitle: {
+    ...typography.h3,
+    color: colors.gray[800],
+    marginBottom: spacing.md,
+  },
+  sectionCard: {
+    marginBottom: spacing.xl,
+  },
+  regionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  regionName: {
+    ...typography.bodySmall,
+    color: colors.gray[700],
+    width: 56,
+  },
+  progressBarContainer: {
+    flex: 1,
+    marginHorizontal: spacing.sm,
+  },
+  progressBarBg: {
+    height: 8,
+    backgroundColor: colors.primary[100],
+    borderRadius: borderRadius.full,
+    overflow: 'hidden',
+  },
+  progressBarFill: {
+    height: '100%',
+    backgroundColor: colors.primary[500],
+    borderRadius: borderRadius.full,
+  },
+  regionCount: {
+    ...typography.bodySmall,
+    color: colors.gray[700],
+    width: 28,
+    textAlign: 'right',
+  },
+  challengeCard: {
+    marginBottom: spacing.md,
+  },
+  challengeName: {
+    ...typography.body,
+    color: colors.gray[800],
+    marginBottom: spacing.sm,
+  },
+  challengeProgress: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+    marginTop: spacing.xs,
+    textAlign: 'right',
+  },
+  badgeGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.lg,
+    marginBottom: spacing.xl,
+  },
+  badgeItem: {
+    alignItems: 'center',
+    width: 80,
+  },
+  badgeCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeEarned: {
+    backgroundColor: colors.warning,
+  },
+  badgeUnearned: {
+    backgroundColor: colors.gray[200],
+  },
+  badgeName: {
+    ...typography.caption,
+    color: colors.gray[600],
+    marginTop: spacing.xs,
+    textAlign: 'center',
   },
 });

--- a/src/screens/ErrorScreen.tsx
+++ b/src/screens/ErrorScreen.tsx
@@ -1,0 +1,109 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { Button } from '@components/common/Button';
+import { ErrorIcon } from '@components/animated/ErrorIcon';
+import { colors } from '@theme/colors';
+import { spacing } from '@theme/spacing';
+import { typography } from '@theme/typography';
+import type { RootStackScreenProps } from '@/navigation/types';
+
+type Props = RootStackScreenProps<'Error'>;
+
+type ErrorType = 'network' | 'location' | 'upload';
+
+const ERROR_CONFIG: Record<
+  ErrorType,
+  {
+    title: string;
+    description: string;
+    primaryButton: string;
+    secondaryButton?: string;
+  }
+> = {
+  network: {
+    title: 'ネットワークエラー',
+    description: 'インターネット接続を確認してください',
+    primaryButton: '再試行',
+  },
+  location: {
+    title: '位置情報エラー',
+    description: '位置情報の利用を許可してください',
+    primaryButton: '設定を開く',
+    secondaryButton: 'あとで設定する',
+  },
+  upload: {
+    title: 'アップロードエラー',
+    description: '画像のアップロードに失敗しました',
+    primaryButton: '再試行',
+    secondaryButton: 'キャンセル',
+  },
+};
+
+export function ErrorScreen({ route, navigation }: Props) {
+  const errorType = route.params.type;
+  const config = ERROR_CONFIG[errorType];
+
+  const handlePrimaryPress = () => {
+    navigation.goBack();
+  };
+
+  const handleSecondaryPress = () => {
+    navigation.goBack();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <ErrorIcon type={errorType} size={64} />
+        <Text style={styles.title}>{config.title}</Text>
+        <Text style={styles.description}>{config.description}</Text>
+        <View style={styles.buttonContainer}>
+          <Button
+            title={config.primaryButton}
+            onPress={handlePrimaryPress}
+            variant="primary"
+            style={styles.primaryButton}
+          />
+          {config.secondaryButton && (
+            <Button title={config.secondaryButton} onPress={handleSecondaryPress} variant="ghost" />
+          )}
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing['3xl'],
+  },
+  title: {
+    ...typography.h2,
+    color: colors.gray[900],
+    marginTop: spacing.xl,
+    textAlign: 'center',
+  },
+  description: {
+    ...typography.body,
+    color: colors.gray[500],
+    marginTop: spacing.md,
+    textAlign: 'center',
+  },
+  buttonContainer: {
+    marginTop: spacing['3xl'],
+    width: '100%',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  primaryButton: {
+    width: '100%',
+  },
+});

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -1,25 +1,135 @@
-import { StyleSheet, Text, View } from 'react-native';
-
+import React, { useState } from 'react';
+import { StyleSheet, Text, View, FlatList, TouchableOpacity, Dimensions } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
 import type { GalleryStackScreenProps } from '@/navigation/types';
 
 type Props = GalleryStackScreenProps<'Gallery'>;
 
-export function GalleryScreen(_props: Props) {
+interface GalleryItem {
+  id: string;
+  spotName: string;
+  date: string;
+}
+
+const MOCK_DATA: GalleryItem[] = [
+  { id: '1', spotName: '明治神宮', date: '2024/01/15' },
+  { id: '2', spotName: '浅草寺', date: '2024/01/10' },
+  { id: '3', spotName: '伏見稲荷大社', date: '2024/01/05' },
+  { id: '4', spotName: '東京大神宮', date: '2023/12/28' },
+  { id: '5', spotName: '鶴岡八幡宮', date: '2023/12/20' },
+  { id: '6', spotName: '清水寺', date: '2023/12/15' },
+  { id: '7', spotName: '出雲大社', date: '2023/12/10' },
+  { id: '8', spotName: '厳島神社', date: '2023/12/05' },
+  { id: '9', spotName: '金閣寺', date: '2023/11/30' },
+];
+
+const NUM_COLUMNS = 3;
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const ITEM_MARGIN = spacing.xs;
+const ITEM_SIZE = (SCREEN_WIDTH - spacing.lg * 2 - ITEM_MARGIN * (NUM_COLUMNS - 1)) / NUM_COLUMNS;
+
+export function GalleryScreen({ navigation }: Props) {
+  const [sortLabel, setSortLabel] = useState('日付順');
+
+  const handleToggleSort = () => {
+    setSortLabel(prev => (prev === '日付順' ? 'スポット順' : '日付順'));
+  };
+
+  const handleItemPress = (item: GalleryItem) => {
+    navigation.navigate('StampDetail', { stampId: item.id });
+  };
+
+  const renderItem = ({ item, index }: { item: GalleryItem; index: number }) => {
+    const isMiddleColumn = index % NUM_COLUMNS === 1;
+    return (
+      <TouchableOpacity
+        style={[styles.gridItem, isMiddleColumn && styles.gridItemMiddle]}
+        onPress={() => handleItemPress(item)}
+        testID={`gallery-item-${item.id}`}
+      >
+        <View style={styles.imagePlaceholder} />
+        <Text style={styles.itemSpotName} numberOfLines={1}>
+          {item.spotName}
+        </Text>
+        <Text style={styles.itemDate}>{item.date}</Text>
+      </TouchableOpacity>
+    );
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Gallery</Text>
-    </View>
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>ギャラリー</Text>
+      </View>
+
+      <View style={styles.sortRow}>
+        <TouchableOpacity onPress={handleToggleSort} testID="sort-button">
+          <Text style={styles.sortText}>{sortLabel} ▼</Text>
+        </TouchableOpacity>
+      </View>
+
+      <FlatList
+        data={MOCK_DATA}
+        renderItem={renderItem}
+        keyExtractor={item => item.id}
+        numColumns={NUM_COLUMNS}
+        contentContainerStyle={styles.listContent}
+        testID="gallery-list"
+      />
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: colors.background,
   },
-  text: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  header: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.lg,
+  },
+  headerTitle: {
+    ...typography.h2,
+    color: colors.gray[800],
+  },
+  sortRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.md,
+  },
+  sortText: {
+    ...typography.bodySmall,
+    color: colors.gray[600],
+  },
+  listContent: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing['3xl'],
+  },
+  gridItem: {
+    width: ITEM_SIZE,
+    marginBottom: spacing.lg,
+  },
+  gridItemMiddle: {
+    marginHorizontal: ITEM_MARGIN,
+  },
+  imagePlaceholder: {
+    width: ITEM_SIZE,
+    height: ITEM_SIZE,
+    backgroundColor: colors.gray[200],
+    borderRadius: borderRadius.md,
+  },
+  itemSpotName: {
+    ...typography.caption,
+    color: colors.gray[800],
+    marginTop: spacing.xs,
+  },
+  itemDate: {
+    ...typography.caption,
+    color: colors.gray[400],
   },
 });

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,25 +1,148 @@
-import { StyleSheet, Text, View } from 'react-native';
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { MaterialIcons } from '@expo/vector-icons';
 
 import type { RootStackScreenProps } from '@/navigation/types';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+import { shadows } from '@theme/shadows';
 
 type Props = RootStackScreenProps<'Login'>;
 
-export function LoginScreen(_props: Props) {
+export function LoginScreen({ navigation }: Props) {
+  const handleGoogleLogin = () => {
+    // TODO: Supabase Auth with Google OAuth
+  };
+
+  const handleLater = () => {
+    navigation.goBack();
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Login</Text>
-    </View>
+    <SafeAreaView style={styles.container} testID="login-screen">
+      <View style={styles.content}>
+        <View style={styles.iconContainer}>
+          <MaterialIcons name="menu-book" size={64} color={colors.primary[500]} />
+        </View>
+
+        <Text style={styles.appName}>御朱印コレクション</Text>
+        <Text style={styles.tagline}>集めるたび、地図があなたの旅になる。</Text>
+
+        <View style={styles.loginSection}>
+          <Text style={styles.loginPrompt}>旅の記録を保存しましょう</Text>
+
+          <TouchableOpacity
+            style={styles.googleButton}
+            onPress={handleGoogleLogin}
+            activeOpacity={0.7}
+            testID="google-login-button"
+          >
+            <Text style={styles.googleIcon}>G</Text>
+            <Text style={styles.googleButtonText}>Google でログイン</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity onPress={handleLater} testID="later-button">
+            <Text style={styles.laterText}>あとにする</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      <View style={styles.footer}>
+        <Text style={styles.termsText}>
+          ログインすると
+          <Text style={styles.termsLink}> 利用規約 </Text>と
+          <Text style={styles.termsLink}> プライバシーポリシー </Text>
+          に同意したことになります
+        </Text>
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: colors.primary[50],
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
     justifyContent: 'center',
+    paddingHorizontal: spacing['3xl'],
+  },
+  iconContainer: {
+    width: 120,
+    height: 120,
+    borderRadius: borderRadius['3xl'],
+    backgroundColor: colors.white,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.lg,
+    marginBottom: spacing.xl,
+  },
+  appName: {
+    ...typography.h1,
+    color: colors.gray[900],
+    textAlign: 'center',
+  },
+  tagline: {
+    ...typography.body,
+    color: colors.gray[500],
+    textAlign: 'center',
+    marginTop: spacing.sm,
+  },
+  loginSection: {
+    width: '100%',
+    alignItems: 'center',
+    marginTop: spacing['5xl'],
+    gap: spacing.lg,
+  },
+  loginPrompt: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+    marginBottom: spacing.sm,
+  },
+  googleButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray[300],
+    borderRadius: borderRadius.lg,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing['2xl'],
+    width: '100%',
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  googleIcon: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.gray[700],
+  },
+  googleButtonText: {
+    ...typography.button,
+    color: colors.gray[700],
+  },
+  laterText: {
+    ...typography.body,
+    color: colors.gray[500],
+    marginTop: spacing.sm,
+  },
+  footer: {
+    paddingHorizontal: spacing['3xl'],
+    paddingBottom: spacing.lg,
     alignItems: 'center',
   },
-  text: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  termsText: {
+    ...typography.caption,
+    color: colors.gray[400],
+    textAlign: 'center',
+  },
+  termsLink: {
+    color: colors.primary[500],
   },
 });

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,25 +1,96 @@
-import { StyleSheet, Text, View } from 'react-native';
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { MaterialIcons } from '@expo/vector-icons';
 
+import { FABButton } from '@components/animated/FABButton';
+import { SearchBar } from '@components/common/SearchBar';
 import type { MapStackScreenProps } from '@/navigation/types';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+import { shadows } from '@theme/shadows';
 
 type Props = MapStackScreenProps<'Map'>;
 
-export function MapScreen(_props: Props) {
+export function MapScreen({ navigation }: Props) {
+  const handleFABPress = () => {
+    const parent = navigation.getParent();
+    if (parent) {
+      parent.navigate('Record');
+    }
+  };
+
+  const handleFilterPress = () => {
+    // TODO: フィルタードロップダウン表示
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Map</Text>
-    </View>
+    <SafeAreaView style={styles.container} edges={['top']} testID="map-screen">
+      <View style={styles.searchRow}>
+        <View style={styles.searchBarWrapper}>
+          <SearchBar />
+        </View>
+        <TouchableOpacity
+          style={styles.filterButton}
+          onPress={handleFilterPress}
+          activeOpacity={0.7}
+          testID="filter-button"
+        >
+          <MaterialIcons name="filter-list" size={24} color={colors.gray[600]} />
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.mapPlaceholder} testID="map-area">
+        <MaterialIcons name="map" size={48} color={colors.gray[300]} />
+        <Text style={styles.mapPlaceholderText}>地図エリア</Text>
+      </View>
+
+      <View style={styles.fabContainer}>
+        <FABButton onPress={handleFABPress} />
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: colors.surface,
   },
-  text: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    gap: spacing.sm,
+  },
+  searchBarWrapper: {
+    flex: 1,
+  },
+  filterButton: {
+    width: 44,
+    height: 44,
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.white,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.sm,
+  },
+  mapPlaceholder: {
+    flex: 1,
+    backgroundColor: colors.gray[100],
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+  },
+  mapPlaceholderText: {
+    ...typography.body,
+    color: colors.gray[400],
+  },
+  fabContainer: {
+    position: 'absolute',
+    bottom: 20,
+    alignSelf: 'center',
   },
 });

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,25 +1,194 @@
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  Dimensions,
+  FlatList,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  ViewToken,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { OnboardingIcon } from '@components/animated/OnboardingIcon';
+import { Button } from '@components/common/Button';
+import { PageIndicator } from '@components/common/PageIndicator';
 import type { RootStackScreenProps } from '@/navigation/types';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
 
 type Props = RootStackScreenProps<'Onboarding'>;
 
-export function OnboardingScreen(_props: Props) {
-  return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Onboarding</Text>
+interface SlideData {
+  icon: 'map' | 'camera-alt' | 'emoji-events' | 'place';
+  bg: string;
+  title: string;
+  desc: string;
+}
+
+const slides: SlideData[] = [
+  {
+    icon: 'map',
+    bg: '#FB923C',
+    title: '御朱印を地図で管理',
+    desc: '訪れた神社やお寺が地図上にマッピングされます',
+  },
+  {
+    icon: 'camera-alt',
+    bg: '#A855F7',
+    title: 'かんたん記録',
+    desc: '写真を撮るだけですぐに御朱印を記録できます',
+  },
+  {
+    icon: 'emoji-events',
+    bg: '#F59E0B',
+    title: 'コレクションを楽しむ',
+    desc: '巡礼チャレンジやバッジで御朱印集めがもっと楽しく',
+  },
+  {
+    icon: 'place',
+    bg: '#22C55E',
+    title: '近くのスポットを発見',
+    desc: '位置情報をオンにすると周辺の神社仏閣が見つかります',
+  },
+];
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+
+export function OnboardingScreen({ navigation }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const flatListRef = useRef<FlatList<SlideData>>(null);
+
+  const onViewableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      if (viewableItems.length > 0 && viewableItems[0].index != null) {
+        setCurrentIndex(viewableItems[0].index);
+      }
+    },
+    []
+  );
+
+  const viewabilityConfig = useRef({ viewAreaCoveragePercentThreshold: 50 }).current;
+
+  const handleNext = () => {
+    if (currentIndex < slides.length - 1) {
+      flatListRef.current?.scrollToIndex({ index: currentIndex + 1 });
+    }
+  };
+
+  const handleSkip = () => {
+    navigation.navigate('MainTabs', { screen: 'MapTab', params: { screen: 'Map' } });
+  };
+
+  const handleComplete = () => {
+    navigation.navigate('MainTabs', { screen: 'MapTab', params: { screen: 'Map' } });
+  };
+
+  const isLastSlide = currentIndex === slides.length - 1;
+
+  const renderSlide = ({ item }: { item: SlideData }) => (
+    <View style={styles.slide} testID="onboarding-slide">
+      <OnboardingIcon name={item.icon} backgroundColor={item.bg} />
+      <Text style={styles.title}>{item.title}</Text>
+      <Text style={styles.description}>{item.desc}</Text>
     </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.container} testID="onboarding-screen">
+      <View style={styles.header}>
+        <TouchableOpacity onPress={handleSkip} testID="skip-button">
+          <Text style={styles.skipText}>スキップ</Text>
+        </TouchableOpacity>
+      </View>
+
+      <FlatList
+        ref={flatListRef}
+        data={slides}
+        renderItem={renderSlide}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onViewableItemsChanged={onViewableItemsChanged}
+        viewabilityConfig={viewabilityConfig}
+        keyExtractor={(_, index) => String(index)}
+        testID="onboarding-flatlist"
+      />
+
+      <View style={styles.footer}>
+        <PageIndicator total={slides.length} current={currentIndex} />
+
+        <View style={styles.buttons}>
+          {isLastSlide ? (
+            <>
+              <Button
+                title="位置情報を許可して始める"
+                onPress={handleComplete}
+                variant="primary"
+                style={styles.primaryButton}
+              />
+              <Button title="あとで設定する" onPress={handleSkip} variant="ghost" />
+            </>
+          ) : (
+            <Button
+              title="次へ"
+              onPress={handleNext}
+              variant="primary"
+              style={styles.primaryButton}
+            />
+          )}
+        </View>
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: colors.white,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+  },
+  skipText: {
+    ...typography.body,
+    color: colors.gray[400],
+  },
+  slide: {
+    width: SCREEN_WIDTH,
+    flex: 1,
+    alignItems: 'center',
     justifyContent: 'center',
+    paddingHorizontal: spacing['3xl'],
+    gap: spacing.lg,
+  },
+  title: {
+    ...typography.h1,
+    color: colors.gray[900],
+    textAlign: 'center',
+    marginTop: spacing.xl,
+  },
+  description: {
+    ...typography.body,
+    color: colors.gray[500],
+    textAlign: 'center',
+  },
+  footer: {
+    paddingHorizontal: spacing['2xl'],
+    paddingBottom: spacing['2xl'],
+    gap: spacing.xl,
     alignItems: 'center',
   },
-  text: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  buttons: {
+    width: '100%',
+    gap: spacing.md,
+  },
+  primaryButton: {
+    width: '100%',
   },
 });

--- a/src/screens/RecordCompleteScreen.tsx
+++ b/src/screens/RecordCompleteScreen.tsx
@@ -1,25 +1,128 @@
-import { StyleSheet, Text, View } from 'react-native';
-
+import React from 'react';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { CheckmarkAnimation } from '@components/animated/CheckmarkAnimation';
+import { BadgeAnimation } from '@components/animated/BadgeAnimation';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
 import type { RootStackScreenProps } from '@/navigation/types';
 
 type Props = RootStackScreenProps<'RecordComplete'>;
 
-export function RecordCompleteScreen(_props: Props) {
+export function RecordCompleteScreen({ navigation }: Props) {
+  const handleRecordAnother = () => {
+    navigation.navigate('Record');
+  };
+
+  const handleViewMap = () => {
+    navigation.navigate('MainTabs', { screen: 'MapTab', params: { screen: 'Map' } });
+  };
+
+  const handleViewCollection = () => {
+    navigation.navigate('MainTabs', { screen: 'Collection' });
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>RecordComplete</Text>
-    </View>
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <View style={styles.content}>
+        <CheckmarkAnimation size={80} />
+
+        <Text style={styles.title}>登録完了！</Text>
+
+        <View style={styles.imagePlaceholder} testID="stamp-image-placeholder" />
+
+        <Text style={styles.countText}>33箇所目の御朱印！</Text>
+
+        <BadgeAnimation badgeName="初めての御朱印" description="最初の御朱印を記録しました" />
+      </View>
+
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={styles.buttonRecordAnother}
+          onPress={handleRecordAnother}
+          testID="button-record-another"
+        >
+          <Text style={styles.buttonRecordAnotherText}>もう1枚記録する</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.buttonViewMap}
+          onPress={handleViewMap}
+          testID="button-view-map"
+        >
+          <Text style={styles.buttonViewMapText}>地図を見る</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.buttonViewCollection}
+          onPress={handleViewCollection}
+          testID="button-view-collection"
+        >
+          <Text style={styles.buttonViewCollectionText}>コレクションを確認</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: colors.primary[500],
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
     justifyContent: 'center',
+    paddingHorizontal: spacing['2xl'],
+    gap: spacing.xl,
+  },
+  title: {
+    ...typography.h1,
+    color: colors.white,
+  },
+  imagePlaceholder: {
+    width: 160,
+    height: 200,
+    borderRadius: borderRadius.lg,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+  },
+  countText: {
+    ...typography.h3,
+    color: colors.white,
+  },
+  actions: {
+    paddingHorizontal: spacing['2xl'],
+    paddingBottom: spacing['2xl'],
+    gap: spacing.md,
+  },
+  buttonRecordAnother: {
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.lg,
     alignItems: 'center',
   },
-  text: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  buttonRecordAnotherText: {
+    ...typography.button,
+    color: colors.white,
+  },
+  buttonViewMap: {
+    backgroundColor: colors.white,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.lg,
+    alignItems: 'center',
+  },
+  buttonViewMapText: {
+    ...typography.button,
+    color: colors.primary[500],
+  },
+  buttonViewCollection: {
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  buttonViewCollectionText: {
+    ...typography.button,
+    color: 'rgba(255,255,255,0.8)',
   },
 });

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -1,25 +1,196 @@
-import { StyleSheet, Text, View } from 'react-native';
-
+import React, { useState } from 'react';
+import { StyleSheet, Text, View, ScrollView, TouchableOpacity, TextInput } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { MaterialIcons } from '@expo/vector-icons';
+import { Button } from '@components/common/Button';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
 import type { RootStackScreenProps } from '@/navigation/types';
 
 type Props = RootStackScreenProps<'Record'>;
 
-export function RecordScreen(_props: Props) {
+export function RecordScreen({ navigation }: Props) {
+  const [selectedSpot, setSelectedSpot] = useState<string | null>(null);
+  const [memo, setMemo] = useState('');
+
+  const today = new Date();
+  const formattedDate = `${today.getFullYear()}年${today.getMonth() + 1}月${today.getDate()}日`;
+
+  const handleSelectSpot = () => {
+    setSelectedSpot('明治神宮');
+  };
+
+  const handleSave = () => {
+    navigation.navigate('RecordComplete');
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Record</Text>
-    </View>
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          style={styles.headerButton}
+          testID="close-button"
+        >
+          <MaterialIcons name="close" size={24} color={colors.gray[800]} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>御朱印を記録</Text>
+        <View style={styles.headerButton} />
+      </View>
+
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={styles.sectionLabel}>スポット</Text>
+        <TouchableOpacity
+          style={styles.spotSelector}
+          onPress={handleSelectSpot}
+          testID="spot-selector"
+        >
+          <MaterialIcons
+            name="place"
+            size={24}
+            color={selectedSpot ? colors.primary[500] : colors.gray[400]}
+          />
+          <Text style={[styles.spotText, !selectedSpot && styles.spotPlaceholder]}>
+            {selectedSpot ?? 'スポットを選択'}
+          </Text>
+          <MaterialIcons name="chevron-right" size={24} color={colors.gray[400]} />
+        </TouchableOpacity>
+
+        <Text style={styles.sectionLabel}>御朱印の写真</Text>
+        <TouchableOpacity style={styles.photoArea} testID="photo-area">
+          <MaterialIcons name="add-a-photo" size={48} color={colors.gray[400]} />
+          <Text style={styles.photoText}>御朱印の写真を追加</Text>
+        </TouchableOpacity>
+
+        <Text style={styles.sectionLabel}>訪問日</Text>
+        <View style={styles.dateRow}>
+          <MaterialIcons name="calendar-today" size={20} color={colors.gray[500]} />
+          <Text style={styles.dateText}>{formattedDate}</Text>
+        </View>
+
+        <Text style={styles.sectionLabel}>メモ（任意）</Text>
+        <TextInput
+          style={styles.memoInput}
+          placeholder="メモを入力..."
+          placeholderTextColor={colors.gray[400]}
+          multiline
+          value={memo}
+          onChangeText={setMemo}
+          testID="memo-input"
+        />
+      </ScrollView>
+
+      <View style={styles.footer}>
+        <Button title="この内容で記録する" onPress={handleSave} variant="primary" />
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: colors.background,
   },
-  text: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray[200],
+  },
+  headerButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    ...typography.h3,
+    color: colors.gray[800],
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: spacing.lg,
+    paddingBottom: spacing['3xl'],
+  },
+  sectionLabel: {
+    ...typography.label,
+    color: colors.gray[600],
+    marginBottom: spacing.sm,
+    marginTop: spacing.lg,
+  },
+  spotSelector: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.lg,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.white,
+    gap: spacing.md,
+  },
+  spotText: {
+    ...typography.body,
+    color: colors.gray[800],
+    flex: 1,
+  },
+  spotPlaceholder: {
+    color: colors.gray[400],
+  },
+  photoArea: {
+    height: 200,
+    borderWidth: 2,
+    borderColor: colors.gray[300],
+    borderStyle: 'dashed',
+    borderRadius: borderRadius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.gray[50],
+    gap: spacing.sm,
+  },
+  photoText: {
+    ...typography.bodySmall,
+    color: colors.gray[400],
+  },
+  dateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    padding: spacing.lg,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.white,
+  },
+  dateText: {
+    ...typography.body,
+    color: colors.gray[800],
+  },
+  memoInput: {
+    ...typography.body,
+    height: 100,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    borderRadius: borderRadius.lg,
+    padding: spacing.lg,
+    backgroundColor: colors.white,
+    textAlignVertical: 'top',
+    color: colors.gray[800],
+  },
+  footer: {
+    padding: spacing.lg,
+    borderTopWidth: 1,
+    borderTopColor: colors.gray[200],
+    backgroundColor: colors.white,
   },
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,25 +1,162 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { Card } from '@components/common/Card';
+import { colors } from '@theme/colors';
+import { borderRadius, spacing } from '@theme/spacing';
+import { typography } from '@theme/typography';
 import type { MainTabScreenProps } from '@/navigation/types';
 
 type Props = MainTabScreenProps<'Settings'>;
 
 export function SettingsScreen(_props: Props) {
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Settings</Text>
-    </View>
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.header}>設定</Text>
+
+        {/* Account Section */}
+        <Text style={styles.sectionTitle}>アカウント</Text>
+        <Card style={styles.sectionCard}>
+          <View style={styles.row}>
+            <MaterialIcons name="person" size={24} color={colors.gray[500]} />
+            <Text style={styles.rowLabel}>ゲスト</Text>
+          </View>
+          <View style={styles.row}>
+            <MaterialIcons name="email" size={24} color={colors.gray[500]} />
+            <Text style={styles.rowLabel}>未設定</Text>
+          </View>
+          <View style={styles.divider} />
+          <TouchableOpacity style={styles.row} accessibilityRole="button">
+            <MaterialIcons name="logout" size={24} color={colors.error} />
+            <Text style={styles.logoutText}>ログアウト</Text>
+          </TouchableOpacity>
+        </Card>
+
+        {/* Plan Section */}
+        <Text style={styles.sectionTitle}>プラン</Text>
+        <Card style={styles.sectionCard}>
+          <View style={styles.planRow}>
+            <View style={styles.planBadge}>
+              <Text style={styles.planBadgeText}>無料プラン</Text>
+            </View>
+            <Text style={styles.planDescription}>基本機能をご利用いただけます</Text>
+          </View>
+          <View style={styles.upgradeBanner}>
+            <Text style={styles.upgradeTitle}>プレミアムプランにアップグレード</Text>
+            <TouchableOpacity accessibilityRole="link">
+              <Text style={styles.upgradeLink}>詳しく見る</Text>
+            </TouchableOpacity>
+          </View>
+        </Card>
+
+        {/* App Info Section */}
+        <Text style={styles.sectionTitle}>アプリ情報</Text>
+        <Card style={styles.sectionCard}>
+          <View style={styles.row}>
+            <Text style={styles.rowLabel}>バージョン</Text>
+            <Text style={styles.rowValue}>1.0.0</Text>
+          </View>
+          <TouchableOpacity style={styles.row} accessibilityRole="button">
+            <Text style={styles.rowLabel}>利用規約</Text>
+            <MaterialIcons name="chevron-right" size={24} color={colors.gray[400]} />
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.row} accessibilityRole="button">
+            <Text style={styles.rowLabel}>プライバシーポリシー</Text>
+            <MaterialIcons name="chevron-right" size={24} color={colors.gray[400]} />
+          </TouchableOpacity>
+        </Card>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: colors.background,
   },
-  text: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  scrollView: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing.lg,
+    paddingBottom: spacing['4xl'],
+  },
+  header: {
+    ...typography.h2,
+    color: colors.gray[900],
+    marginBottom: spacing.lg,
+  },
+  sectionTitle: {
+    ...typography.h3,
+    color: colors.gray[800],
+    marginBottom: spacing.md,
+  },
+  sectionCard: {
+    marginBottom: spacing.xl,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    gap: spacing.md,
+  },
+  rowLabel: {
+    ...typography.body,
+    color: colors.gray[700],
+    flex: 1,
+  },
+  rowValue: {
+    ...typography.body,
+    color: colors.gray[500],
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.gray[200],
+  },
+  logoutText: {
+    ...typography.body,
+    color: colors.error,
+    flex: 1,
+  },
+  planRow: {
+    paddingVertical: spacing.md,
+  },
+  planBadge: {
+    backgroundColor: colors.primary[100],
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: borderRadius.full,
+    alignSelf: 'flex-start',
+    marginBottom: spacing.sm,
+  },
+  planBadgeText: {
+    ...typography.label,
+    color: colors.primary[600],
+  },
+  planDescription: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+  },
+  upgradeBanner: {
+    backgroundColor: colors.primary[50],
+    borderRadius: borderRadius.md,
+    padding: spacing.lg,
+    marginTop: spacing.md,
+  },
+  upgradeTitle: {
+    ...typography.body,
+    color: colors.gray[800],
+    marginBottom: spacing.sm,
+  },
+  upgradeLink: {
+    ...typography.bodySmall,
+    color: colors.primary[500],
   },
 });

--- a/src/screens/SpotDetailScreen.tsx
+++ b/src/screens/SpotDetailScreen.tsx
@@ -1,25 +1,244 @@
-import { StyleSheet, Text, View } from 'react-native';
+import React from 'react';
+import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { MaterialIcons } from '@expo/vector-icons';
 
+import { Badge } from '@components/common/Badge';
+import { Button } from '@components/common/Button';
+import { Card } from '@components/common/Card';
 import type { MapStackScreenProps } from '@/navigation/types';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
 
 type Props = MapStackScreenProps<'SpotDetail'>;
 
-export function SpotDetailScreen(_props: Props) {
-  return (
-    <View style={styles.container}>
-      <Text style={styles.text}>SpotDetail</Text>
+interface MockStamp {
+  id: string;
+  date: string;
+}
+
+const MOCK_STAMPS: MockStamp[] = [
+  { id: '1', date: '2024/01/15' },
+  { id: '2', date: '2023/05/20' },
+  { id: '3', date: '2022/09/10' },
+  { id: '4', date: '2022/03/05' },
+];
+
+export function SpotDetailScreen({ navigation }: Props) {
+  const handleBack = () => {
+    navigation.goBack();
+  };
+
+  const handleRecord = () => {
+    const parent = navigation.getParent();
+    if (parent) {
+      parent.navigate('Record');
+    }
+  };
+
+  const renderStampItem = ({ item }: { item: MockStamp }) => (
+    <View style={styles.stampItem} testID="stamp-item">
+      <View style={styles.stampImagePlaceholder}>
+        <MaterialIcons name="image" size={32} color={colors.gray[300]} />
+      </View>
+      <Text style={styles.stampDate}>{item.date}</Text>
     </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.container} testID="spot-detail-screen">
+      <View style={styles.header}>
+        <TouchableOpacity onPress={handleBack} testID="back-button">
+          <MaterialIcons name="arrow-back" size={24} color={colors.gray[800]} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>スポット詳細</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <FlatList
+        data={MOCK_STAMPS}
+        renderItem={renderStampItem}
+        keyExtractor={item => item.id}
+        numColumns={2}
+        columnWrapperStyle={styles.stampRow}
+        contentContainerStyle={styles.scrollContent}
+        ListHeaderComponent={
+          <>
+            <View style={styles.badgeRow}>
+              <Badge type="shrine" />
+              <Badge type="visited" />
+            </View>
+
+            <Text style={styles.spotName}>大崎八幡宮</Text>
+            <View style={styles.addressRow}>
+              <MaterialIcons name="place" size={16} color={colors.gray[400]} />
+              <Text style={styles.address}>宮城県仙台市青葉区八幡4-6-1</Text>
+            </View>
+
+            <Card style={styles.visitCard}>
+              <View style={styles.visitRow}>
+                <View style={styles.visitItem}>
+                  <Text style={styles.visitLabel}>訪問回数</Text>
+                  <Text style={styles.visitValue}>3回</Text>
+                </View>
+                <View style={styles.visitDivider} />
+                <View style={styles.visitItem}>
+                  <Text style={styles.visitLabel}>最終訪問</Text>
+                  <Text style={styles.visitValue}>2024/01/15</Text>
+                </View>
+              </View>
+            </Card>
+
+            <Button
+              title="ここで記録する"
+              onPress={handleRecord}
+              variant="primary"
+              style={styles.recordButton}
+            />
+
+            <Text style={styles.sectionTitle}>
+              あなたが記録した御朱印（{MOCK_STAMPS.length}件）
+            </Text>
+          </>
+        }
+        ListFooterComponent={
+          <>
+            <Text style={styles.sectionTitle}>アクセス</Text>
+            <View style={styles.miniMap} testID="mini-map">
+              <MaterialIcons name="map" size={32} color={colors.gray[300]} />
+              <Text style={styles.miniMapText}>地図</Text>
+            </View>
+            <View style={styles.miniMapAddress}>
+              <MaterialIcons name="place" size={16} color={colors.primary[500]} />
+              <Text style={styles.miniMapAddressText}>〒980-0871 宮城県仙台市青葉区八幡4-6-1</Text>
+            </View>
+          </>
+        }
+        testID="stamp-list"
+      />
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
+    backgroundColor: colors.white,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  headerTitle: {
+    ...typography.h3,
+    color: colors.gray[800],
+    flex: 1,
+    textAlign: 'center',
+  },
+  headerSpacer: {
+    width: 24,
+  },
+  scrollContent: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing['3xl'],
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginBottom: spacing.md,
+  },
+  spotName: {
+    ...typography.h2,
+    color: colors.gray[900],
+    marginBottom: spacing.sm,
+  },
+  addressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginBottom: spacing.xl,
+  },
+  address: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+  },
+  visitCard: {
+    marginBottom: spacing.lg,
+  },
+  visitRow: {
+    flexDirection: 'row',
     alignItems: 'center',
   },
-  text: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  visitItem: {
+    flex: 1,
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  visitLabel: {
+    ...typography.caption,
+    color: colors.gray[500],
+  },
+  visitValue: {
+    ...typography.h3,
+    color: colors.gray[900],
+  },
+  visitDivider: {
+    width: 1,
+    height: 40,
+    backgroundColor: colors.gray[200],
+  },
+  recordButton: {
+    marginBottom: spacing.xl,
+  },
+  sectionTitle: {
+    ...typography.h3,
+    color: colors.gray[800],
+    marginBottom: spacing.md,
+    marginTop: spacing.lg,
+  },
+  stampRow: {
+    gap: spacing.md,
+  },
+  stampItem: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  stampImagePlaceholder: {
+    aspectRatio: 1,
+    backgroundColor: colors.gray[100],
+    borderRadius: borderRadius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  stampDate: {
+    ...typography.caption,
+    color: colors.gray[500],
+    textAlign: 'center',
+  },
+  miniMap: {
+    height: 150,
+    backgroundColor: colors.gray[100],
+    borderRadius: borderRadius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+  },
+  miniMapText: {
+    ...typography.bodySmall,
+    color: colors.gray[400],
+  },
+  miniMapAddress: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginTop: spacing.md,
+  },
+  miniMapAddressText: {
+    ...typography.bodySmall,
+    color: colors.gray[600],
+    flex: 1,
   },
 });

--- a/src/screens/StampDetailScreen.tsx
+++ b/src/screens/StampDetailScreen.tsx
@@ -1,25 +1,107 @@
-import { StyleSheet, Text, View } from 'react-native';
-
+import React from 'react';
+import { StyleSheet, Text, View, ScrollView, TouchableOpacity } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { MaterialIcons } from '@expo/vector-icons';
+import { Badge } from '@components/common/Badge';
+import { Card } from '@components/common/Card';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
 import type { GalleryStackScreenProps } from '@/navigation/types';
 
 type Props = GalleryStackScreenProps<'StampDetail'>;
 
-export function StampDetailScreen(_props: Props) {
+export function StampDetailScreen({ navigation }: Props) {
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>StampDetail</Text>
-    </View>
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          style={styles.headerButton}
+          testID="back-button"
+        >
+          <MaterialIcons name="arrow-back" size={24} color={colors.gray[800]} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>御朱印詳細</Text>
+        <View style={styles.headerButton} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={styles.imageArea} testID="stamp-image">
+          <MaterialIcons name="image" size={48} color={colors.gray[400]} />
+        </View>
+
+        <View style={styles.infoSection}>
+          <Text style={styles.spotName}>明治神宮</Text>
+          <Badge type="shrine" />
+          <Text style={styles.visitDate}>2024年1月15日</Text>
+        </View>
+
+        <Card style={styles.memoCard}>
+          <Text style={styles.memoLabel}>メモ</Text>
+          <Text style={styles.memoText}>初めての御朱印。天気が良くて気持ちの良い参拝でした。</Text>
+        </Card>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: colors.background,
   },
-  text: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray[200],
+  },
+  headerButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    ...typography.h3,
+    color: colors.gray[800],
+  },
+  scrollContent: {
+    paddingBottom: spacing['3xl'],
+  },
+  imageArea: {
+    width: '100%',
+    height: 300,
+    backgroundColor: colors.gray[200],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  infoSection: {
+    padding: spacing.lg,
+    gap: spacing.sm,
+  },
+  spotName: {
+    ...typography.h2,
+    color: colors.gray[800],
+  },
+  visitDate: {
+    ...typography.body,
+    color: colors.gray[500],
+  },
+  memoCard: {
+    marginHorizontal: spacing.lg,
+  },
+  memoLabel: {
+    ...typography.label,
+    color: colors.gray[500],
+    marginBottom: spacing.sm,
+  },
+  memoText: {
+    ...typography.body,
+    color: colors.gray[800],
   },
 });

--- a/src/screens/__tests__/CollectionScreen.test.tsx
+++ b/src/screens/__tests__/CollectionScreen.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { CollectionScreen } from '../CollectionScreen';
+import type { MainTabScreenProps } from '@/navigation/types';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const RN = require('react-native');
+  return {
+    SafeAreaView: RN.View,
+    SafeAreaProvider: RN.View,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+} as unknown as MainTabScreenProps<'Collection'>['navigation'];
+
+const mockRoute = {
+  key: 'test',
+  name: 'Collection' as const,
+  params: undefined,
+} as unknown as MainTabScreenProps<'Collection'>['route'];
+
+describe('CollectionScreen', () => {
+  it('renders the header', () => {
+    const { getByText } = render(
+      <CollectionScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('コレクション')).toBeTruthy();
+  });
+
+  it('renders achievement summary cards', () => {
+    const { getByText } = render(
+      <CollectionScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('33')).toBeTruthy();
+    expect(getByText('箇所')).toBeTruthy();
+    expect(getByText('45')).toBeTruthy();
+    expect(getByText('枚')).toBeTruthy();
+  });
+
+  it('renders region section', () => {
+    const { getByText } = render(
+      <CollectionScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('地域別')).toBeTruthy();
+    expect(getByText('東京都')).toBeTruthy();
+    expect(getByText('京都府')).toBeTruthy();
+    expect(getByText('宮城県')).toBeTruthy();
+  });
+
+  it('renders challenge section', () => {
+    const { getByText } = render(
+      <CollectionScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('巡礼チャレンジ')).toBeTruthy();
+    expect(getByText('四国八十八ヶ所')).toBeTruthy();
+    expect(getByText('12/88')).toBeTruthy();
+    expect(getByText('西国三十三所')).toBeTruthy();
+    expect(getByText('5/33')).toBeTruthy();
+  });
+
+  it('renders badge section with earned and unearned badges', () => {
+    const { getByText } = render(
+      <CollectionScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('バッジ')).toBeTruthy();
+    expect(getByText('初参拝')).toBeTruthy();
+    expect(getByText('10箇所達成')).toBeTruthy();
+    expect(getByText('巡礼者')).toBeTruthy();
+    expect(getByText('全国制覇')).toBeTruthy();
+  });
+});

--- a/src/screens/__tests__/ErrorScreen.test.tsx
+++ b/src/screens/__tests__/ErrorScreen.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { ErrorScreen } from '../ErrorScreen';
+import type { RootStackScreenProps } from '@/navigation/types';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const RN = require('react-native');
+  return {
+    SafeAreaView: RN.View,
+    SafeAreaProvider: RN.View,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+} as unknown as RootStackScreenProps<'Error'>['navigation'];
+
+describe('ErrorScreen', () => {
+  it('renders network error type', () => {
+    const mockRoute = {
+      key: 'test',
+      name: 'Error' as const,
+      params: { type: 'network' as const },
+    } as unknown as RootStackScreenProps<'Error'>['route'];
+
+    const { getByText } = render(<ErrorScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('ネットワークエラー')).toBeTruthy();
+    expect(getByText('インターネット接続を確認してください')).toBeTruthy();
+    expect(getByText('再試行')).toBeTruthy();
+  });
+
+  it('renders location error type with secondary button', () => {
+    const mockRoute = {
+      key: 'test',
+      name: 'Error' as const,
+      params: { type: 'location' as const },
+    } as unknown as RootStackScreenProps<'Error'>['route'];
+
+    const { getByText } = render(<ErrorScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('位置情報エラー')).toBeTruthy();
+    expect(getByText('位置情報の利用を許可してください')).toBeTruthy();
+    expect(getByText('設定を開く')).toBeTruthy();
+    expect(getByText('あとで設定する')).toBeTruthy();
+  });
+
+  it('renders upload error type with secondary button', () => {
+    const mockRoute = {
+      key: 'test',
+      name: 'Error' as const,
+      params: { type: 'upload' as const },
+    } as unknown as RootStackScreenProps<'Error'>['route'];
+
+    const { getByText } = render(<ErrorScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('アップロードエラー')).toBeTruthy();
+    expect(getByText('画像のアップロードに失敗しました')).toBeTruthy();
+    expect(getByText('再試行')).toBeTruthy();
+    expect(getByText('キャンセル')).toBeTruthy();
+  });
+
+  it('does not render secondary button for network error', () => {
+    const mockRoute = {
+      key: 'test',
+      name: 'Error' as const,
+      params: { type: 'network' as const },
+    } as unknown as RootStackScreenProps<'Error'>['route'];
+
+    const { queryByText } = render(<ErrorScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(queryByText('あとで設定する')).toBeNull();
+    expect(queryByText('キャンセル')).toBeNull();
+  });
+});

--- a/src/screens/__tests__/GalleryScreen.test.tsx
+++ b/src/screens/__tests__/GalleryScreen.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { GalleryScreen } from '@screens/GalleryScreen';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: View,
+    SafeAreaProvider: View,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+} as any;
+
+const mockRoute = {
+  key: 'test',
+  name: 'Gallery' as const,
+  params: undefined,
+};
+
+describe('GalleryScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { getByText } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('ギャラリー')).toBeTruthy();
+  });
+
+  it('renders sort button', () => {
+    const { getByTestId } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByTestId('sort-button')).toBeTruthy();
+  });
+
+  it('toggles sort label on press', () => {
+    const { getByTestId, getByText } = render(
+      <GalleryScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('日付順 ▼')).toBeTruthy();
+    fireEvent.press(getByTestId('sort-button'));
+    expect(getByText('スポット順 ▼')).toBeTruthy();
+  });
+
+  it('renders gallery list', () => {
+    const { getByTestId } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByTestId('gallery-list')).toBeTruthy();
+  });
+
+  it('renders mock gallery items', () => {
+    const { getByText } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('明治神宮')).toBeTruthy();
+    expect(getByText('浅草寺')).toBeTruthy();
+  });
+
+  it('navigates to StampDetail on item press', () => {
+    const { getByTestId } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(getByTestId('gallery-item-1'));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('StampDetail', { stampId: '1' });
+  });
+});

--- a/src/screens/__tests__/LoginScreen.test.tsx
+++ b/src/screens/__tests__/LoginScreen.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { LoginScreen } from '@screens/LoginScreen';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const React = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+      React.createElement(View, props, children),
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+  dispatch: jest.fn(),
+  reset: jest.fn(),
+  isFocused: jest.fn(),
+  canGoBack: jest.fn(),
+  getId: jest.fn(),
+  getState: jest.fn(),
+  setParams: jest.fn(),
+  setOptions: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  pop: jest.fn(),
+  push: jest.fn(),
+  replace: jest.fn(),
+  popTo: jest.fn(),
+  popToTop: jest.fn(),
+};
+
+const mockRoute = { key: 'test', name: 'Login' as const, params: undefined };
+
+describe('LoginScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { getByTestId } = render(
+      <LoginScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('login-screen')).toBeTruthy();
+  });
+
+  it('displays app name', () => {
+    const { getByText } = render(
+      <LoginScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByText('御朱印コレクション')).toBeTruthy();
+  });
+
+  it('displays tagline', () => {
+    const { getByText } = render(
+      <LoginScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByText('集めるたび、地図があなたの旅になる。')).toBeTruthy();
+  });
+
+  it('displays Google login button', () => {
+    const { getByTestId, getByText } = render(
+      <LoginScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('google-login-button')).toBeTruthy();
+    expect(getByText('Google でログイン')).toBeTruthy();
+  });
+
+  it('displays later button', () => {
+    const { getByTestId, getByText } = render(
+      <LoginScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('later-button')).toBeTruthy();
+    expect(getByText('あとにする')).toBeTruthy();
+  });
+
+  it('navigates back when later is pressed', () => {
+    const { getByTestId } = render(
+      <LoginScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('later-button'));
+    expect(mockNavigation.goBack).toHaveBeenCalled();
+  });
+
+  it('displays login prompt text', () => {
+    const { getByText } = render(
+      <LoginScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByText('旅の記録を保存しましょう')).toBeTruthy();
+  });
+});

--- a/src/screens/__tests__/MapScreen.test.tsx
+++ b/src/screens/__tests__/MapScreen.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { MapScreen } from '@screens/MapScreen';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const React = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+      React.createElement(View, props, children),
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+  dispatch: jest.fn(),
+  reset: jest.fn(),
+  isFocused: jest.fn(),
+  canGoBack: jest.fn(),
+  getId: jest.fn(),
+  getState: jest.fn(),
+  setParams: jest.fn(),
+  setOptions: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  pop: jest.fn(),
+  push: jest.fn(),
+  replace: jest.fn(),
+  popTo: jest.fn(),
+  popToTop: jest.fn(),
+};
+
+const mockRoute = { key: 'test', name: 'Map' as const, params: undefined };
+
+describe('MapScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { getByTestId } = render(
+      <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('map-screen')).toBeTruthy();
+  });
+
+  it('displays search bar', () => {
+    const { getByTestId } = render(
+      <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('search-bar')).toBeTruthy();
+  });
+
+  it('displays filter button', () => {
+    const { getByTestId } = render(
+      <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('filter-button')).toBeTruthy();
+  });
+
+  it('displays map area placeholder', () => {
+    const { getByTestId, getByText } = render(
+      <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('map-area')).toBeTruthy();
+    expect(getByText('地図エリア')).toBeTruthy();
+  });
+
+  it('displays FAB button', () => {
+    const { getByTestId } = render(
+      <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('fab-button')).toBeTruthy();
+  });
+});

--- a/src/screens/__tests__/OnboardingScreen.test.tsx
+++ b/src/screens/__tests__/OnboardingScreen.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { OnboardingScreen } from '@screens/OnboardingScreen';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const React = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+      React.createElement(View, props, children),
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+  dispatch: jest.fn(),
+  reset: jest.fn(),
+  isFocused: jest.fn(),
+  canGoBack: jest.fn(),
+  getId: jest.fn(),
+  getState: jest.fn(),
+  setParams: jest.fn(),
+  setOptions: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  pop: jest.fn(),
+  push: jest.fn(),
+  replace: jest.fn(),
+  popTo: jest.fn(),
+  popToTop: jest.fn(),
+};
+
+const mockRoute = { key: 'test', name: 'Onboarding' as const, params: undefined };
+
+describe('OnboardingScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { getByTestId } = render(
+      <OnboardingScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('onboarding-screen')).toBeTruthy();
+  });
+
+  it('displays skip button', () => {
+    const { getByTestId, getByText } = render(
+      <OnboardingScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('skip-button')).toBeTruthy();
+    expect(getByText('スキップ')).toBeTruthy();
+  });
+
+  it('displays page indicator', () => {
+    const { getByTestId } = render(
+      <OnboardingScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('page-indicator')).toBeTruthy();
+  });
+
+  it('displays "次へ" button on first slide', () => {
+    const { getByText } = render(
+      <OnboardingScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByText('次へ')).toBeTruthy();
+  });
+
+  it('navigates to MainTabs when skip is pressed', () => {
+    const { getByTestId } = render(
+      <OnboardingScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('skip-button'));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('MainTabs', {
+      screen: 'MapTab',
+      params: { screen: 'Map' },
+    });
+  });
+
+  it('renders onboarding slides', () => {
+    const { getAllByTestId } = render(
+      <OnboardingScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    const slides = getAllByTestId('onboarding-slide');
+    expect(slides.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders onboarding icons', () => {
+    const { getAllByTestId } = render(
+      <OnboardingScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    const icons = getAllByTestId('onboarding-icon');
+    expect(icons.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/screens/__tests__/RecordCompleteScreen.test.tsx
+++ b/src/screens/__tests__/RecordCompleteScreen.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { RecordCompleteScreen } from '@screens/RecordCompleteScreen';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: View,
+    SafeAreaProvider: View,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+} as any;
+
+const mockRoute = {
+  key: 'test',
+  name: 'RecordComplete' as const,
+  params: undefined,
+};
+
+describe('RecordCompleteScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { getByText } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('登録完了！')).toBeTruthy();
+  });
+
+  it('renders checkmark animation', () => {
+    const { getByTestId } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByTestId('checkmark-animation')).toBeTruthy();
+  });
+
+  it('renders stamp image placeholder', () => {
+    const { getByTestId } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByTestId('stamp-image-placeholder')).toBeTruthy();
+  });
+
+  it('renders count text', () => {
+    const { getByText } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('33箇所目の御朱印！')).toBeTruthy();
+  });
+
+  it('renders badge animation', () => {
+    const { getByTestId, getByText } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByTestId('badge-animation')).toBeTruthy();
+    expect(getByText('初めての御朱印')).toBeTruthy();
+  });
+
+  it('renders three action buttons', () => {
+    const { getByText } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('もう1枚記録する')).toBeTruthy();
+    expect(getByText('地図を見る')).toBeTruthy();
+    expect(getByText('コレクションを確認')).toBeTruthy();
+  });
+
+  it('navigates to Record on "record another" press', () => {
+    const { getByTestId } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('button-record-another'));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('Record');
+  });
+
+  it('navigates to MainTabs on "view map" press', () => {
+    const { getByTestId } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('button-view-map'));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('MainTabs', {
+      screen: 'MapTab',
+      params: { screen: 'Map' },
+    });
+  });
+
+  it('navigates to Collection on "view collection" press', () => {
+    const { getByTestId } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('button-view-collection'));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('MainTabs', {
+      screen: 'Collection',
+    });
+  });
+});

--- a/src/screens/__tests__/RecordScreen.test.tsx
+++ b/src/screens/__tests__/RecordScreen.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { RecordScreen } from '@screens/RecordScreen';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: View,
+    SafeAreaProvider: View,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+} as any;
+
+const mockRoute = {
+  key: 'test',
+  name: 'Record' as const,
+  params: undefined,
+};
+
+describe('RecordScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { getByText } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('御朱印を記録')).toBeTruthy();
+  });
+
+  it('renders all form sections', () => {
+    const { getByText } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('スポット')).toBeTruthy();
+    expect(getByText('御朱印の写真')).toBeTruthy();
+    expect(getByText('訪問日')).toBeTruthy();
+    expect(getByText('メモ（任意）')).toBeTruthy();
+  });
+
+  it('renders spot selector with placeholder', () => {
+    const { getByText, getByTestId } = render(
+      <RecordScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByTestId('spot-selector')).toBeTruthy();
+    expect(getByText('スポットを選択')).toBeTruthy();
+  });
+
+  it('renders photo area', () => {
+    const { getByTestId, getByText } = render(
+      <RecordScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByTestId('photo-area')).toBeTruthy();
+    expect(getByText('御朱印の写真を追加')).toBeTruthy();
+  });
+
+  it('renders memo input', () => {
+    const { getByTestId } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByTestId('memo-input')).toBeTruthy();
+  });
+
+  it('renders save button', () => {
+    const { getByText } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('この内容で記録する')).toBeTruthy();
+  });
+
+  it('navigates back on close button press', () => {
+    const { getByTestId } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(getByTestId('close-button'));
+    expect(mockNavigation.goBack).toHaveBeenCalled();
+  });
+
+  it('selects spot on spot selector press', () => {
+    const { getByTestId, getByText } = render(
+      <RecordScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('spot-selector'));
+    expect(getByText('明治神宮')).toBeTruthy();
+  });
+});

--- a/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/src/screens/__tests__/SettingsScreen.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { SettingsScreen } from '../SettingsScreen';
+import type { MainTabScreenProps } from '@/navigation/types';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const RN = require('react-native');
+  return {
+    SafeAreaView: RN.View,
+    SafeAreaProvider: RN.View,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+} as unknown as MainTabScreenProps<'Settings'>['navigation'];
+
+const mockRoute = {
+  key: 'test',
+  name: 'Settings' as const,
+  params: undefined,
+} as unknown as MainTabScreenProps<'Settings'>['route'];
+
+describe('SettingsScreen', () => {
+  it('renders the header', () => {
+    const { getByText } = render(<SettingsScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('設定')).toBeTruthy();
+  });
+
+  it('renders account section', () => {
+    const { getByText } = render(<SettingsScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('アカウント')).toBeTruthy();
+    expect(getByText('ゲスト')).toBeTruthy();
+    expect(getByText('未設定')).toBeTruthy();
+    expect(getByText('ログアウト')).toBeTruthy();
+  });
+
+  it('renders plan section', () => {
+    const { getByText } = render(<SettingsScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('プラン')).toBeTruthy();
+    expect(getByText('無料プラン')).toBeTruthy();
+    expect(getByText('プレミアムプランにアップグレード')).toBeTruthy();
+    expect(getByText('詳しく見る')).toBeTruthy();
+  });
+
+  it('renders app info section', () => {
+    const { getByText } = render(<SettingsScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('アプリ情報')).toBeTruthy();
+    expect(getByText('バージョン')).toBeTruthy();
+    expect(getByText('1.0.0')).toBeTruthy();
+    expect(getByText('利用規約')).toBeTruthy();
+    expect(getByText('プライバシーポリシー')).toBeTruthy();
+  });
+});

--- a/src/screens/__tests__/SpotDetailScreen.test.tsx
+++ b/src/screens/__tests__/SpotDetailScreen.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { SpotDetailScreen } from '@screens/SpotDetailScreen';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const React = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+      React.createElement(View, props, children),
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+  dispatch: jest.fn(),
+  reset: jest.fn(),
+  isFocused: jest.fn(),
+  canGoBack: jest.fn(),
+  getId: jest.fn(),
+  getState: jest.fn(),
+  setParams: jest.fn(),
+  setOptions: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  pop: jest.fn(),
+  push: jest.fn(),
+  replace: jest.fn(),
+  popTo: jest.fn(),
+  popToTop: jest.fn(),
+};
+
+const mockRoute = {
+  key: 'test',
+  name: 'SpotDetail' as const,
+  params: { spotId: 'test-spot-1' },
+};
+
+describe('SpotDetailScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { getByTestId } = render(
+      <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('spot-detail-screen')).toBeTruthy();
+  });
+
+  it('displays back button', () => {
+    const { getByTestId } = render(
+      <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('back-button')).toBeTruthy();
+  });
+
+  it('displays header title', () => {
+    const { getByText } = render(
+      <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByText('スポット詳細')).toBeTruthy();
+  });
+
+  it('displays spot name', () => {
+    const { getByText } = render(
+      <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByText('大崎八幡宮')).toBeTruthy();
+  });
+
+  it('displays badges', () => {
+    const { getByTestId } = render(
+      <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('badge-shrine')).toBeTruthy();
+    expect(getByTestId('badge-visited')).toBeTruthy();
+  });
+
+  it('displays visit info card', () => {
+    const { getByText } = render(
+      <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByText('訪問回数')).toBeTruthy();
+    expect(getByText('3回')).toBeTruthy();
+    expect(getByText('最終訪問')).toBeTruthy();
+  });
+
+  it('displays record button', () => {
+    const { getByText } = render(
+      <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByText('ここで記録する')).toBeTruthy();
+  });
+
+  it('displays mini map', () => {
+    const { getByTestId } = render(
+      <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('mini-map')).toBeTruthy();
+  });
+
+  it('navigates back when back button is pressed', () => {
+    const { getByTestId } = render(
+      <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('back-button'));
+    expect(mockNavigation.goBack).toHaveBeenCalled();
+  });
+
+  it('displays stamp items', () => {
+    const { getAllByTestId } = render(
+      <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    const stamps = getAllByTestId('stamp-item');
+    expect(stamps.length).toBe(4);
+  });
+});

--- a/src/screens/__tests__/StampDetailScreen.test.tsx
+++ b/src/screens/__tests__/StampDetailScreen.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { StampDetailScreen } from '@screens/StampDetailScreen';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: View,
+    SafeAreaProvider: View,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+} as any;
+
+const mockRoute = {
+  key: 'test',
+  name: 'StampDetail' as const,
+  params: { stampId: '1' },
+};
+
+describe('StampDetailScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { getByText } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('御朱印詳細')).toBeTruthy();
+  });
+
+  it('renders stamp image area', () => {
+    const { getByTestId } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByTestId('stamp-image')).toBeTruthy();
+  });
+
+  it('renders spot name', () => {
+    const { getByText } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('明治神宮')).toBeTruthy();
+  });
+
+  it('renders shrine badge', () => {
+    const { getByTestId } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByTestId('badge-shrine')).toBeTruthy();
+  });
+
+  it('renders visit date', () => {
+    const { getByText } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('2024年1月15日')).toBeTruthy();
+  });
+
+  it('renders memo section', () => {
+    const { getByText } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('メモ')).toBeTruthy();
+    expect(getByText('初めての御朱印。天気が良くて気持ちの良い参拝でした。')).toBeTruthy();
+  });
+
+  it('navigates back on back button press', () => {
+    const { getByTestId } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('back-button'));
+    expect(mockNavigation.goBack).toHaveBeenCalled();
+  });
+});

--- a/src/theme/__tests__/theme.test.ts
+++ b/src/theme/__tests__/theme.test.ts
@@ -1,0 +1,89 @@
+import { colors, typography, spacing, borderRadius, shadows } from '@theme/index';
+
+describe('Theme', () => {
+  describe('colors', () => {
+    it('should export primary color palette', () => {
+      expect(colors.primary[500]).toBe('#f27f0d');
+      expect(colors.primary[50]).toBeDefined();
+      expect(colors.primary[900]).toBeDefined();
+    });
+
+    it('should export shrine colors', () => {
+      expect(colors.shrine[500]).toBe('#EF4444');
+      expect(colors.shrine[100]).toBe('#FEE2E2');
+      expect(colors.shrine[600]).toBe('#DC2626');
+    });
+
+    it('should export temple colors', () => {
+      expect(colors.temple[500]).toBe('#A855F7');
+      expect(colors.temple[100]).toBe('#F3E8FF');
+      expect(colors.temple[600]).toBe('#9333EA');
+    });
+
+    it('should export pin colors', () => {
+      expect(colors.pin.shrineVisited).toBe('#EF4444');
+      expect(colors.pin.templeVisited).toBe('#A855F7');
+      expect(colors.pin.unvisited).toBe('#9CA3AF');
+      expect(colors.pin.currentLocation).toBe('#3B82F6');
+    });
+
+    it('should export semantic colors', () => {
+      expect(colors.background).toBe('#FFFFFF');
+      expect(colors.surface).toBe('#F9FAFB');
+      expect(colors.success).toBeDefined();
+      expect(colors.error).toBeDefined();
+    });
+  });
+
+  describe('typography', () => {
+    it('should export heading styles', () => {
+      expect(typography.h1.fontSize).toBe(28);
+      expect(typography.h2.fontSize).toBe(22);
+      expect(typography.h3.fontSize).toBe(18);
+    });
+
+    it('should export body styles', () => {
+      expect(typography.body.fontSize).toBe(16);
+      expect(typography.bodySmall.fontSize).toBe(14);
+    });
+
+    it('should export label and button styles', () => {
+      expect(typography.label.fontSize).toBe(12);
+      expect(typography.button.fontSize).toBe(16);
+      expect(typography.buttonSmall.fontSize).toBe(14);
+    });
+  });
+
+  describe('spacing', () => {
+    it('should export spacing scale', () => {
+      expect(spacing.xs).toBe(4);
+      expect(spacing.sm).toBe(8);
+      expect(spacing.md).toBe(12);
+      expect(spacing.lg).toBe(16);
+      expect(spacing.xl).toBe(20);
+    });
+  });
+
+  describe('borderRadius', () => {
+    it('should export border radius scale', () => {
+      expect(borderRadius.sm).toBe(4);
+      expect(borderRadius.md).toBe(8);
+      expect(borderRadius.lg).toBe(12);
+      expect(borderRadius.full).toBe(9999);
+    });
+  });
+
+  describe('shadows', () => {
+    it('should export shadow styles', () => {
+      expect(shadows.sm.shadowOpacity).toBe(0.05);
+      expect(shadows.md.shadowOpacity).toBe(0.1);
+      expect(shadows.lg.shadowOpacity).toBe(0.15);
+    });
+
+    it('should include elevation for Android', () => {
+      expect(shadows.sm.elevation).toBe(1);
+      expect(shadows.md.elevation).toBe(3);
+      expect(shadows.lg.elevation).toBe(5);
+    });
+  });
+});

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,66 @@
+export const colors = {
+  primary: {
+    50: '#FFF7ED',
+    100: '#FFEDD5',
+    200: '#FED7AA',
+    300: '#FDBA74',
+    400: '#FB923C',
+    500: '#f27f0d',
+    600: '#EA580C',
+    700: '#C2410C',
+    800: '#9A3412',
+    900: '#7C2D12',
+  },
+
+  shrine: {
+    50: '#FEF2F2',
+    100: '#FEE2E2',
+    200: '#FECACA',
+    500: '#EF4444',
+    600: '#DC2626',
+    700: '#B91C1C',
+  },
+
+  temple: {
+    50: '#FAF5FF',
+    100: '#F3E8FF',
+    200: '#E9D5FF',
+    500: '#A855F7',
+    600: '#9333EA',
+    700: '#7E22CE',
+  },
+
+  gray: {
+    50: '#F9FAFB',
+    100: '#F3F4F6',
+    200: '#E5E7EB',
+    300: '#D1D5DB',
+    400: '#9CA3AF',
+    500: '#6B7280',
+    600: '#4B5563',
+    700: '#374151',
+    800: '#1F2937',
+    900: '#111827',
+  },
+
+  pin: {
+    shrineVisited: '#EF4444',
+    templeVisited: '#A855F7',
+    unvisited: '#9CA3AF',
+    currentLocation: '#3B82F6',
+  },
+
+  white: '#FFFFFF',
+  black: '#000000',
+  transparent: 'transparent',
+
+  background: '#FFFFFF',
+  surface: '#F9FAFB',
+
+  success: '#22C55E',
+  warning: '#F59E0B',
+  error: '#EF4444',
+  info: '#3B82F6',
+} as const;
+
+export type Colors = typeof colors;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,9 @@
+export { colors } from './colors';
+export { typography } from './typography';
+export { spacing, borderRadius } from './spacing';
+export { shadows } from './shadows';
+
+export type { Colors } from './colors';
+export type { Typography } from './typography';
+export type { Spacing, BorderRadius } from './spacing';
+export type { Shadows } from './shadows';

--- a/src/theme/shadows.ts
+++ b/src/theme/shadows.ts
@@ -1,0 +1,29 @@
+import { ViewStyle } from 'react-native';
+
+export const shadows = {
+  sm: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  } as ViewStyle,
+
+  md: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  } as ViewStyle,
+
+  lg: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.15,
+    shadowRadius: 8,
+    elevation: 5,
+  } as ViewStyle,
+} as const;
+
+export type Shadows = typeof shadows;

--- a/src/theme/spacing.ts
+++ b/src/theme/spacing.ts
@@ -1,0 +1,25 @@
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 20,
+  '2xl': 24,
+  '3xl': 32,
+  '4xl': 40,
+  '5xl': 48,
+  '6xl': 64,
+} as const;
+
+export const borderRadius = {
+  sm: 4,
+  md: 8,
+  lg: 12,
+  xl: 16,
+  '2xl': 20,
+  '3xl': 24,
+  full: 9999,
+} as const;
+
+export type Spacing = typeof spacing;
+export type BorderRadius = typeof borderRadius;

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,0 +1,59 @@
+import { TextStyle } from 'react-native';
+
+export const typography = {
+  h1: {
+    fontSize: 28,
+    fontWeight: '700',
+    lineHeight: 34,
+  } as TextStyle,
+
+  h2: {
+    fontSize: 22,
+    fontWeight: '700',
+    lineHeight: 28,
+  } as TextStyle,
+
+  h3: {
+    fontSize: 18,
+    fontWeight: '600',
+    lineHeight: 24,
+  } as TextStyle,
+
+  body: {
+    fontSize: 16,
+    fontWeight: '400',
+    lineHeight: 24,
+  } as TextStyle,
+
+  bodySmall: {
+    fontSize: 14,
+    fontWeight: '400',
+    lineHeight: 20,
+  } as TextStyle,
+
+  label: {
+    fontSize: 12,
+    fontWeight: '500',
+    lineHeight: 16,
+  } as TextStyle,
+
+  button: {
+    fontSize: 16,
+    fontWeight: '600',
+    lineHeight: 24,
+  } as TextStyle,
+
+  buttonSmall: {
+    fontSize: 14,
+    fontWeight: '600',
+    lineHeight: 20,
+  } as TextStyle,
+
+  caption: {
+    fontSize: 12,
+    fontWeight: '400',
+    lineHeight: 16,
+  } as TextStyle,
+} as const;
+
+export type Typography = typeof typography;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
       "@services/*": ["src/services/*"],
       "@stores/*": ["src/stores/*"],
       "@types/*": ["src/types/*"],
-      "@utils/*": ["src/utils/*"]
+      "@utils/*": ["src/utils/*"],
+      "@theme/*": ["src/theme/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
## Summary
- Stitch MCPのデザインデータを参考に、プレースホルダーだった全10画面をReact Native + StyleSheet.create()で本格的なUIに置き換え
- テーマ定義（colors, typography, spacing, shadows）、共通コンポーネント（Button, Badge, Card等）、アニメーション対象コンポーネント（FAB, Checkmark等）を新規作成
- エラー画面（network/location/upload 3タイプ）を新規作成し、タブバーアイコンをMaterialIconsに更新

## Changes (47 files, +3476 / -101)

### 新規作成
- `src/theme/` - カラーパレット、タイポグラフィ、スペーシング、シャドウ定義（5ファイル）
- `src/components/common/` - Button, Badge, Card, SearchBar, PageIndicator（5ファイル）
- `src/components/animated/` - FABButton, CheckmarkAnimation, BadgeAnimation, OnboardingIcon, ErrorIcon（5ファイル）
- `src/screens/ErrorScreen.tsx` - エラー画面（3タイプ切り替え）
- テストファイル - 14ファイル（テーマ1 + コンポーネント2 + 画面11）

### 変更
- `src/screens/` - 既存10画面のプレースホルダーをUI実装に置き換え
- `src/navigation/TabNavigator.tsx` - 絵文字アイコン → MaterialIcons
- `src/navigation/types.ts` - Error画面パラメータ追加
- `tsconfig.json`, `jest.config.js` - `@theme/*` パスエイリアス追加
- `jest.setup.js` - `@expo/vector-icons` モック追加

## Test plan
- [x] `npm test` - 全19 suites, 131テスト通過
- [x] `npm run lint` - 0 errors
- [x] `npm run typecheck` - 型エラーなし
- [ ] Expo Go で実機確認 - 各画面の表示・画面遷移が正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)