### PR TITLE
feat(spot-detail): スポット詳細画面の拡張 (#13)

### DIFF
--- a/src/hooks/__tests__/useSpotStamps.test.ts
+++ b/src/hooks/__tests__/useSpotStamps.test.ts
@@ -1,0 +1,101 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useSpotStamps } from '@hooks/useSpotStamps';
+import type { Stamp } from '@/types/supabase';
+
+const mockFetchStampsBySpotId = jest.fn();
+
+jest.mock('@services/stamps', () => ({
+  fetchStampsBySpotId: (...args: unknown[]) => mockFetchStampsBySpotId(...args),
+}));
+
+let mockIsAuthenticated = false;
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => ({
+    isAuthenticated: mockIsAuthenticated,
+  }),
+}));
+
+const makeStamp = (overrides: Partial<Stamp> = {}): Stamp => ({
+  id: 'stamp-1',
+  user_id: 'user-1',
+  spot_id: 'spot-1',
+  goshuincho_id: null,
+  visited_at: '2024-06-01',
+  image_path: 'img/1.jpg',
+  memo: null,
+  created_at: '2024-06-01',
+  updated_at: '2024-06-01',
+  ...overrides,
+});
+
+describe('useSpotStamps', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsAuthenticated = false;
+  });
+
+  it('returns empty result when not authenticated', async () => {
+    mockIsAuthenticated = false;
+    const { result } = renderHook(() => useSpotStamps('spot-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.stamps).toEqual([]);
+    expect(result.current.visitCount).toBe(0);
+    expect(result.current.latestVisitDate).toBeNull();
+    expect(mockFetchStampsBySpotId).not.toHaveBeenCalled();
+  });
+
+  it('fetches stamps when authenticated', async () => {
+    mockIsAuthenticated = true;
+    const stamps = [
+      makeStamp({ id: 'stamp-1', visited_at: '2024-06-01' }),
+      makeStamp({ id: 'stamp-2', visited_at: '2024-01-15' }),
+    ];
+    mockFetchStampsBySpotId.mockResolvedValue(stamps);
+
+    const { result } = renderHook(() => useSpotStamps('spot-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockFetchStampsBySpotId).toHaveBeenCalledWith('spot-1');
+    expect(result.current.stamps).toEqual(stamps);
+    expect(result.current.visitCount).toBe(2);
+    expect(result.current.latestVisitDate).toBe('2024-06-01');
+  });
+
+  it('returns empty result when authenticated but no stamps', async () => {
+    mockIsAuthenticated = true;
+    mockFetchStampsBySpotId.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useSpotStamps('spot-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.stamps).toEqual([]);
+    expect(result.current.visitCount).toBe(0);
+    expect(result.current.latestVisitDate).toBeNull();
+  });
+
+  it('returns empty result on fetch error', async () => {
+    mockIsAuthenticated = true;
+    mockFetchStampsBySpotId.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useSpotStamps('spot-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.stamps).toEqual([]);
+    expect(result.current.visitCount).toBe(0);
+    expect(result.current.latestVisitDate).toBeNull();
+  });
+});

--- a/src/hooks/useSpotStamps.ts
+++ b/src/hooks/useSpotStamps.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '@hooks/useAuth';
+import { fetchStampsBySpotId } from '@services/stamps';
+import type { Stamp } from '@/types/supabase';
+
+interface UseSpotStampsReturn {
+  stamps: Stamp[];
+  visitCount: number;
+  latestVisitDate: string | null;
+  isLoading: boolean;
+}
+
+export function useSpotStamps(spotId: string): UseSpotStampsReturn {
+  const { isAuthenticated } = useAuth();
+  const [stamps, setStamps] = useState<Stamp[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setStamps([]);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const data = await fetchStampsBySpotId(spotId);
+        if (!cancelled) setStamps(data);
+      } catch {
+        if (!cancelled) setStamps([]);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, spotId]);
+
+  return {
+    stamps,
+    visitCount: stamps.length,
+    latestVisitDate: stamps[0]?.visited_at ?? null,
+    isLoading,
+  };
+}

--- a/src/navigation/__tests__/RootNavigator.test.tsx
+++ b/src/navigation/__tests__/RootNavigator.test.tsx
@@ -80,6 +80,19 @@ jest.mock('@hooks/useSpotDetail', () => ({
   }),
 }));
 
+jest.mock('@hooks/useSpotStamps', () => ({
+  useSpotStamps: () => ({
+    stamps: [],
+    visitCount: 0,
+    latestVisitDate: null,
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@services/stamps', () => ({
+  getStampImageUrl: (path: string) => `https://example.com/stamps/${path}`,
+}));
+
 function renderWithNavigation() {
   return render(
     <NavigationContainer>

--- a/src/navigation/__tests__/TabNavigator.test.tsx
+++ b/src/navigation/__tests__/TabNavigator.test.tsx
@@ -73,6 +73,19 @@ jest.mock('@hooks/useSpotDetail', () => ({
   }),
 }));
 
+jest.mock('@hooks/useSpotStamps', () => ({
+  useSpotStamps: () => ({
+    stamps: [],
+    visitCount: 0,
+    latestVisitDate: null,
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@services/stamps', () => ({
+  getStampImageUrl: (path: string) => `https://example.com/stamps/${path}`,
+}));
+
 // Wrap TabNavigator in a RootStack to support Login navigation
 const Stack = createNativeStackNavigator<RootStackParamList>();
 

--- a/src/services/__tests__/stamps.test.ts
+++ b/src/services/__tests__/stamps.test.ts
@@ -1,11 +1,19 @@
-import { fetchVisitedSpotIds } from '@services/stamps';
+import { fetchVisitedSpotIds, fetchStampsBySpotId, getStampImageUrl } from '@services/stamps';
 
 const mockSelect = jest.fn();
+const mockEq = jest.fn();
+const mockOrder = jest.fn();
 const mockFrom = jest.fn();
+const mockGetPublicUrl = jest.fn();
 
 jest.mock('@services/supabase', () => ({
   supabase: {
     from: (...args: unknown[]) => mockFrom(...args),
+    storage: {
+      from: () => ({
+        getPublicUrl: (...args: unknown[]) => mockGetPublicUrl(...args),
+      }),
+    },
   },
 }));
 
@@ -38,6 +46,48 @@ describe('stamps service', () => {
       const result = await fetchVisitedSpotIds();
       expect(result).toBeInstanceOf(Set);
       expect(result.size).toBe(0);
+    });
+  });
+
+  describe('fetchStampsBySpotId', () => {
+    it('returns stamps array for a given spot', async () => {
+      const mockStamps = [
+        { id: 'stamp-1', spot_id: 'spot-1', visited_at: '2024-06-01', image_path: 'img/1.jpg' },
+        { id: 'stamp-2', spot_id: 'spot-1', visited_at: '2024-01-15', image_path: 'img/2.jpg' },
+      ];
+      mockFrom.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValue({ order: mockOrder });
+      mockOrder.mockReturnValue({ data: mockStamps, error: null });
+
+      const result = await fetchStampsBySpotId('spot-1');
+      expect(mockFrom).toHaveBeenCalledWith('stamps');
+      expect(mockSelect).toHaveBeenCalledWith('*');
+      expect(mockEq).toHaveBeenCalledWith('spot_id', 'spot-1');
+      expect(mockOrder).toHaveBeenCalledWith('visited_at', { ascending: false });
+      expect(result).toEqual(mockStamps);
+    });
+
+    it('returns empty array on error', async () => {
+      mockFrom.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValue({ order: mockOrder });
+      mockOrder.mockReturnValue({ data: null, error: { message: 'error' } });
+
+      const result = await fetchStampsBySpotId('spot-1');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getStampImageUrl', () => {
+    it('returns public URL for stamp image', () => {
+      mockGetPublicUrl.mockReturnValue({
+        data: { publicUrl: 'https://example.com/stamps/img/1.jpg' },
+      });
+
+      const result = getStampImageUrl('img/1.jpg');
+      expect(mockGetPublicUrl).toHaveBeenCalledWith('img/1.jpg');
+      expect(result).toBe('https://example.com/stamps/img/1.jpg');
     });
   });
 });

--- a/src/services/stamps.ts
+++ b/src/services/stamps.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@services/supabase';
+import type { Stamp } from '@/types/supabase';
 
 export async function fetchVisitedSpotIds(): Promise<Set<string>> {
   const { data, error } = await supabase.from('stamps').select('spot_id');
@@ -9,4 +10,24 @@ export async function fetchVisitedSpotIds(): Promise<Set<string>> {
   }
 
   return new Set((data as { spot_id: string }[]).map(row => row.spot_id));
+}
+
+export async function fetchStampsBySpotId(spotId: string): Promise<Stamp[]> {
+  const { data, error } = await supabase
+    .from('stamps')
+    .select('*')
+    .eq('spot_id', spotId)
+    .order('visited_at', { ascending: false });
+
+  if (error) {
+    console.warn('fetchStampsBySpotId error:', error.message);
+    return [];
+  }
+
+  return data as Stamp[];
+}
+
+export function getStampImageUrl(imagePath: string): string {
+  const { data } = supabase.storage.from('stamps').getPublicUrl(imagePath);
+  return data.publicUrl;
 }


### PR DESCRIPTION
## Summary
- スポット詳細画面に訪問履歴（訪問回数・最終訪問日）、記録済み御朱印の3列グリッド、ミニマップ（MapView）を追加
- `fetchStampsBySpotId` / `getStampImageUrl` をサービス層に追加、`useSpotStamps` フックを新規作成
- 画面を ScrollView 化し、ログイン状態に応じて訪問済みバッジを表示

## Test plan
- [x] 全30テストスイート / 268テスト通過
- [x] ESLint エラーなし
- [x] TypeScript 型チェック通過
- [ ] 未ログイン状態でスポット詳細画面を確認（訪問情報・グリッド非表示）
- [ ] ログイン済み・訪問済みスポットで訪問済みバッジ・訪問回数・御朱印グリッドが表示される
- [ ] ミニマップが正しい位置にマーカー付きで表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)