### PR TITLE
feat(onboarding): 完了フラグ永続化と位置情報許可リクエスト (#10)

### DIFF
--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -9,10 +9,12 @@ import {
   ViewToken,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import * as Location from 'expo-location';
 
 import { OnboardingIcon } from '@components/animated/OnboardingIcon';
 import { Button } from '@components/common/Button';
 import { PageIndicator } from '@components/common/PageIndicator';
+import { useOnboarding } from '@hooks/useOnboarding';
 import type { RootStackScreenProps } from '@/navigation/types';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
@@ -59,6 +61,7 @@ const { width: SCREEN_WIDTH } = Dimensions.get('window');
 export function OnboardingScreen({ navigation }: Props) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const flatListRef = useRef<FlatList<SlideData>>(null);
+  const { completeOnboarding } = useOnboarding();
 
   const onViewableItemsChanged = useCallback(
     ({ viewableItems }: { viewableItems: ViewToken[] }) => {
@@ -78,10 +81,17 @@ export function OnboardingScreen({ navigation }: Props) {
   };
 
   const handleSkip = () => {
+    completeOnboarding();
     navigation.navigate('MainTabs', { screen: 'MapTab', params: { screen: 'Map' } });
   };
 
-  const handleComplete = () => {
+  const handleComplete = async () => {
+    try {
+      await Location.requestForegroundPermissionsAsync();
+    } catch {
+      // エラーでもオンボーディングは完了させる
+    }
+    completeOnboarding();
     navigation.navigate('MainTabs', { screen: 'MapTab', params: { screen: 'Map' } });
   };
 


### PR DESCRIPTION
## Summary
- オンボーディングのスキップ・完了時にAsyncStorageへ完了フラグを保存し、2回目以降の起動時にオンボーディングをスキップ
- 最終スライドの「位置情報を許可して始める」ボタンでexpo-locationの許可ダイアログを表示
- 位置情報が拒否・エラーでもオンボーディングは完了扱いとする

## Test plan
- [x] スキップ押下時に completeOnboarding が呼ばれる
- [x] 「位置情報を許可して始める」で requestForegroundPermissionsAsync が呼ばれる
- [x] 完了時に completeOnboarding + navigate が呼ばれる
- [x] 位置情報 denied でも completeOnboarding が呼ばれる
- [x] requestForegroundPermissionsAsync エラー時も completeOnboarding が呼ばれる
- [x] 「あとで設定する」は位置情報リクエストなしで completeOnboarding + navigate

🤖 Generated with [Claude Code](https://claude.com/claude-code)