### PR TITLE
feat(ui): 共通コンポーネント追加・テーマトークン適用 (#9)

### DIFF
--- a/src/components/__tests__/common.test.tsx
+++ b/src/components/__tests__/common.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import { Button } from '@components/common/Button';
 import { Badge } from '@components/common/Badge';
 import { Card } from '@components/common/Card';
 import { SearchBar } from '@components/common/SearchBar';
 import { PageIndicator } from '@components/common/PageIndicator';
+import { LoadingIndicator } from '@components/common/LoadingIndicator';
+import { TextInput } from '@components/common/TextInput';
+import { Header } from '@components/common/Header';
+import { Modal } from '@components/common/Modal';
+import { MapPin } from '@components/common/MapPin';
 import { Text } from 'react-native';
 
 describe('Common Components', () => {
@@ -101,6 +106,180 @@ describe('Common Components', () => {
       const { getAllByTestId } = render(<PageIndicator total={4} current={2} />);
       expect(getAllByTestId('dot-active')).toHaveLength(1);
       expect(getAllByTestId('dot-inactive')).toHaveLength(3);
+    });
+  });
+
+  describe('LoadingIndicator', () => {
+    it('renders with default props', () => {
+      const { getByTestId } = render(<LoadingIndicator />);
+      expect(getByTestId('loading-indicator')).toBeTruthy();
+    });
+
+    it('renders with message', () => {
+      const { getByTestId } = render(<LoadingIndicator message="読み込み中..." />);
+      expect(getByTestId('loading-message')).toBeTruthy();
+    });
+
+    it('does not render message when not provided', () => {
+      const { queryByTestId } = render(<LoadingIndicator />);
+      expect(queryByTestId('loading-message')).toBeNull();
+    });
+
+    it('renders fullScreen variant', () => {
+      const { getByTestId } = render(<LoadingIndicator fullScreen />);
+      expect(getByTestId('loading-indicator')).toBeTruthy();
+    });
+  });
+
+  describe('TextInput', () => {
+    it('renders with placeholder', () => {
+      const { getByTestId, getByPlaceholderText } = render(
+        <TextInput placeholder="入力してください" />
+      );
+      expect(getByTestId('text-input')).toBeTruthy();
+      expect(getByPlaceholderText('入力してください')).toBeTruthy();
+    });
+
+    it('renders with label', () => {
+      const { getByTestId } = render(<TextInput label="名前" />);
+      expect(getByTestId('text-input-label')).toBeTruthy();
+    });
+
+    it('renders error message', () => {
+      const { getByTestId } = render(<TextInput error="入力必須です" />);
+      expect(getByTestId('text-input-error')).toBeTruthy();
+    });
+
+    it('does not render label when not provided', () => {
+      const { queryByTestId } = render(<TextInput />);
+      expect(queryByTestId('text-input-label')).toBeNull();
+    });
+
+    it('does not render error when not provided', () => {
+      const { queryByTestId } = render(<TextInput />);
+      expect(queryByTestId('text-input-error')).toBeNull();
+    });
+
+    it('calls onChangeText', () => {
+      const onChangeText = jest.fn();
+      const { getByTestId } = render(<TextInput onChangeText={onChangeText} />);
+      fireEvent.changeText(getByTestId('text-input'), 'テスト');
+      expect(onChangeText).toHaveBeenCalledWith('テスト');
+    });
+  });
+
+  describe('Header', () => {
+    it('renders with title', () => {
+      const { getByTestId } = render(<Header title="テストタイトル" />);
+      expect(getByTestId('header')).toBeTruthy();
+      expect(getByTestId('header-title')).toBeTruthy();
+    });
+
+    it('renders back button when onBack provided', () => {
+      const { getByTestId } = render(<Header title="テスト" onBack={() => {}} />);
+      expect(getByTestId('header-back-button')).toBeTruthy();
+    });
+
+    it('renders close button when onClose provided', () => {
+      const { getByTestId } = render(<Header title="テスト" onClose={() => {}} />);
+      expect(getByTestId('header-close-button')).toBeTruthy();
+    });
+
+    it('calls onBack when back button pressed', () => {
+      const onBack = jest.fn();
+      const { getByTestId } = render(<Header title="テスト" onBack={onBack} />);
+      fireEvent.press(getByTestId('header-back-button'));
+      expect(onBack).toHaveBeenCalled();
+    });
+
+    it('calls onClose when close button pressed', () => {
+      const onClose = jest.fn();
+      const { getByTestId } = render(<Header title="テスト" onClose={onClose} />);
+      fireEvent.press(getByTestId('header-close-button'));
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('renders rightElement', () => {
+      const { getByText } = render(<Header title="テスト" rightElement={<Text>右</Text>} />);
+      expect(getByText('右')).toBeTruthy();
+    });
+  });
+
+  describe('Modal', () => {
+    it('renders when visible', () => {
+      const { getByTestId } = render(
+        <Modal visible onClose={() => {}}>
+          <Text>モーダル内容</Text>
+        </Modal>
+      );
+      expect(getByTestId('modal-overlay')).toBeTruthy();
+      expect(getByTestId('modal-content')).toBeTruthy();
+    });
+
+    it('renders with title', () => {
+      const { getByTestId } = render(
+        <Modal visible onClose={() => {}} title="テストモーダル">
+          <Text>内容</Text>
+        </Modal>
+      );
+      expect(getByTestId('modal-title')).toBeTruthy();
+    });
+
+    it('does not render title when not provided', () => {
+      const { queryByTestId } = render(
+        <Modal visible onClose={() => {}}>
+          <Text>内容</Text>
+        </Modal>
+      );
+      expect(queryByTestId('modal-title')).toBeNull();
+    });
+
+    it('renders children', () => {
+      const { getByText } = render(
+        <Modal visible onClose={() => {}}>
+          <Text>子要素テスト</Text>
+        </Modal>
+      );
+      expect(getByText('子要素テスト')).toBeTruthy();
+    });
+
+    it('calls onClose on backdrop press when closeOnBackdrop is true', () => {
+      const onClose = jest.fn();
+      const { getByTestId } = render(
+        <Modal visible onClose={onClose} closeOnBackdrop>
+          <Text>内容</Text>
+        </Modal>
+      );
+      fireEvent.press(getByTestId('modal-overlay'));
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('MapPin', () => {
+    it('renders shrine-visited pin', () => {
+      const { getByTestId } = render(<MapPin type="shrine-visited" />);
+      expect(getByTestId('map-pin-shrine-visited')).toBeTruthy();
+    });
+
+    it('renders temple-visited pin', () => {
+      const { getByTestId } = render(<MapPin type="temple-visited" />);
+      expect(getByTestId('map-pin-temple-visited')).toBeTruthy();
+    });
+
+    it('renders unvisited pin', () => {
+      const { getByTestId } = render(<MapPin type="unvisited" />);
+      expect(getByTestId('map-pin-unvisited')).toBeTruthy();
+    });
+
+    it('renders current-location pin with pulse', () => {
+      const { getByTestId } = render(<MapPin type="current-location" />);
+      expect(getByTestId('map-pin-current-location')).toBeTruthy();
+      expect(getByTestId('map-pin-pulse')).toBeTruthy();
+    });
+
+    it('does not render pulse for non-current-location pins', () => {
+      const { queryByTestId } = render(<MapPin type="shrine-visited" />);
+      expect(queryByTestId('map-pin-pulse')).toBeNull();
     });
   });
 });

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
+
+interface HeaderProps {
+  title: string;
+  variant?: 'page' | 'modal';
+  onBack?: () => void;
+  onClose?: () => void;
+  rightElement?: React.ReactNode;
+  style?: ViewStyle;
+}
+
+export function Header({
+  title,
+  variant = 'page',
+  onBack,
+  onClose,
+  rightElement,
+  style,
+}: HeaderProps) {
+  return (
+    <View
+      style={[styles.container, variant === 'modal' && styles.modalVariant, style]}
+      testID="header"
+    >
+      <View style={styles.leftSlot}>
+        {onBack && (
+          <TouchableOpacity onPress={onBack} testID="header-back-button">
+            <MaterialIcons name="arrow-back" size={24} color={colors.gray[800]} />
+          </TouchableOpacity>
+        )}
+        {onClose && (
+          <TouchableOpacity
+            onPress={onClose}
+            style={styles.iconButton}
+            testID="header-close-button"
+          >
+            <MaterialIcons name="close" size={24} color={colors.gray[800]} />
+          </TouchableOpacity>
+        )}
+      </View>
+      <Text style={styles.title} testID="header-title">
+        {title}
+      </Text>
+      <View style={styles.rightSlot}>{rightElement}</View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  modalVariant: {
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray[200],
+  },
+  leftSlot: {
+    width: 40,
+    alignItems: 'flex-start',
+  },
+  iconButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    ...typography.h3,
+    color: colors.gray[800],
+    flex: 1,
+    textAlign: 'center',
+  },
+  rightSlot: {
+    width: 40,
+    alignItems: 'flex-end',
+  },
+});

--- a/src/components/common/LoadingIndicator.tsx
+++ b/src/components/common/LoadingIndicator.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { ActivityIndicator, StyleSheet, Text, View, ViewStyle } from 'react-native';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
+
+interface LoadingIndicatorProps {
+  size?: 'small' | 'large';
+  color?: string;
+  message?: string;
+  fullScreen?: boolean;
+  style?: ViewStyle;
+}
+
+export function LoadingIndicator({
+  size = 'large',
+  color = colors.primary[500],
+  message,
+  fullScreen = false,
+  style,
+}: LoadingIndicatorProps) {
+  return (
+    <View
+      style={[styles.container, fullScreen && styles.fullScreen, style]}
+      testID="loading-indicator"
+    >
+      <ActivityIndicator size={size} color={color} />
+      {message && (
+        <Text style={styles.message} testID="loading-message">
+          {message}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  fullScreen: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  message: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+  },
+});

--- a/src/components/common/MapPin.tsx
+++ b/src/components/common/MapPin.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
+import { colors } from '@theme/colors';
+
+type PinType = 'shrine-visited' | 'temple-visited' | 'unvisited' | 'current-location';
+
+interface MapPinProps {
+  type: PinType;
+}
+
+const PIN_CONFIG: Record<PinType, { color: string; size: number }> = {
+  'shrine-visited': { color: colors.pin.shrineVisited, size: 16 },
+  'temple-visited': { color: colors.pin.templeVisited, size: 16 },
+  unvisited: { color: colors.pin.unvisited, size: 12 },
+  'current-location': { color: colors.pin.currentLocation, size: 20 },
+};
+
+export function MapPin({ type }: MapPinProps) {
+  const pulseAnim = useRef(new Animated.Value(1)).current;
+  const opacityAnim = useRef(new Animated.Value(0.6)).current;
+  const config = PIN_CONFIG[type];
+
+  useEffect(() => {
+    if (type !== 'current-location') return;
+
+    const animation = Animated.loop(
+      Animated.parallel([
+        Animated.sequence([
+          Animated.timing(pulseAnim, {
+            toValue: 2,
+            duration: 1500,
+            useNativeDriver: true,
+          }),
+          Animated.timing(pulseAnim, {
+            toValue: 1,
+            duration: 0,
+            useNativeDriver: true,
+          }),
+        ]),
+        Animated.sequence([
+          Animated.timing(opacityAnim, {
+            toValue: 0,
+            duration: 1500,
+            useNativeDriver: true,
+          }),
+          Animated.timing(opacityAnim, {
+            toValue: 0.6,
+            duration: 0,
+            useNativeDriver: true,
+          }),
+        ]),
+      ])
+    );
+    animation.start();
+
+    return () => animation.stop();
+  }, [type, pulseAnim, opacityAnim]);
+
+  return (
+    <View style={styles.wrapper} testID={`map-pin-${type}`}>
+      {type === 'current-location' && (
+        <Animated.View
+          testID="map-pin-pulse"
+          style={[
+            styles.pulse,
+            {
+              width: config.size * 2,
+              height: config.size * 2,
+              borderRadius: config.size,
+              backgroundColor: config.color,
+              transform: [{ scale: pulseAnim }],
+              opacity: opacityAnim,
+            },
+          ]}
+        />
+      )}
+      <View
+        style={[
+          styles.pin,
+          {
+            width: config.size,
+            height: config.size,
+            borderRadius: config.size / 2,
+            backgroundColor: config.color,
+          },
+        ]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pulse: {
+    position: 'absolute',
+  },
+  pin: {},
+});

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Modal as RNModal, Pressable, StyleSheet, Text } from 'react-native';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+import { shadows } from '@theme/shadows';
+
+interface ModalProps {
+  visible: boolean;
+  onClose: () => void;
+  variant?: 'center' | 'bottom';
+  title?: string;
+  children: React.ReactNode;
+  closeOnBackdrop?: boolean;
+}
+
+export function Modal({
+  visible,
+  onClose,
+  variant = 'center',
+  title,
+  children,
+  closeOnBackdrop = true,
+}: ModalProps) {
+  const handleBackdropPress = () => {
+    if (closeOnBackdrop) {
+      onClose();
+    }
+  };
+
+  return (
+    <RNModal
+      visible={visible}
+      transparent
+      animationType={variant === 'center' ? 'fade' : 'slide'}
+      onRequestClose={onClose}
+    >
+      <Pressable
+        style={[styles.overlay, variant === 'bottom' && styles.overlayBottom]}
+        onPress={handleBackdropPress}
+        testID="modal-overlay"
+      >
+        <Pressable
+          style={[styles.content, variant === 'bottom' && styles.contentBottom]}
+          testID="modal-content"
+        >
+          {title && (
+            <Text style={styles.title} testID="modal-title">
+              {title}
+            </Text>
+          )}
+          {children}
+        </Pressable>
+      </Pressable>
+    </RNModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing['2xl'],
+  },
+  overlayBottom: {
+    justifyContent: 'flex-end',
+    padding: 0,
+  },
+  content: {
+    backgroundColor: colors.white,
+    borderRadius: borderRadius.xl,
+    padding: spacing['2xl'],
+    width: '100%',
+    ...shadows.lg,
+  },
+  contentBottom: {
+    borderRadius: 0,
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+  },
+  title: {
+    ...typography.h3,
+    color: colors.gray[800],
+    marginBottom: spacing.lg,
+  },
+});

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { StyleSheet, Text, TextInput as RNTextInput, View, ViewStyle } from 'react-native';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+
+interface TextInputProps {
+  label?: string;
+  placeholder?: string;
+  value?: string;
+  onChangeText?: (text: string) => void;
+  multiline?: boolean;
+  error?: string;
+  disabled?: boolean;
+  style?: ViewStyle;
+  maxLength?: number;
+}
+
+export function TextInput({
+  label,
+  placeholder,
+  value,
+  onChangeText,
+  multiline = false,
+  error,
+  disabled = false,
+  style,
+  maxLength,
+}: TextInputProps) {
+  return (
+    <View style={style}>
+      {label && (
+        <Text style={styles.label} testID="text-input-label">
+          {label}
+        </Text>
+      )}
+      <RNTextInput
+        style={[
+          styles.input,
+          multiline && styles.multiline,
+          error && styles.inputError,
+          disabled && styles.inputDisabled,
+        ]}
+        placeholder={placeholder}
+        placeholderTextColor={colors.gray[400]}
+        value={value}
+        onChangeText={onChangeText}
+        multiline={multiline}
+        editable={!disabled}
+        maxLength={maxLength}
+        testID="text-input"
+      />
+      {error && (
+        <Text style={styles.error} testID="text-input-error">
+          {error}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  label: {
+    ...typography.label,
+    color: colors.gray[600],
+    marginBottom: spacing.xs,
+  },
+  input: {
+    ...typography.body,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    borderRadius: borderRadius.lg,
+    padding: spacing.lg,
+    backgroundColor: colors.white,
+    color: colors.gray[800],
+  },
+  multiline: {
+    height: 100,
+    textAlignVertical: 'top',
+  },
+  inputError: {
+    borderColor: colors.error,
+  },
+  inputDisabled: {
+    backgroundColor: colors.gray[100],
+    color: colors.gray[400],
+  },
+  error: {
+    ...typography.caption,
+    color: colors.error,
+    marginTop: spacing.xs,
+  },
+});

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -8,6 +8,7 @@ import { GalleryStack } from '@/navigation/GalleryStack';
 import { CollectionScreen } from '@screens/CollectionScreen';
 import { SettingsScreen } from '@screens/SettingsScreen';
 import { useAuth } from '@hooks/useAuth';
+import { colors } from '@theme/colors';
 import type { MainTabParamList, RootStackParamList } from '@/navigation/types';
 
 const Tab = createBottomTabNavigator<MainTabParamList>();
@@ -22,7 +23,7 @@ export function TabNavigator() {
     <Tab.Navigator
       screenOptions={{
         headerShown: false,
-        tabBarActiveTintColor: '#F97316',
+        tabBarActiveTintColor: colors.primary[500],
       }}
     >
       <Tab.Screen

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View, ScrollView, TouchableOpacity, TextInput } from 
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialIcons } from '@expo/vector-icons';
 import { Button } from '@components/common/Button';
+import { Header } from '@components/common/Header';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing, borderRadius } from '@theme/spacing';
@@ -27,17 +28,7 @@ export function RecordScreen({ navigation }: Props) {
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
-      <View style={styles.header}>
-        <TouchableOpacity
-          onPress={() => navigation.goBack()}
-          style={styles.headerButton}
-          testID="close-button"
-        >
-          <MaterialIcons name="close" size={24} color={colors.gray[800]} />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>御朱印を記録</Text>
-        <View style={styles.headerButton} />
-      </View>
+      <Header title="御朱印を記録" variant="modal" onClose={() => navigation.goBack()} />
 
       <ScrollView
         style={styles.scrollView}
@@ -96,25 +87,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.md,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.gray[200],
-  },
-  headerButton: {
-    width: 40,
-    height: 40,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  headerTitle: {
-    ...typography.h3,
-    color: colors.gray[800],
   },
   scrollView: {
     flex: 1,

--- a/src/screens/SpotDetailScreen.tsx
+++ b/src/screens/SpotDetailScreen.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { FlatList, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialIcons } from '@expo/vector-icons';
 
 import { Badge } from '@components/common/Badge';
 import { Button } from '@components/common/Button';
 import { Card } from '@components/common/Card';
+import { Header } from '@components/common/Header';
 import type { MapStackScreenProps } from '@/navigation/types';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
@@ -48,13 +49,7 @@ export function SpotDetailScreen({ navigation }: Props) {
 
   return (
     <SafeAreaView style={styles.container} testID="spot-detail-screen">
-      <View style={styles.header}>
-        <TouchableOpacity onPress={handleBack} testID="back-button">
-          <MaterialIcons name="arrow-back" size={24} color={colors.gray[800]} />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>スポット詳細</Text>
-        <View style={styles.headerSpacer} />
-      </View>
+      <Header title="スポット詳細" onBack={handleBack} />
 
       <FlatList
         data={MOCK_STAMPS}
@@ -125,21 +120,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.white,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.md,
-  },
-  headerTitle: {
-    ...typography.h3,
-    color: colors.gray[800],
-    flex: 1,
-    textAlign: 'center',
-  },
-  headerSpacer: {
-    width: 24,
   },
   scrollContent: {
     paddingHorizontal: spacing.lg,

--- a/src/screens/__tests__/RecordScreen.test.tsx
+++ b/src/screens/__tests__/RecordScreen.test.tsx
@@ -70,7 +70,7 @@ describe('RecordScreen', () => {
 
   it('navigates back on close button press', () => {
     const { getByTestId } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
-    fireEvent.press(getByTestId('close-button'));
+    fireEvent.press(getByTestId('header-close-button'));
     expect(mockNavigation.goBack).toHaveBeenCalled();
   });
 

--- a/src/screens/__tests__/SpotDetailScreen.test.tsx
+++ b/src/screens/__tests__/SpotDetailScreen.test.tsx
@@ -57,7 +57,7 @@ describe('SpotDetailScreen', () => {
     const { getByTestId } = render(
       <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
     );
-    expect(getByTestId('back-button')).toBeTruthy();
+    expect(getByTestId('header-back-button')).toBeTruthy();
   });
 
   it('displays header title', () => {
@@ -109,7 +109,7 @@ describe('SpotDetailScreen', () => {
     const { getByTestId } = render(
       <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
     );
-    fireEvent.press(getByTestId('back-button'));
+    fireEvent.press(getByTestId('header-back-button'));
     expect(mockNavigation.goBack).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- LoadingIndicator, TextInput, Header, Modal, MapPin の5つの共通コンポーネントを新規作成
- SpotDetailScreen, RecordScreen の重複ヘッダーを共通 Header コンポーネントに置き換え
- TabNavigator のハードコード色 `#F97316` を `colors.primary[500]` に修正

## Test plan
- [x] 新規5コンポーネントのユニットテスト追加（26テスト）
- [x] 既存画面テスト（SpotDetailScreen, RecordScreen, GalleryScreen）がリファクタリング後も通過
- [x] 全157テスト通過
- [x] lint エラー 0件
- [x] 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)