### PR TITLE
feat(auth): Google OAuth認証・遅延ログイン・ログアウト機能を実装 (#11)

### DIFF
--- a/app.json
+++ b/app.json
@@ -35,6 +35,12 @@
         "READ_EXTERNAL_STORAGE"
       ]
     },
-    "plugins": ["expo-location", "expo-image-picker", "expo-camera", "expo-asset"]
+    "plugins": [
+      "expo-location",
+      "expo-image-picker",
+      "expo-camera",
+      "expo-asset",
+      "@react-native-google-signin/google-signin"
+    ]
   }
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -43,6 +43,26 @@ Object.defineProperty(global, 'localStorage', {
   value: localStorageMock,
 });
 
+// @react-native-google-signin/google-signin mock
+jest.mock('@react-native-google-signin/google-signin', () => ({
+  GoogleSignin: {
+    configure: jest.fn(),
+    hasPlayServices: jest.fn(() => Promise.resolve(true)),
+    signIn: jest.fn(() =>
+      Promise.resolve({ data: { idToken: 'mock-id-token', user: { email: 'test@example.com' } } })
+    ),
+    signOut: jest.fn(() => Promise.resolve()),
+    isSignedIn: jest.fn(() => Promise.resolve(false)),
+    getCurrentUser: jest.fn(() => Promise.resolve(null)),
+  },
+  statusCodes: {
+    SIGN_IN_CANCELLED: 'SIGN_IN_CANCELLED',
+    IN_PROGRESS: 'IN_PROGRESS',
+    PLAY_SERVICES_NOT_AVAILABLE: 'PLAY_SERVICES_NOT_AVAILABLE',
+  },
+  isErrorWithCode: jest.fn(error => error && typeof error === 'object' && 'code' in error),
+}));
+
 // @expo/vector-icons mock
 jest.mock('@expo/vector-icons', () => {
   const React = require('react');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-google-signin/google-signin": "^16.1.1",
         "@react-navigation/bottom-tabs": "^7.12.0",
         "@react-navigation/native": "^7.1.28",
         "@react-navigation/native-stack": "^7.12.0",
@@ -2984,6 +2985,22 @@
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
+    "node_modules/@react-native-google-signin/google-signin": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-google-signin/google-signin/-/google-signin-16.1.1.tgz",
+      "integrity": "sha512-lcHBnZ7uvCJiWtGooKOklo/4okqszWvJ0BatW1UaIe+ynmpVpp1lyJkvv1Mj08d39k4soaWuhZVNKjD/RFL34Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": ">=52.0.40",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.81.5",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.81.5.tgz",
@@ -3655,7 +3672,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5663,7 +5680,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-google-signin/google-signin": "^16.1.1",
     "@react-navigation/bottom-tabs": "^7.12.0",
     "@react-navigation/native": "^7.1.28",
     "@react-navigation/native-stack": "^7.12.0",

--- a/src/components/__tests__/LoginPromptModal.test.tsx
+++ b/src/components/__tests__/LoginPromptModal.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+
+import { LoginPromptModal } from '../common/LoginPromptModal';
+
+const mockSignInWithGoogle = jest.fn();
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: null,
+    session: null,
+    isLoading: false,
+    isAuthenticated: false,
+    isSigningIn: false,
+    signInWithGoogle: mockSignInWithGoogle,
+    signOut: jest.fn(),
+  }),
+}));
+
+describe('LoginPromptModal', () => {
+  const defaultProps = {
+    visible: true,
+    onClose: jest.fn(),
+    onLoginSuccess: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders modal with login prompt text', () => {
+    const { getByText } = render(<LoginPromptModal {...defaultProps} />);
+    expect(getByText('ログインが必要です')).toBeTruthy();
+    expect(getByText('御朱印を記録するにはログインしてください')).toBeTruthy();
+  });
+
+  it('renders Google login button', () => {
+    const { getByTestId } = render(<LoginPromptModal {...defaultProps} />);
+    expect(getByTestId('modal-google-login-button')).toBeTruthy();
+  });
+
+  it('renders later button', () => {
+    const { getByText } = render(<LoginPromptModal {...defaultProps} />);
+    expect(getByText('あとにする')).toBeTruthy();
+  });
+
+  it('calls onClose when later button is pressed', () => {
+    const { getByTestId } = render(<LoginPromptModal {...defaultProps} />);
+    fireEvent.press(getByTestId('modal-later-button'));
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('calls signInWithGoogle on Google button press and onLoginSuccess on success', async () => {
+    mockSignInWithGoogle.mockResolvedValue({ success: true });
+
+    const { getByTestId } = render(<LoginPromptModal {...defaultProps} />);
+    fireEvent.press(getByTestId('modal-google-login-button'));
+
+    await waitFor(() => {
+      expect(mockSignInWithGoogle).toHaveBeenCalled();
+      expect(defaultProps.onLoginSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it('does not call onLoginSuccess on cancelled sign-in', async () => {
+    mockSignInWithGoogle.mockResolvedValue({
+      success: false,
+      error: { code: 'CANCELLED', message: 'cancelled' },
+    });
+
+    const { getByTestId } = render(<LoginPromptModal {...defaultProps} />);
+    fireEvent.press(getByTestId('modal-google-login-button'));
+
+    await waitFor(() => {
+      expect(mockSignInWithGoogle).toHaveBeenCalled();
+    });
+    expect(defaultProps.onLoginSuccess).not.toHaveBeenCalled();
+  });
+
+  it('does not render when visible is false', () => {
+    const { queryByText } = render(<LoginPromptModal {...defaultProps} visible={false} />);
+    expect(queryByText('ログインが必要です')).toBeNull();
+  });
+});

--- a/src/components/common/LoginPromptModal.tsx
+++ b/src/components/common/LoginPromptModal.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+
+import { Modal } from '@components/common/Modal';
+import { useAuth } from '@hooks/useAuth';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+import { shadows } from '@theme/shadows';
+
+interface LoginPromptModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onLoginSuccess: () => void;
+}
+
+export function LoginPromptModal({ visible, onClose, onLoginSuccess }: LoginPromptModalProps) {
+  const { signInWithGoogle } = useAuth();
+
+  const handleGoogleLogin = async () => {
+    const result = await signInWithGoogle();
+
+    if (result.success) {
+      onLoginSuccess();
+      return;
+    }
+
+    if (result.error.code !== 'CANCELLED') {
+      Alert.alert('ログインエラー', result.error.message);
+    }
+  };
+
+  return (
+    <Modal visible={visible} onClose={onClose} variant="center" closeOnBackdrop={false}>
+      <View style={styles.content}>
+        <View style={styles.iconContainer}>
+          <MaterialIcons name="camera-alt" size={32} color={colors.primary[500]} />
+        </View>
+
+        <Text style={styles.title}>ログインが必要です</Text>
+        <Text style={styles.description}>御朱印を記録するにはログインしてください</Text>
+
+        <TouchableOpacity
+          style={styles.googleButton}
+          onPress={handleGoogleLogin}
+          activeOpacity={0.7}
+          testID="modal-google-login-button"
+        >
+          <Text style={styles.googleIcon}>G</Text>
+          <Text style={styles.googleButtonText}>Google でログイン</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity onPress={onClose} testID="modal-later-button">
+          <Text style={styles.laterText}>あとにする</Text>
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    alignItems: 'center',
+  },
+  iconContainer: {
+    width: 64,
+    height: 64,
+    borderRadius: borderRadius['2xl'],
+    backgroundColor: colors.primary[50],
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing.lg,
+  },
+  title: {
+    ...typography.h3,
+    color: colors.gray[800],
+    marginBottom: spacing.sm,
+  },
+  description: {
+    ...typography.body,
+    color: colors.gray[500],
+    textAlign: 'center',
+    marginBottom: spacing.xl,
+  },
+  googleButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray[300],
+    borderRadius: borderRadius.lg,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing['2xl'],
+    width: '100%',
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  googleIcon: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.gray[700],
+  },
+  googleButtonText: {
+    ...typography.button,
+    color: colors.gray[700],
+  },
+  laterText: {
+    ...typography.body,
+    color: colors.gray[500],
+    marginTop: spacing.lg,
+  },
+});

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,18 +1,24 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
 import { supabase } from '@services/supabase';
+import { signInWithGoogle as authSignIn, signOut as authSignOut } from '@services/auth';
+import type { AuthResult, SignOutResult } from '@services/auth';
 
 interface AuthState {
   user: User | null;
   session: Session | null;
   isLoading: boolean;
   isAuthenticated: boolean;
+  isSigningIn: boolean;
+  signInWithGoogle: () => Promise<AuthResult>;
+  signOut: () => Promise<SignOutResult>;
 }
 
 export function useAuth(): AuthState {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isSigningIn, setIsSigningIn] = useState(false);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session: currentSession } }) => {
@@ -33,10 +39,26 @@ export function useAuth(): AuthState {
     };
   }, []);
 
+  const signInWithGoogle = useCallback(async (): Promise<AuthResult> => {
+    setIsSigningIn(true);
+    try {
+      return await authSignIn();
+    } finally {
+      setIsSigningIn(false);
+    }
+  }, []);
+
+  const signOut = useCallback(async (): Promise<SignOutResult> => {
+    return authSignOut();
+  }, []);
+
   return {
     user,
     session,
     isLoading,
     isAuthenticated: user !== null,
+    isSigningIn,
+    signInWithGoogle,
+    signOut,
   };
 }

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,6 +1,6 @@
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-
+import { configureGoogleSignIn } from '@services/auth';
 import { TabNavigator } from '@/navigation/TabNavigator';
 import { OnboardingScreen } from '@screens/OnboardingScreen';
 import { LoginScreen } from '@screens/LoginScreen';
@@ -8,6 +8,8 @@ import { RecordScreen } from '@screens/RecordScreen';
 import { RecordCompleteScreen } from '@screens/RecordCompleteScreen';
 import { useOnboarding } from '@hooks/useOnboarding';
 import type { RootStackParamList } from '@/navigation/types';
+
+configureGoogleSignIn();
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 

--- a/src/navigation/__tests__/RootNavigator.test.tsx
+++ b/src/navigation/__tests__/RootNavigator.test.tsx
@@ -3,6 +3,13 @@ import { NavigationContainer } from '@react-navigation/native';
 
 import { RootNavigator } from '../RootNavigator';
 
+// Mock auth service before importing RootNavigator (it calls configureGoogleSignIn at module scope)
+jest.mock('@services/auth', () => ({
+  configureGoogleSignIn: jest.fn(),
+  signInWithGoogle: jest.fn(),
+  signOut: jest.fn(),
+}));
+
 // Mock environment variables for supabase
 const env = process.env;
 env['EXPO_PUBLIC_SUPABASE_URL'] = 'https://test.supabase.co';
@@ -21,6 +28,9 @@ jest.mock('@hooks/useAuth', () => ({
     session: null,
     isLoading: false,
     isAuthenticated: false,
+    isSigningIn: false,
+    signInWithGoogle: jest.fn(),
+    signOut: jest.fn(),
   }),
 }));
 

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialIcons } from '@expo/vector-icons';
 
 import { FABButton } from '@components/animated/FABButton';
 import { SearchBar } from '@components/common/SearchBar';
+import { LoginPromptModal } from '@components/common/LoginPromptModal';
+import { useAuth } from '@hooks/useAuth';
 import type { MapStackScreenProps } from '@/navigation/types';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
@@ -14,11 +16,27 @@ import { shadows } from '@theme/shadows';
 type Props = MapStackScreenProps<'Map'>;
 
 export function MapScreen({ navigation }: Props) {
-  const handleFABPress = () => {
+  const { isAuthenticated } = useAuth();
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  const navigateToRecord = () => {
     const parent = navigation.getParent();
     if (parent) {
       parent.navigate('Record');
     }
+  };
+
+  const handleFABPress = () => {
+    if (isAuthenticated) {
+      navigateToRecord();
+    } else {
+      setShowLoginModal(true);
+    }
+  };
+
+  const handleLoginSuccess = () => {
+    setShowLoginModal(false);
+    navigateToRecord();
   };
 
   const handleFilterPress = () => {
@@ -49,6 +67,12 @@ export function MapScreen({ navigation }: Props) {
       <View style={styles.fabContainer}>
         <FABButton onPress={handleFABPress} />
       </View>
+
+      <LoginPromptModal
+        visible={showLoginModal}
+        onClose={() => setShowLoginModal(false)}
+        onLoginSuccess={handleLoginSuccess}
+      />
     </SafeAreaView>
   );
 }

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,8 +1,9 @@
 import { MaterialIcons } from '@expo/vector-icons';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Card } from '@components/common/Card';
+import { useAuth } from '@hooks/useAuth';
 import { colors } from '@theme/colors';
 import { borderRadius, spacing } from '@theme/spacing';
 import { typography } from '@theme/typography';
@@ -10,7 +11,29 @@ import type { MainTabScreenProps } from '@/navigation/types';
 
 type Props = MainTabScreenProps<'Settings'>;
 
-export function SettingsScreen(_props: Props) {
+export function SettingsScreen({ navigation }: Props) {
+  const { user, isAuthenticated, signOut } = useAuth();
+
+  const displayName = isAuthenticated
+    ? (user?.user_metadata?.full_name as string) || 'ユーザー'
+    : 'ゲスト';
+
+  const displayEmail = isAuthenticated ? (user?.email ?? '未設定') : '未設定';
+
+  const handleLogout = async () => {
+    const result = await signOut();
+    if (!result.success) {
+      Alert.alert('エラー', result.error.message);
+    }
+  };
+
+  const handleLogin = () => {
+    const parent = navigation.getParent();
+    if (parent) {
+      parent.navigate('Login');
+    }
+  };
+
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <ScrollView
@@ -25,17 +48,24 @@ export function SettingsScreen(_props: Props) {
         <Card style={styles.sectionCard}>
           <View style={styles.row}>
             <MaterialIcons name="person" size={24} color={colors.gray[500]} />
-            <Text style={styles.rowLabel}>ゲスト</Text>
+            <Text style={styles.rowLabel}>{displayName}</Text>
           </View>
           <View style={styles.row}>
             <MaterialIcons name="email" size={24} color={colors.gray[500]} />
-            <Text style={styles.rowLabel}>未設定</Text>
+            <Text style={styles.rowLabel}>{displayEmail}</Text>
           </View>
           <View style={styles.divider} />
-          <TouchableOpacity style={styles.row} accessibilityRole="button">
-            <MaterialIcons name="logout" size={24} color={colors.error} />
-            <Text style={styles.logoutText}>ログアウト</Text>
-          </TouchableOpacity>
+          {isAuthenticated ? (
+            <TouchableOpacity style={styles.row} accessibilityRole="button" onPress={handleLogout}>
+              <MaterialIcons name="logout" size={24} color={colors.error} />
+              <Text style={styles.logoutText}>ログアウト</Text>
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity style={styles.row} accessibilityRole="button" onPress={handleLogin}>
+              <MaterialIcons name="login" size={24} color={colors.primary[500]} />
+              <Text style={styles.loginText}>ログイン</Text>
+            </TouchableOpacity>
+          )}
         </Card>
 
         {/* Plan Section */}
@@ -123,6 +153,11 @@ const styles = StyleSheet.create({
   logoutText: {
     ...typography.body,
     color: colors.error,
+    flex: 1,
+  },
+  loginText: {
+    ...typography.body,
+    color: colors.primary[500],
     flex: 1,
   },
   planRow: {

--- a/src/screens/__tests__/LoginScreen.test.tsx
+++ b/src/screens/__tests__/LoginScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
 import { LoginScreen } from '@screens/LoginScreen';
 
 jest.mock('react-native-safe-area-context', () => {
@@ -13,6 +14,22 @@ jest.mock('react-native-safe-area-context', () => {
     SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
   };
 });
+
+const mockSignInWithGoogle = jest.fn();
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: null,
+    session: null,
+    isLoading: false,
+    isAuthenticated: false,
+    isSigningIn: false,
+    signInWithGoogle: mockSignInWithGoogle,
+    signOut: jest.fn(),
+  }),
+}));
+
+jest.spyOn(Alert, 'alert');
 
 const mockNavigation = {
   navigate: jest.fn(),
@@ -92,5 +109,56 @@ describe('LoginScreen', () => {
       <LoginScreen navigation={mockNavigation as never} route={mockRoute} />
     );
     expect(getByText('旅の記録を保存しましょう')).toBeTruthy();
+  });
+
+  it('calls signInWithGoogle and navigates back on success', async () => {
+    mockSignInWithGoogle.mockResolvedValue({ success: true });
+
+    const { getByTestId } = render(
+      <LoginScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+
+    fireEvent.press(getByTestId('google-login-button'));
+
+    await waitFor(() => {
+      expect(mockSignInWithGoogle).toHaveBeenCalled();
+      expect(mockNavigation.goBack).toHaveBeenCalled();
+    });
+  });
+
+  it('shows Alert on non-CANCELLED error', async () => {
+    mockSignInWithGoogle.mockResolvedValue({
+      success: false,
+      error: { code: 'SUPABASE_ERROR', message: 'auth failed' },
+    });
+
+    const { getByTestId } = render(
+      <LoginScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+
+    fireEvent.press(getByTestId('google-login-button'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('ログインエラー', 'auth failed');
+    });
+  });
+
+  it('does not show Alert when user cancels', async () => {
+    mockSignInWithGoogle.mockResolvedValue({
+      success: false,
+      error: { code: 'CANCELLED', message: 'cancelled' },
+    });
+
+    const { getByTestId } = render(
+      <LoginScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+
+    fireEvent.press(getByTestId('google-login-button'));
+
+    await waitFor(() => {
+      expect(mockSignInWithGoogle).toHaveBeenCalled();
+    });
+    expect(Alert.alert).not.toHaveBeenCalled();
+    expect(mockNavigation.goBack).not.toHaveBeenCalled();
   });
 });

--- a/src/screens/__tests__/MapScreen.test.tsx
+++ b/src/screens/__tests__/MapScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { MapScreen } from '@screens/MapScreen';
 
 jest.mock('react-native-safe-area-context', () => {
@@ -14,10 +14,25 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
+let mockUseAuthReturn = {
+  user: null,
+  session: null,
+  isLoading: false,
+  isAuthenticated: false,
+  isSigningIn: false,
+  signInWithGoogle: jest.fn(),
+  signOut: jest.fn(),
+};
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => mockUseAuthReturn,
+}));
+
+const mockParentNavigate = jest.fn();
 const mockNavigation = {
   navigate: jest.fn(),
   goBack: jest.fn(),
-  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+  getParent: jest.fn(() => ({ navigate: mockParentNavigate })),
   dispatch: jest.fn(),
   reset: jest.fn(),
   isFocused: jest.fn(),
@@ -40,6 +55,15 @@ const mockRoute = { key: 'test', name: 'Map' as const, params: undefined };
 describe('MapScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseAuthReturn = {
+      user: null,
+      session: null,
+      isLoading: false,
+      isAuthenticated: false,
+      isSigningIn: false,
+      signInWithGoogle: jest.fn(),
+      signOut: jest.fn(),
+    };
   });
 
   it('renders without crashing', () => {
@@ -76,5 +100,63 @@ describe('MapScreen', () => {
       <MapScreen navigation={mockNavigation as never} route={mockRoute} />
     );
     expect(getByTestId('fab-button')).toBeTruthy();
+  });
+
+  describe('FAB press with authentication', () => {
+    it('navigates to Record when authenticated', () => {
+      mockUseAuthReturn = {
+        ...mockUseAuthReturn,
+        isAuthenticated: true,
+        user: { id: 'user-123' } as never,
+      };
+
+      const { getByTestId } = render(
+        <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+
+      fireEvent.press(getByTestId('fab-button'));
+      expect(mockParentNavigate).toHaveBeenCalledWith('Record');
+    });
+
+    it('shows LoginPromptModal when not authenticated', () => {
+      const { getByTestId, getByText } = render(
+        <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+
+      fireEvent.press(getByTestId('fab-button'));
+      expect(getByText('ログインが必要です')).toBeTruthy();
+    });
+
+    it('navigates to Record after successful login from modal', async () => {
+      mockUseAuthReturn.signInWithGoogle.mockResolvedValue({ success: true });
+
+      const { getByTestId } = render(
+        <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+
+      // Show modal
+      fireEvent.press(getByTestId('fab-button'));
+
+      // Press login in modal
+      fireEvent.press(getByTestId('modal-google-login-button'));
+
+      await waitFor(() => {
+        expect(mockParentNavigate).toHaveBeenCalledWith('Record');
+      });
+    });
+
+    it('closes modal when later button is pressed', () => {
+      const { getByTestId, queryByText } = render(
+        <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+
+      // Show modal
+      fireEvent.press(getByTestId('fab-button'));
+      expect(queryByText('ログインが必要です')).toBeTruthy();
+
+      // Close modal
+      fireEvent.press(getByTestId('modal-later-button'));
+      expect(queryByText('ログインが必要です')).toBeNull();
+    });
   });
 });

--- a/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/src/screens/__tests__/SettingsScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
 
 import { SettingsScreen } from '../SettingsScreen';
 import type { MainTabScreenProps } from '@/navigation/types';
@@ -14,6 +15,25 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
+const mockSignOut = jest.fn();
+const mockSignInWithGoogle = jest.fn();
+
+let mockUseAuthReturn: Record<string, unknown> = {
+  user: null,
+  session: null,
+  isLoading: false,
+  isAuthenticated: false,
+  isSigningIn: false,
+  signInWithGoogle: mockSignInWithGoogle,
+  signOut: mockSignOut,
+};
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => mockUseAuthReturn,
+}));
+
+jest.spyOn(Alert, 'alert');
+
 const mockNavigation = {
   navigate: jest.fn(),
   goBack: jest.fn(),
@@ -27,6 +47,19 @@ const mockRoute = {
 } as unknown as MainTabScreenProps<'Settings'>['route'];
 
 describe('SettingsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuthReturn = {
+      user: null,
+      session: null,
+      isLoading: false,
+      isAuthenticated: false,
+      isSigningIn: false,
+      signInWithGoogle: mockSignInWithGoogle,
+      signOut: mockSignOut,
+    };
+  });
+
   it('renders the header', () => {
     const { getByText } = render(<SettingsScreen navigation={mockNavigation} route={mockRoute} />);
     expect(getByText('設定')).toBeTruthy();
@@ -35,9 +68,94 @@ describe('SettingsScreen', () => {
   it('renders account section', () => {
     const { getByText } = render(<SettingsScreen navigation={mockNavigation} route={mockRoute} />);
     expect(getByText('アカウント')).toBeTruthy();
-    expect(getByText('ゲスト')).toBeTruthy();
-    expect(getByText('未設定')).toBeTruthy();
-    expect(getByText('ログアウト')).toBeTruthy();
+  });
+
+  describe('when not authenticated', () => {
+    it('shows guest name and email', () => {
+      const { getByText } = render(
+        <SettingsScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      expect(getByText('ゲスト')).toBeTruthy();
+      expect(getByText('未設定')).toBeTruthy();
+    });
+
+    it('shows login button instead of logout', () => {
+      const { getByText, queryByText } = render(
+        <SettingsScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      expect(getByText('ログイン')).toBeTruthy();
+      expect(queryByText('ログアウト')).toBeNull();
+    });
+
+    it('navigates to Login screen when login button is pressed', () => {
+      const parentNavigate = jest.fn();
+      const nav = {
+        ...mockNavigation,
+        getParent: jest.fn(() => ({ navigate: parentNavigate })),
+      } as unknown as MainTabScreenProps<'Settings'>['navigation'];
+
+      const { getByText } = render(<SettingsScreen navigation={nav} route={mockRoute} />);
+      fireEvent.press(getByText('ログイン'));
+      expect(parentNavigate).toHaveBeenCalledWith('Login');
+    });
+  });
+
+  describe('when authenticated', () => {
+    beforeEach(() => {
+      mockUseAuthReturn = {
+        ...mockUseAuthReturn,
+        isAuthenticated: true,
+        user: {
+          id: 'user-123',
+          email: 'test@example.com',
+          user_metadata: { full_name: 'テストユーザー' },
+        },
+      };
+    });
+
+    it('shows user name and email', () => {
+      const { getByText } = render(
+        <SettingsScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      expect(getByText('テストユーザー')).toBeTruthy();
+      expect(getByText('test@example.com')).toBeTruthy();
+    });
+
+    it('shows logout button', () => {
+      const { getByText } = render(
+        <SettingsScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      expect(getByText('ログアウト')).toBeTruthy();
+    });
+
+    it('calls signOut when logout button is pressed', async () => {
+      mockSignOut.mockResolvedValue({ success: true });
+
+      const { getByText } = render(
+        <SettingsScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      fireEvent.press(getByText('ログアウト'));
+
+      await waitFor(() => {
+        expect(mockSignOut).toHaveBeenCalled();
+      });
+    });
+
+    it('shows Alert when signOut fails', async () => {
+      mockSignOut.mockResolvedValue({
+        success: false,
+        error: { code: 'SIGN_OUT_ERROR', message: 'Failed' },
+      });
+
+      const { getByText } = render(
+        <SettingsScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      fireEvent.press(getByText('ログアウト'));
+
+      await waitFor(() => {
+        expect(Alert.alert).toHaveBeenCalledWith('エラー', 'Failed');
+      });
+    });
   });
 
   it('renders plan section', () => {

--- a/src/services/__tests__/auth.test.ts
+++ b/src/services/__tests__/auth.test.ts
@@ -1,0 +1,149 @@
+import { configureGoogleSignIn, signInWithGoogle, signOut } from '../auth';
+
+// Get references to the mocked module (set up in jest.setup.js)
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+const {
+  GoogleSignin,
+  statusCodes,
+  isErrorWithCode,
+} = require('@react-native-google-signin/google-signin');
+/* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+
+const mockSignInWithIdToken = jest.fn();
+const mockSignOut = jest.fn();
+
+jest.mock('@services/supabase', () => ({
+  supabase: {
+    auth: {
+      signInWithIdToken: (...args: unknown[]) => mockSignInWithIdToken(...args),
+      signOut: (...args: unknown[]) => mockSignOut(...args),
+    },
+  },
+}));
+
+describe('auth service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('configureGoogleSignIn', () => {
+    it('calls GoogleSignin.configure with webClientId', () => {
+      process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID = 'test-web-client-id';
+      process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID = 'test-ios-client-id';
+
+      configureGoogleSignIn();
+
+      expect(GoogleSignin.configure).toHaveBeenCalledWith({
+        webClientId: 'test-web-client-id',
+        iosClientId: 'test-ios-client-id',
+      });
+    });
+  });
+
+  describe('signInWithGoogle', () => {
+    it('returns success with user and session on successful sign-in', async () => {
+      const mockUser = { id: 'user-123', email: 'test@example.com' };
+      const mockSession = { access_token: 'token' };
+
+      (GoogleSignin.signIn as jest.Mock).mockResolvedValue({
+        data: { idToken: 'google-id-token', user: { email: 'test@example.com' } },
+      });
+      mockSignInWithIdToken.mockResolvedValue({
+        data: { user: mockUser, session: mockSession },
+        error: null,
+      });
+
+      const result = await signInWithGoogle();
+
+      expect(result).toEqual({
+        success: true,
+        user: mockUser,
+        session: mockSession,
+      });
+      expect(mockSignInWithIdToken).toHaveBeenCalledWith({
+        provider: 'google',
+        token: 'google-id-token',
+      });
+    });
+
+    it('returns CANCELLED error when user cancels sign-in', async () => {
+      const cancelError = { code: statusCodes.SIGN_IN_CANCELLED };
+      (GoogleSignin.signIn as jest.Mock).mockRejectedValue(cancelError);
+      (isErrorWithCode as jest.Mock).mockReturnValue(true);
+
+      const result = await signInWithGoogle();
+
+      expect(result).toEqual({
+        success: false,
+        error: { code: 'CANCELLED', message: 'ログインがキャンセルされました' },
+      });
+    });
+
+    it('returns NO_ID_TOKEN error when idToken is missing', async () => {
+      (GoogleSignin.signIn as jest.Mock).mockResolvedValue({
+        data: { idToken: null, user: { email: 'test@example.com' } },
+      });
+
+      const result = await signInWithGoogle();
+
+      expect(result).toEqual({
+        success: false,
+        error: { code: 'NO_ID_TOKEN', message: 'Google認証トークンの取得に失敗しました' },
+      });
+    });
+
+    it('returns SUPABASE_ERROR when Supabase auth fails', async () => {
+      (GoogleSignin.signIn as jest.Mock).mockResolvedValue({
+        data: { idToken: 'google-id-token', user: { email: 'test@example.com' } },
+      });
+      mockSignInWithIdToken.mockResolvedValue({
+        data: { user: null, session: null },
+        error: { message: 'Invalid token' },
+      });
+
+      const result = await signInWithGoogle();
+
+      expect(result).toEqual({
+        success: false,
+        error: { code: 'SUPABASE_ERROR', message: 'Invalid token' },
+      });
+    });
+
+    it('returns UNKNOWN_ERROR for unexpected errors', async () => {
+      const unknownError = new Error('Something went wrong');
+      (GoogleSignin.signIn as jest.Mock).mockRejectedValue(unknownError);
+      (isErrorWithCode as jest.Mock).mockReturnValue(false);
+
+      const result = await signInWithGoogle();
+
+      expect(result).toEqual({
+        success: false,
+        error: { code: 'UNKNOWN_ERROR', message: 'Something went wrong' },
+      });
+    });
+  });
+
+  describe('signOut', () => {
+    it('returns success when sign-out succeeds', async () => {
+      mockSignOut.mockResolvedValue({ error: null });
+      (GoogleSignin.signOut as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await signOut();
+
+      expect(result).toEqual({ success: true });
+      expect(mockSignOut).toHaveBeenCalled();
+      expect(GoogleSignin.signOut).toHaveBeenCalled();
+    });
+
+    it('returns error when Supabase sign-out fails', async () => {
+      mockSignOut.mockResolvedValue({ error: { message: 'Sign out failed' } });
+
+      const result = await signOut();
+
+      expect(result).toEqual({
+        success: false,
+        error: { code: 'SIGN_OUT_ERROR', message: 'Sign out failed' },
+      });
+    });
+  });
+});

--- a/src/services/__tests__/supabase.test.ts
+++ b/src/services/__tests__/supabase.test.ts
@@ -11,6 +11,13 @@ jest.mock('@supabase/supabase-js', () => ({
 
 jest.mock('react-native-url-polyfill/auto', () => {});
 
+const mockAsyncStorage = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+};
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
+
 describe('Supabase client', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -31,7 +38,7 @@ describe('Supabase client', () => {
       'test-anon-key',
       expect.objectContaining({
         auth: expect.objectContaining({
-          storage: globalThis.localStorage,
+          storage: mockAsyncStorage,
           autoRefreshToken: true,
           persistSession: true,
           detectSessionInUrl: false,

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,120 @@
+import type { Session, User } from '@supabase/supabase-js';
+import { supabase } from '@services/supabase';
+
+const env = process.env;
+
+// Lazy-load Google Sign-In to avoid crash on Expo Go
+// (native module not available without development build)
+function getGoogleSignIn() {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('@react-native-google-signin/google-signin');
+}
+
+type AuthSuccess = {
+  success: true;
+  user: User;
+  session: Session;
+};
+
+type AuthError = {
+  success: false;
+  error: {
+    code: 'CANCELLED' | 'NO_ID_TOKEN' | 'SUPABASE_ERROR' | 'UNKNOWN_ERROR' | 'SIGN_OUT_ERROR';
+    message: string;
+  };
+};
+
+export type AuthResult = AuthSuccess | AuthError;
+
+export type SignOutResult =
+  | { success: true }
+  | { success: false; error: { code: 'SIGN_OUT_ERROR'; message: string } };
+
+export function configureGoogleSignIn(): void {
+  try {
+    const { GoogleSignin } = getGoogleSignIn();
+    GoogleSignin.configure({
+      webClientId: env['EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID'],
+      iosClientId: env['EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID'],
+    });
+  } catch {
+    // Native module not available (e.g. Expo Go) — skip configuration
+  }
+}
+
+export async function signInWithGoogle(): Promise<AuthResult> {
+  try {
+    const { GoogleSignin } = getGoogleSignIn();
+
+    const response = await GoogleSignin.signIn();
+    const idToken = response.data?.idToken;
+
+    if (!idToken) {
+      return {
+        success: false,
+        error: { code: 'NO_ID_TOKEN', message: 'Google認証トークンの取得に失敗しました' },
+      };
+    }
+
+    const { data, error } = await supabase.auth.signInWithIdToken({
+      provider: 'google',
+      token: idToken,
+    });
+
+    if (error) {
+      return {
+        success: false,
+        error: { code: 'SUPABASE_ERROR', message: error.message },
+      };
+    }
+
+    return {
+      success: true,
+      user: data.user!,
+      session: data.session!,
+    };
+  } catch (error: unknown) {
+    try {
+      const { statusCodes, isErrorWithCode } = getGoogleSignIn();
+      if (
+        isErrorWithCode(error) &&
+        (error as { code: string }).code === statusCodes.SIGN_IN_CANCELLED
+      ) {
+        return {
+          success: false,
+          error: { code: 'CANCELLED', message: 'ログインがキャンセルされました' },
+        };
+      }
+    } catch {
+      // Native module not available
+    }
+
+    return {
+      success: false,
+      error: {
+        code: 'UNKNOWN_ERROR',
+        message: error instanceof Error ? error.message : '予期しないエラーが発生しました',
+      },
+    };
+  }
+}
+
+export async function signOut(): Promise<SignOutResult> {
+  const { error } = await supabase.auth.signOut();
+
+  if (error) {
+    return {
+      success: false,
+      error: { code: 'SIGN_OUT_ERROR', message: error.message },
+    };
+  }
+
+  try {
+    const { GoogleSignin } = getGoogleSignIn();
+    await GoogleSignin.signOut();
+  } catch {
+    // Google signOut failure is non-critical
+  }
+
+  return { success: true };
+}

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -1,5 +1,6 @@
 import 'react-native-url-polyfill/auto';
 
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createClient } from '@supabase/supabase-js';
 
 // babel-preset-expo は process.env.EXPO_PUBLIC_* をビルド時にインライン化する。
@@ -18,7 +19,7 @@ if (!supabaseAnonKey) {
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
-    storage: globalThis.localStorage,
+    storage: AsyncStorage,
     autoRefreshToken: true,
     persistSession: true,
     detectSessionInUrl: false,


### PR DESCRIPTION
## Summary
- Google OAuth 認証フロー（`@react-native-google-signin/google-signin` + Supabase `signInWithIdToken`）を実装
- 遅延ログイン方式：未認証でも地図閲覧可能、FAB 押下時にログイン促進モーダル表示
- 設定画面に認証情報表示・ログイン/ログアウト切り替えを追加
- Supabase セッション永続化を `AsyncStorage` に変更
- ネイティブモジュールの遅延読み込みにより Expo Go でもクラッシュせず UI 確認可能

## Changes
| 操作 | ファイル |
|------|----------|
| 修正 | `app.json` — plugins に google-signin 追加 |
| 修正 | `jest.setup.js` — google-signin モック追加 |
| 修正 | `src/services/supabase.ts` — AsyncStorage 対応 |
| 新規 | `src/services/auth.ts` — 認証サービス |
| 修正 | `src/hooks/useAuth.ts` — signInWithGoogle, signOut, isSigningIn 追加 |
| 修正 | `src/navigation/RootNavigator.tsx` — configureGoogleSignIn 呼び出し |
| 修正 | `src/screens/LoginScreen.tsx` — OAuth ログインフロー接続 |
| 新規 | `src/components/common/LoginPromptModal.tsx` — ログイン促進モーダル |
| 修正 | `src/screens/MapScreen.tsx` — FAB 認証チェック |
| 修正 | `src/screens/SettingsScreen.tsx` — 認証情報表示・ログイン/ログアウト |

## Test plan
- [x] `npm test` — 21 suites, 196 tests 全通過
- [x] `npm run lint` — エラー 0
- [x] `npm run typecheck` — エラーなし
- [x] Expo Go で UI 確認（FAB → モーダル表示、設定画面のログインボタン）

🤖 Generated with [Claude Code](https://claude.com/claude-code)