### PR TITLE
feat(map): スポットマーカーにラベル表示とズーム制御を追加

### DIFF
--- a/src/components/__tests__/common.test.tsx
+++ b/src/components/__tests__/common.test.tsx
@@ -10,6 +10,7 @@ import { TextInput } from '@components/common/TextInput';
 import { Header } from '@components/common/Header';
 import { Modal } from '@components/common/Modal';
 import { MapPin } from '@components/common/MapPin';
+import { SpotMarker } from '@components/common/SpotMarker';
 import { Text } from 'react-native';
 
 describe('Common Components', () => {
@@ -273,30 +274,61 @@ describe('Common Components', () => {
   });
 
   describe('MapPin', () => {
-    it('renders shrine-visited pin', () => {
-      const { getByTestId } = render(<MapPin type="shrine-visited" />);
-      expect(getByTestId('map-pin-shrine-visited')).toBeTruthy();
-    });
-
-    it('renders temple-visited pin', () => {
-      const { getByTestId } = render(<MapPin type="temple-visited" />);
-      expect(getByTestId('map-pin-temple-visited')).toBeTruthy();
-    });
-
-    it('renders unvisited pin', () => {
-      const { getByTestId } = render(<MapPin type="unvisited" />);
-      expect(getByTestId('map-pin-unvisited')).toBeTruthy();
-    });
-
     it('renders current-location pin with pulse', () => {
       const { getByTestId } = render(<MapPin type="current-location" />);
       expect(getByTestId('map-pin-current-location')).toBeTruthy();
       expect(getByTestId('map-pin-pulse')).toBeTruthy();
     });
+  });
 
-    it('does not render pulse for non-current-location pins', () => {
-      const { queryByTestId } = render(<MapPin type="shrine-visited" />);
-      expect(queryByTestId('map-pin-pulse')).toBeNull();
+  describe('SpotMarker', () => {
+    it('renders pin head and tail', () => {
+      const { getByTestId } = render(
+        <SpotMarker color="#EF4444" name="Test Shrine" showLabel={false} />
+      );
+      expect(getByTestId('spot-marker-pin-head')).toBeTruthy();
+      expect(getByTestId('spot-marker-pin-tail')).toBeTruthy();
+    });
+
+    it('shows label when showLabel is true', () => {
+      const { getByTestId, getByText } = render(
+        <SpotMarker color="#EF4444" name="Test Shrine" showLabel />
+      );
+      expect(getByTestId('spot-marker-label')).toBeTruthy();
+      expect(getByText('Test Shrine')).toBeTruthy();
+    });
+
+    it('hides label when showLabel is false', () => {
+      const { queryByTestId } = render(
+        <SpotMarker color="#EF4444" name="Test Shrine" showLabel={false} />
+      );
+      expect(queryByTestId('spot-marker-label')).toBeNull();
+    });
+
+    it('applies the correct color to pin head', () => {
+      const { getByTestId } = render(
+        <SpotMarker color="#A855F7" name="Test Temple" showLabel={false} />
+      );
+      const pinHead = getByTestId('spot-marker-pin-head');
+      const flatStyle = Object.assign({}, ...[].concat(pinHead.props.style));
+      expect(flatStyle).toEqual(expect.objectContaining({ backgroundColor: '#A855F7' }));
+    });
+
+    it('applies the correct color to pin tail', () => {
+      const { getByTestId } = render(
+        <SpotMarker color="#A855F7" name="Test Temple" showLabel={false} />
+      );
+      const pinTail = getByTestId('spot-marker-pin-tail');
+      const flatStyle = Object.assign({}, ...[].concat(pinTail.props.style));
+      expect(flatStyle).toEqual(expect.objectContaining({ borderTopColor: '#A855F7' }));
+    });
+
+    it('truncates long label text with numberOfLines=1', () => {
+      const { getByTestId } = render(
+        <SpotMarker color="#EF4444" name="非常に長いスポット名のテスト" showLabel />
+      );
+      const label = getByTestId('spot-marker-label');
+      expect(label.props.numberOfLines).toBe(1);
     });
   });
 });

--- a/src/components/common/MapPin.tsx
+++ b/src/components/common/MapPin.tsx
@@ -2,27 +2,18 @@ import React, { useEffect, useRef } from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
 import { colors } from '@theme/colors';
 
-type PinType = 'shrine-visited' | 'temple-visited' | 'unvisited' | 'current-location';
-
 interface MapPinProps {
-  type: PinType;
+  type: 'current-location';
 }
 
-const PIN_CONFIG: Record<PinType, { color: string; size: number }> = {
-  'shrine-visited': { color: colors.pin.shrineVisited, size: 16 },
-  'temple-visited': { color: colors.pin.templeVisited, size: 16 },
-  unvisited: { color: colors.pin.unvisited, size: 12 },
-  'current-location': { color: colors.pin.currentLocation, size: 20 },
-};
+const PIN_CONFIG = { color: colors.pin.currentLocation, size: 20 };
 
 export function MapPin({ type }: MapPinProps) {
   const pulseAnim = useRef(new Animated.Value(1)).current;
   const opacityAnim = useRef(new Animated.Value(0.6)).current;
-  const config = PIN_CONFIG[type];
+  const config = PIN_CONFIG;
 
   useEffect(() => {
-    if (type !== 'current-location') return;
-
     const animation = Animated.loop(
       Animated.parallel([
         Animated.sequence([
@@ -58,22 +49,20 @@ export function MapPin({ type }: MapPinProps) {
 
   return (
     <View style={styles.wrapper} testID={`map-pin-${type}`}>
-      {type === 'current-location' && (
-        <Animated.View
-          testID="map-pin-pulse"
-          style={[
-            styles.pulse,
-            {
-              width: config.size * 2,
-              height: config.size * 2,
-              borderRadius: config.size,
-              backgroundColor: config.color,
-              transform: [{ scale: pulseAnim }],
-              opacity: opacityAnim,
-            },
-          ]}
-        />
-      )}
+      <Animated.View
+        testID="map-pin-pulse"
+        style={[
+          styles.pulse,
+          {
+            width: config.size * 2,
+            height: config.size * 2,
+            borderRadius: config.size,
+            backgroundColor: config.color,
+            transform: [{ scale: pulseAnim }],
+            opacity: opacityAnim,
+          },
+        ]}
+      />
       <View
         style={[
           styles.pin,

--- a/src/components/common/SpotMarker.tsx
+++ b/src/components/common/SpotMarker.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+import { shadows } from '@theme/shadows';
+
+interface SpotMarkerProps {
+  color: string;
+  name: string;
+  showLabel: boolean;
+}
+
+export const SpotMarker = React.memo(function SpotMarker({
+  color,
+  name,
+  showLabel,
+}: SpotMarkerProps) {
+  return (
+    <View style={styles.wrapper}>
+      {showLabel && (
+        <Text style={styles.label} numberOfLines={1} testID="spot-marker-label">
+          {name}
+        </Text>
+      )}
+      <View style={[styles.pinHead, { backgroundColor: color }]} testID="spot-marker-pin-head" />
+      <View style={[styles.pinTail, { borderTopColor: color }]} testID="spot-marker-pin-tail" />
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  wrapper: {
+    alignItems: 'center',
+  },
+  label: {
+    ...typography.caption,
+    color: colors.gray[800],
+    backgroundColor: colors.white,
+    paddingHorizontal: spacing.xs,
+    borderRadius: borderRadius.sm,
+    maxWidth: 80,
+    marginBottom: 2,
+    textAlign: 'center',
+    overflow: 'hidden',
+    ...shadows.sm,
+  },
+  pinHead: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    borderWidth: 2.5,
+    borderColor: colors.white,
+    ...shadows.sm,
+  },
+  pinTail: {
+    width: 0,
+    height: 0,
+    borderLeftWidth: 6,
+    borderRightWidth: 6,
+    borderTopWidth: 10,
+    borderLeftColor: 'transparent',
+    borderRightColor: 'transparent',
+    marginTop: -2,
+  },
+});


### PR DESCRIPTION
## Summary
- 地図上のスポットピンをカスタム`SpotMarker`コンポーネント（ドロップ型ピン + ラベル）に置き換え
- ズームレベルに応じてスポット名ラベルの表示/非表示を制御（~8km範囲でラベル表示、それ以上でピンのみ）
- `MapPin`コンポーネントをcurrent-location専用に簡素化

## Test plan
- [x] SpotMarker: ピン形状のレンダリング、ラベル表示/非表示、色の適用、テキストtruncate
- [x] MapScreen: SpotMarker children の存在確認、ズームアウトでラベル非表示、ズームインで再表示
- [x] 全テスト 273件パス、lint・型チェッククリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)