### PR TITLE
feat(record): 御朱印記録画面の実装 (#14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/datetimepicker": "^8.6.0",
         "@react-navigation/bottom-tabs": "^7.12.0",
         "@react-navigation/native": "^7.1.28",
         "@react-navigation/native-stack": "^7.12.0",
@@ -2987,6 +2988,29 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.6.0.tgz",
+      "integrity": "sha512-yxPSqNfxgpGaqHQIpatqe6ykeBdU/1pdsk/G3x01mY2bpTflLpmVTLqFSJYd3MiZzxNZcMs/j1dQakUczSjcYA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/datetimepicker": "^8.6.0",
     "@react-navigation/bottom-tabs": "^7.12.0",
     "@react-navigation/native": "^7.1.28",
     "@react-navigation/native-stack": "^7.12.0",

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Modal as RNModal, Pressable, StyleSheet, Text } from 'react-native';
+import {
+  Modal as RNModal,
+  Pressable,
+  StyleSheet,
+  Text,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing, borderRadius } from '@theme/spacing';
@@ -35,28 +42,36 @@ export function Modal({
       animationType={variant === 'center' ? 'fade' : 'slide'}
       onRequestClose={onClose}
     >
-      <Pressable
-        style={[styles.overlay, variant === 'bottom' && styles.overlayBottom]}
-        onPress={handleBackdropPress}
-        testID="modal-overlay"
+      <KeyboardAvoidingView
+        style={styles.keyboardAvoiding}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       >
         <Pressable
-          style={[styles.content, variant === 'bottom' && styles.contentBottom]}
-          testID="modal-content"
+          style={[styles.overlay, variant === 'bottom' && styles.overlayBottom]}
+          onPress={handleBackdropPress}
+          testID="modal-overlay"
         >
-          {title && (
-            <Text style={styles.title} testID="modal-title">
-              {title}
-            </Text>
-          )}
-          {children}
+          <Pressable
+            style={[styles.content, variant === 'bottom' && styles.contentBottom]}
+            testID="modal-content"
+          >
+            {title && (
+              <Text style={styles.title} testID="modal-title">
+                {title}
+              </Text>
+            )}
+            {children}
+          </Pressable>
         </Pressable>
-      </Pressable>
+      </KeyboardAvoidingView>
     </RNModal>
   );
 }
 
 const styles = StyleSheet.create({
+  keyboardAvoiding: {
+    flex: 1,
+  },
   overlay: {
     flex: 1,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',

--- a/src/components/record/ConfirmModal.tsx
+++ b/src/components/record/ConfirmModal.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Modal } from '@components/common/Modal';
+import { Button } from '@components/common/Button';
+import { Badge } from '@components/common/Badge';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
+
+interface ConfirmModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  spotName: string;
+  spotType: 'shrine' | 'temple';
+  visitedAt: Date;
+  isSubmitting: boolean;
+}
+
+function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}年${m}月${d}日`;
+}
+
+export function ConfirmModal({
+  visible,
+  onClose,
+  onConfirm,
+  spotName,
+  spotType,
+  visitedAt,
+  isSubmitting,
+}: ConfirmModalProps) {
+  return (
+    <Modal visible={visible} onClose={onClose} variant="center" title="登録内容の確認">
+      <View style={styles.row}>
+        <Text style={styles.label}>スポット</Text>
+        <View style={styles.spotRow}>
+          <Text style={styles.value}>{spotName}</Text>
+          <Badge type={spotType} />
+        </View>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>訪問日</Text>
+        <Text style={styles.value}>{formatDate(visitedAt)}</Text>
+      </View>
+      <View style={styles.buttons}>
+        <Button title="戻る" onPress={onClose} variant="outline" style={styles.button} />
+        <Button
+          title={isSubmitting ? '登録中...' : '登録する'}
+          onPress={onConfirm}
+          variant="primary"
+          disabled={isSubmitting}
+          style={styles.button}
+        />
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    marginBottom: spacing.lg,
+  },
+  spotRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  label: {
+    ...typography.label,
+    color: colors.gray[500],
+    marginBottom: spacing.xs,
+  },
+  value: {
+    ...typography.body,
+    color: colors.gray[800],
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.lg,
+  },
+  button: {
+    flex: 1,
+  },
+});

--- a/src/components/record/PhotoPickerModal.tsx
+++ b/src/components/record/PhotoPickerModal.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { Modal } from '@components/common/Modal';
+import * as ImagePicker from 'expo-image-picker';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
+
+interface PhotoPickerModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onImageSelected: (uri: string) => void;
+}
+
+const pickerOptions = {
+  allowsEditing: true,
+  aspect: [3, 4] as [number, number],
+  quality: 0.8,
+};
+
+export function PhotoPickerModal({ visible, onClose, onImageSelected }: PhotoPickerModalProps) {
+  const handleCamera = async () => {
+    const result = await ImagePicker.launchCameraAsync(pickerOptions);
+    if (!result.canceled) {
+      onImageSelected(result.assets[0].uri);
+    }
+  };
+
+  const handleGallery = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync(pickerOptions);
+    if (!result.canceled) {
+      onImageSelected(result.assets[0].uri);
+    }
+  };
+
+  return (
+    <Modal visible={visible} onClose={onClose} variant="bottom" title="写真を追加">
+      <TouchableOpacity style={styles.option} onPress={handleCamera} activeOpacity={0.7}>
+        <Text style={styles.optionText}>カメラで撮影</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.option} onPress={handleGallery} activeOpacity={0.7}>
+        <Text style={styles.optionText}>ギャラリーから選択</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.cancelOption} onPress={onClose} activeOpacity={0.7}>
+        <Text style={styles.cancelText}>キャンセル</Text>
+      </TouchableOpacity>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  option: {
+    paddingVertical: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray[100],
+  },
+  optionText: {
+    ...typography.body,
+    color: colors.gray[800],
+    textAlign: 'center',
+  },
+  cancelOption: {
+    paddingVertical: spacing.lg,
+    marginTop: spacing.sm,
+  },
+  cancelText: {
+    ...typography.body,
+    color: colors.gray[400],
+    textAlign: 'center',
+  },
+});

--- a/src/components/record/PhotoSection.tsx
+++ b/src/components/record/PhotoSection.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { View, Text, Image, TouchableOpacity, StyleSheet } from 'react-native';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+
+interface PhotoSectionProps {
+  imageUri: string | null;
+  onPress: () => void;
+  error: string | null;
+}
+
+export function PhotoSection({ imageUri, onPress, error }: PhotoSectionProps) {
+  return (
+    <View>
+      <TouchableOpacity
+        style={[styles.container, error && styles.containerError]}
+        onPress={onPress}
+        activeOpacity={0.7}
+        testID="photo-section"
+      >
+        {imageUri ? (
+          <View style={styles.previewContainer}>
+            <Image
+              source={{ uri: imageUri }}
+              style={styles.preview}
+              resizeMode="cover"
+              testID="photo-preview"
+            />
+            <View style={styles.changeButton}>
+              <Text style={styles.changeText}>変更</Text>
+            </View>
+          </View>
+        ) : (
+          <View style={styles.placeholder}>
+            <Text style={styles.cameraIcon}>📷</Text>
+            <Text style={styles.placeholderText}>写真を追加</Text>
+          </View>
+        )}
+      </TouchableOpacity>
+      {error && <Text style={styles.errorText}>{error}</Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 2,
+    borderColor: colors.gray[200],
+    borderStyle: 'dashed',
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+  },
+  containerError: {
+    borderColor: colors.error,
+  },
+  placeholder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing['4xl'],
+  },
+  cameraIcon: {
+    fontSize: 32,
+    marginBottom: spacing.sm,
+  },
+  placeholderText: {
+    ...typography.body,
+    color: colors.gray[400],
+  },
+  previewContainer: {
+    position: 'relative',
+    aspectRatio: 3 / 4,
+  },
+  preview: {
+    width: '100%',
+    height: '100%',
+  },
+  changeButton: {
+    position: 'absolute',
+    top: spacing.sm,
+    right: spacing.sm,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderRadius: borderRadius.sm,
+  },
+  changeText: {
+    ...typography.label,
+    color: colors.white,
+  },
+  errorText: {
+    ...typography.caption,
+    color: colors.error,
+    marginTop: spacing.xs,
+  },
+});

--- a/src/components/record/SpotAddModal.tsx
+++ b/src/components/record/SpotAddModal.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import { View, TextInput, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { Modal } from '@components/common/Modal';
+import { Button } from '@components/common/Button';
+import { createSpot } from '@/services/spots';
+import type { Spot } from '@/types/supabase';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+
+interface SpotAddModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSpotCreated: (spot: Spot) => void;
+  userLocation: { latitude: number; longitude: number } | null;
+  userId: string;
+}
+
+export function SpotAddModal({
+  visible,
+  onClose,
+  onSpotCreated,
+  userLocation,
+  userId,
+}: SpotAddModalProps) {
+  const [name, setName] = useState('');
+  const [type, setType] = useState<'shrine' | 'temple'>('shrine');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleAdd = async () => {
+    if (!name.trim() || !userLocation) return;
+
+    setIsSubmitting(true);
+    setErrorMessage(null);
+    try {
+      const spot = await createSpot({
+        name: name.trim(),
+        type,
+        lat: userLocation.latitude,
+        lng: userLocation.longitude,
+        createdByUserId: userId,
+      });
+      onSpotCreated(spot);
+      setName('');
+      setType('shrine');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'スポットの追加に失敗しました';
+      setErrorMessage(msg);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal visible={visible} onClose={onClose} variant="center" title="スポットを追加">
+      <TextInput
+        style={styles.input}
+        placeholder="スポット名を入力"
+        placeholderTextColor={colors.gray[400]}
+        value={name}
+        onChangeText={setName}
+        testID="spot-name-input"
+      />
+      <View style={styles.typeRow}>
+        <TouchableOpacity
+          style={[styles.typeButton, type === 'shrine' && styles.typeButtonActive]}
+          onPress={() => setType('shrine')}
+          activeOpacity={0.7}
+        >
+          <Text style={[styles.typeText, type === 'shrine' && styles.typeTextActive]}>神社</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.typeButton, type === 'temple' && styles.typeButtonActive]}
+          onPress={() => setType('temple')}
+          activeOpacity={0.7}
+        >
+          <Text style={[styles.typeText, type === 'temple' && styles.typeTextActive]}>寺院</Text>
+        </TouchableOpacity>
+      </View>
+      {errorMessage && <Text style={styles.errorText}>{errorMessage}</Text>}
+      <Button
+        title={isSubmitting ? '追加中...' : '追加'}
+        onPress={handleAdd}
+        variant="primary"
+        disabled={!name.trim() || isSubmitting}
+      />
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  input: {
+    ...typography.body,
+    color: colors.gray[800],
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    borderRadius: borderRadius.lg,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    marginBottom: spacing.lg,
+  },
+  typeRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginBottom: spacing['2xl'],
+  },
+  typeButton: {
+    flex: 1,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    alignItems: 'center',
+  },
+  typeButtonActive: {
+    borderColor: colors.primary[500],
+    backgroundColor: colors.primary[50],
+  },
+  typeText: {
+    ...typography.body,
+    color: colors.gray[600],
+  },
+  typeTextActive: {
+    color: colors.primary[500],
+    fontWeight: '600',
+  },
+  errorText: {
+    ...typography.bodySmall,
+    color: colors.error,
+    marginBottom: spacing.md,
+    textAlign: 'center',
+  },
+});

--- a/src/components/record/SpotSelector.tsx
+++ b/src/components/record/SpotSelector.tsx
@@ -1,0 +1,200 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, FlatList, StyleSheet } from 'react-native';
+import { SearchBar } from '@components/common/SearchBar';
+import { Badge } from '@components/common/Badge';
+import type { Spot } from '@/types/supabase';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+import { shadows } from '@theme/shadows';
+
+export interface SpotWithDistance {
+  spot: Spot;
+  distanceKm: number;
+}
+
+interface SpotSelectorProps {
+  selectedSpot: Spot | null;
+  nearbySpots: SpotWithDistance[];
+  searchQuery: string;
+  onSearchQueryChange: (q: string) => void;
+  onSelectSpot: (spot: Spot) => void;
+  onAddSpotPress: () => void;
+  error: string | null;
+}
+
+export function SpotSelector({
+  selectedSpot,
+  nearbySpots,
+  searchQuery,
+  onSearchQueryChange,
+  onSelectSpot,
+  onAddSpotPress,
+  error,
+}: SpotSelectorProps) {
+  const [showDropdown, setShowDropdown] = useState(false);
+
+  const handleSelectSpot = (spot: Spot) => {
+    onSelectSpot(spot);
+    setShowDropdown(false);
+    onSearchQueryChange('');
+  };
+
+  const handleFocus = () => {
+    setShowDropdown(true);
+  };
+
+  const handleClear = () => {
+    onSearchQueryChange('');
+  };
+
+  return (
+    <View style={styles.wrapper}>
+      {selectedSpot && !showDropdown ? (
+        <TouchableOpacity
+          style={[styles.selectedRow, error && styles.selectedRowError]}
+          onPress={() => setShowDropdown(true)}
+          activeOpacity={0.7}
+          testID="spot-selector-trigger"
+        >
+          <Text style={styles.selectedName}>{selectedSpot.name}</Text>
+          <Badge type={selectedSpot.type} />
+        </TouchableOpacity>
+      ) : (
+        <View testID="spot-selector-trigger">
+          <SearchBar
+            value={searchQuery}
+            onChangeText={onSearchQueryChange}
+            onFocus={handleFocus}
+            placeholder="スポット名で検索"
+            showClearButton={searchQuery.length > 0}
+            onClear={handleClear}
+          />
+        </View>
+      )}
+      {error && !showDropdown && <Text style={styles.errorText}>{error}</Text>}
+
+      {showDropdown && (
+        <View style={styles.dropdown}>
+          <FlatList
+            data={nearbySpots}
+            keyExtractor={item => item.spot.id}
+            keyboardShouldPersistTaps="handled"
+            style={styles.list}
+            renderItem={({ item }) => (
+              <TouchableOpacity
+                style={styles.spotRow}
+                onPress={() => handleSelectSpot(item.spot)}
+                activeOpacity={0.7}
+              >
+                <View style={styles.spotInfo}>
+                  <Text style={styles.spotName} numberOfLines={1}>
+                    {item.spot.name}
+                  </Text>
+                  <Badge type={item.spot.type} />
+                </View>
+                <Text style={styles.distance}>{item.distanceKm.toFixed(1)}km</Text>
+              </TouchableOpacity>
+            )}
+            ListEmptyComponent={
+              <View style={styles.emptyContainer}>
+                <Text style={styles.emptyText}>候補が見つかりません</Text>
+              </View>
+            }
+          />
+          <TouchableOpacity
+            style={styles.addLink}
+            onPress={() => {
+              setShowDropdown(false);
+              onAddSpotPress();
+            }}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.addLinkText}>スポットが見つからない場合は追加</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    zIndex: 10,
+  },
+  selectedRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    borderRadius: borderRadius.lg,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    backgroundColor: colors.white,
+  },
+  selectedRowError: {
+    borderColor: colors.error,
+  },
+  selectedName: {
+    ...typography.body,
+    color: colors.gray[800],
+    flex: 1,
+  },
+  errorText: {
+    ...typography.caption,
+    color: colors.error,
+    marginTop: spacing.xs,
+  },
+  dropdown: {
+    marginTop: spacing.xs,
+    backgroundColor: colors.white,
+    borderRadius: borderRadius.lg,
+    ...shadows.md,
+  },
+  list: {
+    maxHeight: 240,
+  },
+  spotRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.gray[200],
+  },
+  spotInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    flex: 1,
+  },
+  spotName: {
+    ...typography.body,
+    color: colors.gray[800],
+  },
+  distance: {
+    ...typography.bodySmall,
+    color: colors.gray[400],
+    marginLeft: spacing.sm,
+  },
+  emptyContainer: {
+    paddingVertical: spacing.xl,
+    alignItems: 'center',
+  },
+  emptyText: {
+    ...typography.bodySmall,
+    color: colors.gray[400],
+  },
+  addLink: {
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.gray[200],
+  },
+  addLinkText: {
+    ...typography.bodySmall,
+    color: colors.primary[500],
+  },
+});

--- a/src/components/record/__tests__/ConfirmModal.test.tsx
+++ b/src/components/record/__tests__/ConfirmModal.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ConfirmModal } from '../ConfirmModal';
+
+describe('ConfirmModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnConfirm = jest.fn();
+  const defaultProps = {
+    visible: true,
+    onClose: mockOnClose,
+    onConfirm: mockOnConfirm,
+    spotName: '仙台東照宮',
+    spotType: 'shrine' as const,
+    visitedAt: new Date(2024, 5, 15), // 2024年6月15日
+    isSubmitting: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('スポット名、種別バッジ、訪問日が表示される', () => {
+    const { getByText, getByTestId } = render(<ConfirmModal {...defaultProps} />);
+
+    expect(getByText('仙台東照宮')).toBeTruthy();
+    expect(getByTestId('badge-shrine')).toBeTruthy();
+    expect(getByText('2024年06月15日')).toBeTruthy();
+  });
+
+  it('「戻る」タップで onClose 呼出', () => {
+    const { getByText } = render(<ConfirmModal {...defaultProps} />);
+
+    fireEvent.press(getByText('戻る'));
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('「登録する」タップで onConfirm 呼出', () => {
+    const { getByText } = render(<ConfirmModal {...defaultProps} />);
+
+    fireEvent.press(getByText('登録する'));
+
+    expect(mockOnConfirm).toHaveBeenCalled();
+  });
+
+  it('isSubmitting=true で「登録中...」表示、ボタン無効', () => {
+    const { getByText } = render(<ConfirmModal {...defaultProps} isSubmitting={true} />);
+
+    expect(getByText('登録中...')).toBeTruthy();
+
+    fireEvent.press(getByText('登録中...'));
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/record/__tests__/PhotoPickerModal.test.tsx
+++ b/src/components/record/__tests__/PhotoPickerModal.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { PhotoPickerModal } from '../PhotoPickerModal';
+import * as ImagePicker from 'expo-image-picker';
+
+jest.mock('expo-image-picker', () => ({
+  launchCameraAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+  MediaTypeOptions: { Images: 'Images' },
+}));
+
+describe('PhotoPickerModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnImageSelected = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('表示時に3つの選択肢が見える', () => {
+    const { getByText } = render(
+      <PhotoPickerModal
+        visible={true}
+        onClose={mockOnClose}
+        onImageSelected={mockOnImageSelected}
+      />
+    );
+
+    expect(getByText('カメラで撮影')).toBeTruthy();
+    expect(getByText('ギャラリーから選択')).toBeTruthy();
+    expect(getByText('キャンセル')).toBeTruthy();
+  });
+
+  it('カメラ撮影タップで launchCameraAsync が呼ばれる', async () => {
+    (ImagePicker.launchCameraAsync as jest.Mock).mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file://camera-photo.jpg' }],
+    });
+
+    const { getByText } = render(
+      <PhotoPickerModal
+        visible={true}
+        onClose={mockOnClose}
+        onImageSelected={mockOnImageSelected}
+      />
+    );
+
+    fireEvent.press(getByText('カメラで撮影'));
+
+    await waitFor(() => {
+      expect(ImagePicker.launchCameraAsync).toHaveBeenCalledWith({
+        allowsEditing: true,
+        aspect: [3, 4],
+        quality: 0.8,
+      });
+      expect(mockOnImageSelected).toHaveBeenCalledWith('file://camera-photo.jpg');
+    });
+  });
+
+  it('ギャラリー選択タップで launchImageLibraryAsync が呼ばれる', async () => {
+    (ImagePicker.launchImageLibraryAsync as jest.Mock).mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file://gallery-photo.jpg' }],
+    });
+
+    const { getByText } = render(
+      <PhotoPickerModal
+        visible={true}
+        onClose={mockOnClose}
+        onImageSelected={mockOnImageSelected}
+      />
+    );
+
+    fireEvent.press(getByText('ギャラリーから選択'));
+
+    await waitFor(() => {
+      expect(ImagePicker.launchImageLibraryAsync).toHaveBeenCalledWith({
+        allowsEditing: true,
+        aspect: [3, 4],
+        quality: 0.8,
+      });
+      expect(mockOnImageSelected).toHaveBeenCalledWith('file://gallery-photo.jpg');
+    });
+  });
+
+  it('キャンセルタップで onClose が呼ばれる', () => {
+    const { getByText } = render(
+      <PhotoPickerModal
+        visible={true}
+        onClose={mockOnClose}
+        onImageSelected={mockOnImageSelected}
+      />
+    );
+
+    fireEvent.press(getByText('キャンセル'));
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/record/__tests__/PhotoSection.test.tsx
+++ b/src/components/record/__tests__/PhotoSection.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { PhotoSection } from '../PhotoSection';
+
+describe('PhotoSection', () => {
+  const mockOnPress = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('未選択時に「写真を追加」テキスト表示', () => {
+    const { getByText } = render(
+      <PhotoSection imageUri={null} onPress={mockOnPress} error={null} />
+    );
+
+    expect(getByText('写真を追加')).toBeTruthy();
+  });
+
+  it('選択済み時に Image コンポーネントと「変更」テキスト表示', () => {
+    const { getByTestId, getByText } = render(
+      <PhotoSection imageUri="file://photo.jpg" onPress={mockOnPress} error={null} />
+    );
+
+    expect(getByTestId('photo-preview')).toBeTruthy();
+    expect(getByText('変更')).toBeTruthy();
+  });
+
+  it('タップで onPress 呼出', () => {
+    const { getByTestId } = render(
+      <PhotoSection imageUri={null} onPress={mockOnPress} error={null} />
+    );
+
+    fireEvent.press(getByTestId('photo-section'));
+
+    expect(mockOnPress).toHaveBeenCalled();
+  });
+
+  it('error 表示', () => {
+    const { getByText } = render(
+      <PhotoSection imageUri={null} onPress={mockOnPress} error="写真を選択してください" />
+    );
+
+    expect(getByText('写真を選択してください')).toBeTruthy();
+  });
+});

--- a/src/components/record/__tests__/SpotAddModal.test.tsx
+++ b/src/components/record/__tests__/SpotAddModal.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { SpotAddModal } from '../SpotAddModal';
+import { createSpot } from '@/services/spots';
+
+jest.mock('@/services/spots', () => ({
+  createSpot: jest.fn(),
+}));
+
+describe('SpotAddModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSpotCreated = jest.fn();
+  const defaultProps = {
+    visible: true,
+    onClose: mockOnClose,
+    onSpotCreated: mockOnSpotCreated,
+    userLocation: { latitude: 38.2682, longitude: 140.8694 },
+    userId: 'user-123',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('表示時にフォーム要素が見える', () => {
+    const { getByPlaceholderText, getByText } = render(<SpotAddModal {...defaultProps} />);
+
+    expect(getByPlaceholderText('スポット名を入力')).toBeTruthy();
+    expect(getByText('神社')).toBeTruthy();
+    expect(getByText('寺院')).toBeTruthy();
+    expect(getByText('追加')).toBeTruthy();
+  });
+
+  it('スポット名未入力時は追加ボタンが無効', () => {
+    const { getByText } = render(<SpotAddModal {...defaultProps} />);
+
+    const addButton = getByText('追加');
+    fireEvent.press(addButton);
+
+    expect(createSpot).not.toHaveBeenCalled();
+  });
+
+  it('種別を切り替えられる', () => {
+    const { getByText } = render(<SpotAddModal {...defaultProps} />);
+
+    const templeButton = getByText('寺院');
+    fireEvent.press(templeButton);
+
+    // 寺院が選択状態（テスト対象はUI反映だがロジック面を確認）
+    expect(templeButton).toBeTruthy();
+  });
+
+  it('追加ボタンタップで createSpot が呼ばれ、成功時 onSpotCreated 呼出', async () => {
+    const mockSpot = {
+      id: 'spot-1',
+      name: 'テスト神社',
+      lat: 38.2682,
+      lng: 140.8694,
+      type: 'shrine' as const,
+      address: null,
+      status: 'pending' as const,
+      created_by_user_id: 'user-123',
+      merged_into_spot_id: null,
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+    };
+    (createSpot as jest.Mock).mockResolvedValue(mockSpot);
+
+    const { getByPlaceholderText, getByText } = render(<SpotAddModal {...defaultProps} />);
+
+    fireEvent.changeText(getByPlaceholderText('スポット名を入力'), 'テスト神社');
+    fireEvent.press(getByText('追加'));
+
+    await waitFor(() => {
+      expect(createSpot).toHaveBeenCalledWith({
+        name: 'テスト神社',
+        type: 'shrine',
+        lat: 38.2682,
+        lng: 140.8694,
+        createdByUserId: 'user-123',
+      });
+      expect(mockOnSpotCreated).toHaveBeenCalledWith(mockSpot);
+    });
+  });
+});

--- a/src/components/record/__tests__/SpotSelector.test.tsx
+++ b/src/components/record/__tests__/SpotSelector.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { SpotSelector } from '../SpotSelector';
+import type { Spot } from '@/types/supabase';
+
+const makeSpot = (overrides: Partial<Spot> = {}): Spot => ({
+  id: 'spot-1',
+  name: '仙台東照宮',
+  lat: 38.2682,
+  lng: 140.8694,
+  type: 'shrine',
+  address: '仙台市青葉区',
+  status: 'active',
+  created_by_user_id: null,
+  merged_into_spot_id: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+  ...overrides,
+});
+
+const nearbySpots = [
+  { spot: makeSpot(), distanceKm: 0.5 },
+  { spot: makeSpot({ id: 'spot-2', name: '大崎八幡宮', type: 'shrine' }), distanceKm: 1.2 },
+  { spot: makeSpot({ id: 'spot-3', name: '瑞鳳殿', type: 'temple' }), distanceKm: 2.0 },
+];
+
+describe('SpotSelector', () => {
+  const mockOnSelectSpot = jest.fn();
+  const mockOnSearchQueryChange = jest.fn();
+  const mockOnAddSpotPress = jest.fn();
+
+  const defaultProps = {
+    selectedSpot: null,
+    nearbySpots,
+    searchQuery: '',
+    onSearchQueryChange: mockOnSearchQueryChange,
+    onSelectSpot: mockOnSelectSpot,
+    onAddSpotPress: mockOnAddSpotPress,
+    error: null,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('未選択時に検索バーが表示される', () => {
+    const { getByPlaceholderText } = render(<SpotSelector {...defaultProps} />);
+
+    expect(getByPlaceholderText('スポット名で検索')).toBeTruthy();
+  });
+
+  it('選択済みスポット名表示', () => {
+    const { getByText } = render(<SpotSelector {...defaultProps} selectedSpot={makeSpot()} />);
+
+    expect(getByText('仙台東照宮')).toBeTruthy();
+  });
+
+  it('検索バーフォーカスで候補ドロップダウンが開く', () => {
+    const { getByPlaceholderText, getByText } = render(<SpotSelector {...defaultProps} />);
+
+    fireEvent(getByPlaceholderText('スポット名で検索'), 'focus');
+
+    expect(getByText('仙台東照宮')).toBeTruthy();
+    expect(getByText('大崎八幡宮')).toBeTruthy();
+  });
+
+  it('スポットをタップすると onSelectSpot 呼出', () => {
+    const { getByPlaceholderText, getByText } = render(<SpotSelector {...defaultProps} />);
+
+    fireEvent(getByPlaceholderText('スポット名で検索'), 'focus');
+    fireEvent.press(getByText('仙台東照宮'));
+
+    expect(mockOnSelectSpot).toHaveBeenCalledWith(nearbySpots[0].spot);
+  });
+
+  it('「追加」リンクタップで onAddSpotPress 呼出', () => {
+    const { getByPlaceholderText, getByText } = render(<SpotSelector {...defaultProps} />);
+
+    fireEvent(getByPlaceholderText('スポット名で検索'), 'focus');
+    fireEvent.press(getByText('スポットが見つからない場合は追加'));
+
+    expect(mockOnAddSpotPress).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useNearbySpots.test.ts
+++ b/src/hooks/__tests__/useNearbySpots.test.ts
@@ -1,0 +1,191 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useNearbySpots } from '@hooks/useNearbySpots';
+import { useLocation } from '@hooks/useLocation';
+import { useSpots } from '@hooks/useSpots';
+import { calculateDistance } from '@utils/geo';
+import type { Spot } from '@/types/supabase';
+
+jest.mock('@hooks/useLocation', () => ({
+  useLocation: jest.fn(),
+}));
+jest.mock('@hooks/useSpots', () => ({
+  useSpots: jest.fn(),
+}));
+jest.mock('@utils/geo', () => ({
+  ...jest.requireActual('@utils/geo'),
+  calculateDistance: jest.fn(),
+}));
+
+const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
+const mockUseSpots = useSpots as jest.MockedFunction<typeof useSpots>;
+const mockCalculateDistance = calculateDistance as jest.MockedFunction<typeof calculateDistance>;
+
+const makeFakeSpot = (overrides: Partial<Spot> = {}): Spot => ({
+  id: 'spot-1',
+  name: 'Test Shrine',
+  lat: 38.27,
+  lng: 140.87,
+  type: 'shrine',
+  address: null,
+  status: 'active',
+  created_by_user_id: null,
+  merged_into_spot_id: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+  ...overrides,
+});
+
+describe('useNearbySpots', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('読み込み中は isLoading: true を返す', () => {
+    mockUseLocation.mockReturnValue({
+      location: null,
+      isLoading: true,
+      error: null,
+      permissionStatus: null,
+      refreshLocation: jest.fn(),
+    });
+    mockUseSpots.mockReturnValue({
+      spots: [],
+      allSpots: [],
+      isLoading: true,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useNearbySpots());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.nearbySpots).toEqual([]);
+  });
+
+  it('スポットを距離順でソートして返す', () => {
+    const location = { latitude: 38.2682, longitude: 140.8694 };
+    const spotA = makeFakeSpot({ id: 'spot-a', name: 'Far Shrine', lat: 38.3, lng: 140.9 });
+    const spotB = makeFakeSpot({ id: 'spot-b', name: 'Near Temple', lat: 38.269, lng: 140.87 });
+    const spotC = makeFakeSpot({ id: 'spot-c', name: 'Mid Shrine', lat: 38.28, lng: 140.88 });
+
+    mockUseLocation.mockReturnValue({
+      location,
+      isLoading: false,
+      error: null,
+      permissionStatus: null,
+      refreshLocation: jest.fn(),
+    });
+    mockUseSpots.mockReturnValue({
+      spots: [spotA, spotB, spotC],
+      allSpots: [spotA, spotB, spotC],
+      isLoading: false,
+      error: null,
+    });
+
+    // Near (0.5km), Mid (1.5km), Far (5.0km)
+    mockCalculateDistance
+      .mockReturnValueOnce(5.0) // spotA
+      .mockReturnValueOnce(0.5) // spotB
+      .mockReturnValueOnce(1.5); // spotC
+
+    const { result } = renderHook(() => useNearbySpots());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.nearbySpots).toHaveLength(3);
+    expect(result.current.nearbySpots[0].spot.id).toBe('spot-b');
+    expect(result.current.nearbySpots[0].distanceKm).toBe(0.5);
+    expect(result.current.nearbySpots[1].spot.id).toBe('spot-c');
+    expect(result.current.nearbySpots[1].distanceKm).toBe(1.5);
+    expect(result.current.nearbySpots[2].spot.id).toBe('spot-a');
+    expect(result.current.nearbySpots[2].distanceKm).toBe(5.0);
+  });
+
+  it('検索クエリでフィルタリングできる', () => {
+    const location = { latitude: 38.2682, longitude: 140.8694 };
+    const spotA = makeFakeSpot({ id: 'spot-a', name: '青葉神社' });
+    const spotB = makeFakeSpot({ id: 'spot-b', name: '大崎八幡宮' });
+    const spotC = makeFakeSpot({ id: 'spot-c', name: '青葉山寺院' });
+
+    mockUseLocation.mockReturnValue({
+      location,
+      isLoading: false,
+      error: null,
+      permissionStatus: null,
+      refreshLocation: jest.fn(),
+    });
+    mockUseSpots.mockReturnValue({
+      spots: [spotA, spotB, spotC],
+      allSpots: [spotA, spotB, spotC],
+      isLoading: false,
+      error: null,
+    });
+
+    mockCalculateDistance
+      .mockReturnValueOnce(1.0)
+      .mockReturnValueOnce(2.0)
+      .mockReturnValueOnce(3.0);
+
+    const { result } = renderHook(() => useNearbySpots());
+
+    // searchQuery が空のとき filteredSpots === nearbySpots
+    expect(result.current.filteredSpots).toEqual(result.current.nearbySpots);
+    expect(result.current.filteredSpots).toHaveLength(3);
+
+    // 検索クエリを設定 - distance が再計算されるので mock を再設定
+    mockCalculateDistance
+      .mockReturnValueOnce(1.0)
+      .mockReturnValueOnce(2.0)
+      .mockReturnValueOnce(3.0);
+
+    act(() => {
+      result.current.setSearchQuery('青葉');
+    });
+
+    expect(result.current.searchQuery).toBe('青葉');
+    expect(result.current.filteredSpots).toHaveLength(2);
+    expect(result.current.filteredSpots[0].spot.name).toBe('青葉神社');
+    expect(result.current.filteredSpots[1].spot.name).toBe('青葉山寺院');
+  });
+
+  it('位置情報なしの場合は空配列を返す', () => {
+    mockUseLocation.mockReturnValue({
+      location: null,
+      isLoading: false,
+      error: null,
+      permissionStatus: null,
+      refreshLocation: jest.fn(),
+    });
+    mockUseSpots.mockReturnValue({
+      spots: [],
+      allSpots: [],
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useNearbySpots());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.nearbySpots).toEqual([]);
+    expect(result.current.filteredSpots).toEqual([]);
+  });
+
+  it('エラー時にerrorを返す', () => {
+    mockUseLocation.mockReturnValue({
+      location: null,
+      isLoading: false,
+      error: '位置情報の取得に失敗しました',
+      permissionStatus: null,
+      refreshLocation: jest.fn(),
+    });
+    mockUseSpots.mockReturnValue({
+      spots: [],
+      allSpots: [],
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useNearbySpots());
+
+    expect(result.current.error).toBe('位置情報の取得に失敗しました');
+    expect(result.current.nearbySpots).toEqual([]);
+  });
+});

--- a/src/hooks/__tests__/useRecordForm.test.ts
+++ b/src/hooks/__tests__/useRecordForm.test.ts
@@ -1,0 +1,234 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useRecordForm } from '@hooks/useRecordForm';
+import type { Spot, Stamp } from '@/types/supabase';
+
+const mockFetchSpotById = jest.fn();
+const mockUploadStampImage = jest.fn();
+const mockCreateStamp = jest.fn();
+const mockUseAuth = jest.fn();
+
+jest.mock('@services/spots', () => ({
+  fetchSpotById: (...args: unknown[]) => mockFetchSpotById(...args),
+}));
+
+jest.mock('@services/stamps', () => ({
+  uploadStampImage: (...args: unknown[]) => mockUploadStampImage(...args),
+  createStamp: (...args: unknown[]) => mockCreateStamp(...args),
+}));
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const fakeSpot: Spot = {
+  id: 'spot-1',
+  name: '大崎八幡宮',
+  lat: 38.2744,
+  lng: 140.8577,
+  type: 'shrine',
+  address: '宮城県仙台市青葉区八幡4-6-1',
+  status: 'active',
+  created_by_user_id: null,
+  merged_into_spot_id: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+};
+
+const fakeStamp: Stamp = {
+  id: 'stamp-1',
+  user_id: 'user-1',
+  spot_id: 'spot-1',
+  goshuincho_id: null,
+  visited_at: '2024-06-01T00:00:00.000Z',
+  image_path: 'user-1/12345.jpg',
+  memo: '',
+  created_at: '2024-06-01T00:00:00Z',
+  updated_at: '2024-06-01T00:00:00Z',
+};
+
+describe('useRecordForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ user: { id: 'user-1' } });
+  });
+
+  it('has correct initial state', () => {
+    const { result } = renderHook(() => useRecordForm());
+
+    expect(result.current.selectedSpot).toBeNull();
+    expect(result.current.imageUri).toBeNull();
+    expect(result.current.visitedAt).toBeInstanceOf(Date);
+    expect(result.current.memo).toBe('');
+    expect(result.current.spotError).toBeNull();
+    expect(result.current.imageError).toBeNull();
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.submitError).toBeNull();
+  });
+
+  it('selects a spot with selectSpot', () => {
+    const { result } = renderHook(() => useRecordForm());
+
+    act(() => {
+      result.current.selectSpot(fakeSpot);
+    });
+
+    expect(result.current.selectedSpot).toEqual(fakeSpot);
+    expect(result.current.spotError).toBeNull();
+  });
+
+  it('sets imageUri with setImageUri', () => {
+    const { result } = renderHook(() => useRecordForm());
+
+    act(() => {
+      result.current.setImageUri('file:///photo.jpg');
+    });
+
+    expect(result.current.imageUri).toBe('file:///photo.jpg');
+    expect(result.current.imageError).toBeNull();
+  });
+
+  it('sets memo with setMemo', () => {
+    const { result } = renderHook(() => useRecordForm());
+
+    act(() => {
+      result.current.setMemo('素晴らしい参拝でした');
+    });
+
+    expect(result.current.memo).toBe('素晴らしい参拝でした');
+  });
+
+  it('validate returns false and sets spotError when no spot selected', () => {
+    const { result } = renderHook(() => useRecordForm());
+
+    act(() => {
+      result.current.setImageUri('file:///photo.jpg');
+    });
+
+    let valid: boolean;
+    act(() => {
+      valid = result.current.validate();
+    });
+
+    expect(valid!).toBe(false);
+    expect(result.current.spotError).toBe('スポットを選択してください');
+  });
+
+  it('validate returns false and sets imageError when no image', () => {
+    const { result } = renderHook(() => useRecordForm());
+
+    act(() => {
+      result.current.selectSpot(fakeSpot);
+    });
+
+    let valid: boolean;
+    act(() => {
+      valid = result.current.validate();
+    });
+
+    expect(valid!).toBe(false);
+    expect(result.current.imageError).toBe('御朱印の写真を追加してください');
+  });
+
+  it('validate returns true when spot and image are set', () => {
+    const { result } = renderHook(() => useRecordForm());
+
+    act(() => {
+      result.current.selectSpot(fakeSpot);
+      result.current.setImageUri('file:///photo.jpg');
+    });
+
+    let valid: boolean;
+    act(() => {
+      valid = result.current.validate();
+    });
+
+    expect(valid!).toBe(true);
+    expect(result.current.spotError).toBeNull();
+    expect(result.current.imageError).toBeNull();
+  });
+
+  it('submit returns stamp on success', async () => {
+    mockUploadStampImage.mockResolvedValue('user-1/12345.jpg');
+    mockCreateStamp.mockResolvedValue(fakeStamp);
+
+    const { result } = renderHook(() => useRecordForm());
+
+    act(() => {
+      result.current.selectSpot(fakeSpot);
+      result.current.setImageUri('file:///photo.jpg');
+    });
+
+    let submitResult: { success: boolean; stamp?: Stamp };
+    await act(async () => {
+      submitResult = await result.current.submit();
+    });
+
+    expect(submitResult!.success).toBe(true);
+    expect(submitResult!.stamp).toEqual(fakeStamp);
+    expect(mockUploadStampImage).toHaveBeenCalledWith('user-1', 'file:///photo.jpg');
+    expect(mockCreateStamp).toHaveBeenCalledWith({
+      userId: 'user-1',
+      spotId: 'spot-1',
+      imagePath: 'user-1/12345.jpg',
+      visitedAt: expect.any(String),
+      memo: '',
+    });
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('submit sets submitError on upload failure', async () => {
+    mockUploadStampImage.mockRejectedValue(new Error('Upload failed'));
+
+    const { result } = renderHook(() => useRecordForm());
+
+    act(() => {
+      result.current.selectSpot(fakeSpot);
+      result.current.setImageUri('file:///photo.jpg');
+    });
+
+    let submitResult: { success: boolean; stamp?: Stamp };
+    await act(async () => {
+      submitResult = await result.current.submit();
+    });
+
+    expect(submitResult!.success).toBe(false);
+    expect(submitResult!.stamp).toBeUndefined();
+    expect(result.current.submitError).toBe('Upload failed');
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('auto-selects spot when initialSpotId is provided', async () => {
+    mockFetchSpotById.mockResolvedValue(fakeSpot);
+
+    const { result } = renderHook(() => useRecordForm({ initialSpotId: 'spot-1' }));
+
+    await waitFor(() => {
+      expect(result.current.selectedSpot).toEqual(fakeSpot);
+    });
+
+    expect(mockFetchSpotById).toHaveBeenCalledWith('spot-1');
+  });
+
+  it('reset restores initial state', () => {
+    const { result } = renderHook(() => useRecordForm());
+
+    act(() => {
+      result.current.selectSpot(fakeSpot);
+      result.current.setImageUri('file:///photo.jpg');
+      result.current.setMemo('test memo');
+    });
+
+    expect(result.current.selectedSpot).toEqual(fakeSpot);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.selectedSpot).toBeNull();
+    expect(result.current.imageUri).toBeNull();
+    expect(result.current.memo).toBe('');
+    expect(result.current.spotError).toBeNull();
+    expect(result.current.imageError).toBeNull();
+    expect(result.current.submitError).toBeNull();
+  });
+});

--- a/src/hooks/useNearbySpots.ts
+++ b/src/hooks/useNearbySpots.ts
@@ -1,0 +1,53 @@
+import { useState, useMemo } from 'react';
+import { useLocation } from '@hooks/useLocation';
+import { useSpots } from '@hooks/useSpots';
+import { calculateDistance } from '@utils/geo';
+import type { Spot } from '@/types/supabase';
+
+export interface SpotWithDistance {
+  spot: Spot;
+  distanceKm: number;
+}
+
+export interface UseNearbySpotsReturn {
+  nearbySpots: SpotWithDistance[];
+  isLoading: boolean;
+  error: string | null;
+  searchQuery: string;
+  setSearchQuery: (q: string) => void;
+  filteredSpots: SpotWithDistance[];
+}
+
+export function useNearbySpots(): UseNearbySpotsReturn {
+  const { location, isLoading: locationLoading, error: locationError } = useLocation();
+  const { spots, isLoading: spotsLoading, error: spotsError } = useSpots(location, 'all');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const isLoading = locationLoading || spotsLoading;
+  const error = locationError || spotsError;
+
+  const nearbySpots = useMemo(() => {
+    if (!location || spots.length === 0) return [];
+
+    return spots
+      .map(spot => ({
+        spot,
+        distanceKm: calculateDistance(location.latitude, location.longitude, spot.lat, spot.lng),
+      }))
+      .sort((a, b) => a.distanceKm - b.distanceKm);
+  }, [location, spots]);
+
+  const filteredSpots = useMemo(() => {
+    if (!searchQuery) return nearbySpots;
+    return nearbySpots.filter(item => item.spot.name.includes(searchQuery));
+  }, [nearbySpots, searchQuery]);
+
+  return {
+    nearbySpots,
+    isLoading,
+    error,
+    searchQuery,
+    setSearchQuery,
+    filteredSpots,
+  };
+}

--- a/src/hooks/useRecordForm.ts
+++ b/src/hooks/useRecordForm.ts
@@ -1,0 +1,138 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { Spot, Stamp } from '@/types/supabase';
+import { fetchSpotById } from '@services/spots';
+import { uploadStampImage, createStamp } from '@services/stamps';
+import { useAuth } from '@hooks/useAuth';
+
+interface UseRecordFormParams {
+  initialSpotId?: string;
+}
+
+interface UseRecordFormReturn {
+  selectedSpot: Spot | null;
+  imageUri: string | null;
+  visitedAt: Date;
+  memo: string;
+  spotError: string | null;
+  imageError: string | null;
+  isSubmitting: boolean;
+  submitError: string | null;
+  selectSpot: (spot: Spot) => void;
+  setImageUri: (uri: string) => void;
+  setVisitedAt: (date: Date) => void;
+  setMemo: (text: string) => void;
+  validate: () => boolean;
+  submit: () => Promise<{ success: boolean; stamp?: Stamp }>;
+  reset: () => void;
+}
+
+export function useRecordForm(params?: UseRecordFormParams): UseRecordFormReturn {
+  const { user } = useAuth();
+
+  const [selectedSpot, setSelectedSpot] = useState<Spot | null>(null);
+  const [imageUri, setImageUriState] = useState<string | null>(null);
+  const [visitedAt, setVisitedAt] = useState<Date>(new Date());
+  const [memo, setMemo] = useState('');
+  const [spotError, setSpotError] = useState<string | null>(null);
+  const [imageError, setImageError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (params?.initialSpotId) {
+      fetchSpotById(params.initialSpotId).then(spot => {
+        if (spot) {
+          setSelectedSpot(spot);
+        }
+      });
+    }
+  }, [params?.initialSpotId]);
+
+  const selectSpot = useCallback((spot: Spot) => {
+    setSelectedSpot(spot);
+    setSpotError(null);
+  }, []);
+
+  const setImageUri = useCallback((uri: string) => {
+    setImageUriState(uri);
+    setImageError(null);
+  }, []);
+
+  const validate = useCallback((): boolean => {
+    let valid = true;
+
+    if (!selectedSpot) {
+      setSpotError('スポットを選択してください');
+      valid = false;
+    } else {
+      setSpotError(null);
+    }
+
+    if (!imageUri) {
+      setImageError('御朱印の写真を追加してください');
+      valid = false;
+    } else {
+      setImageError(null);
+    }
+
+    return valid;
+  }, [selectedSpot, imageUri]);
+
+  const submit = useCallback(async (): Promise<{ success: boolean; stamp?: Stamp }> => {
+    if (!validate()) {
+      return { success: false };
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const userId = user!.id;
+      const imagePath = await uploadStampImage(userId, imageUri!);
+      const stamp = await createStamp({
+        userId,
+        spotId: selectedSpot!.id,
+        imagePath,
+        visitedAt: visitedAt.toISOString(),
+        memo,
+      });
+
+      return { success: true, stamp };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '保存に失敗しました';
+      setSubmitError(message);
+      return { success: false };
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [validate, user, imageUri, selectedSpot, visitedAt, memo]);
+
+  const reset = useCallback(() => {
+    setSelectedSpot(null);
+    setImageUriState(null);
+    setVisitedAt(new Date());
+    setMemo('');
+    setSpotError(null);
+    setImageError(null);
+    setSubmitError(null);
+    setIsSubmitting(false);
+  }, []);
+
+  return {
+    selectedSpot,
+    imageUri,
+    visitedAt,
+    memo,
+    spotError,
+    imageError,
+    isSubmitting,
+    submitError,
+    selectSpot,
+    setImageUri,
+    setVisitedAt,
+    setMemo,
+    validate,
+    submit,
+    reset,
+  };
+}

--- a/src/navigation/__tests__/RootNavigator.test.tsx
+++ b/src/navigation/__tests__/RootNavigator.test.tsx
@@ -91,7 +91,55 @@ jest.mock('@hooks/useSpotStamps', () => ({
 
 jest.mock('@services/stamps', () => ({
   getStampImageUrl: (path: string) => `https://example.com/stamps/${path}`,
+  uploadStampImage: jest.fn(),
+  createStamp: jest.fn(),
 }));
+
+jest.mock('@services/spots', () => ({
+  fetchSpotsByBounds: jest.fn().mockResolvedValue([]),
+  fetchSpotById: jest.fn().mockResolvedValue(null),
+  searchSpotsByName: jest.fn().mockResolvedValue([]),
+  createSpot: jest.fn(),
+}));
+
+jest.mock('@hooks/useNearbySpots', () => ({
+  useNearbySpots: () => ({
+    nearbySpots: [],
+    isLoading: false,
+    error: null,
+    searchQuery: '',
+    setSearchQuery: jest.fn(),
+    filteredSpots: [],
+  }),
+}));
+
+jest.mock('@hooks/useRecordForm', () => ({
+  useRecordForm: () => ({
+    selectedSpot: null,
+    imageUri: null,
+    visitedAt: new Date(),
+    memo: '',
+    spotError: null,
+    imageError: null,
+    isSubmitting: false,
+    submitError: null,
+    selectSpot: jest.fn(),
+    setImageUri: jest.fn(),
+    setVisitedAt: jest.fn(),
+    setMemo: jest.fn(),
+    validate: jest.fn(),
+    submit: jest.fn(),
+    reset: jest.fn(),
+  }),
+}));
+
+jest.mock('expo-image-picker', () => ({
+  launchCameraAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+  MediaTypeOptions: { Images: 'Images' },
+}));
+
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
 
 function renderWithNavigation() {
   return render(

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -7,8 +7,8 @@ import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
 export type RootStackParamList = {
   Onboarding: undefined;
   MainTabs: NavigatorScreenParams<MainTabParamList>;
-  Record: undefined;
-  RecordComplete: undefined;
+  Record: { spotId?: string } | undefined;
+  RecordComplete: { stampImageUrl?: string; spotName?: string; visitCount?: number } | undefined;
   Login: undefined;
   Error: { type: 'network' | 'location' | 'upload' };
 };

--- a/src/screens/RecordCompleteScreen.tsx
+++ b/src/screens/RecordCompleteScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+import { Image, StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { CheckmarkAnimation } from '@components/animated/CheckmarkAnimation';
 import { BadgeAnimation } from '@components/animated/BadgeAnimation';
@@ -10,7 +10,11 @@ import type { RootStackScreenProps } from '@/navigation/types';
 
 type Props = RootStackScreenProps<'RecordComplete'>;
 
-export function RecordCompleteScreen({ navigation }: Props) {
+export function RecordCompleteScreen({ navigation, route }: Props) {
+  const stampImageUrl = route.params?.stampImageUrl;
+  const spotName = route.params?.spotName;
+  const visitCount = route.params?.visitCount;
+
   const handleRecordAnother = () => {
     navigation.navigate('Record');
   };
@@ -30,9 +34,26 @@ export function RecordCompleteScreen({ navigation }: Props) {
 
         <Text style={styles.title}>登録完了！</Text>
 
-        <View style={styles.imagePlaceholder} testID="stamp-image-placeholder" />
+        {stampImageUrl ? (
+          <Image
+            source={{ uri: stampImageUrl }}
+            style={styles.stampImage}
+            resizeMode="cover"
+            testID="stamp-image"
+          />
+        ) : (
+          <View style={styles.imagePlaceholder} testID="stamp-image-placeholder" />
+        )}
 
-        <Text style={styles.countText}>33箇所目の御朱印！</Text>
+        {spotName && (
+          <Text style={styles.spotName} testID="spot-name">
+            {spotName}
+          </Text>
+        )}
+
+        <Text style={styles.countText} testID="visit-count">
+          {visitCount ? `${visitCount}箇所目の御朱印！` : '御朱印を記録しました！'}
+        </Text>
 
         <BadgeAnimation badgeName="初めての御朱印" description="最初の御朱印を記録しました" />
       </View>
@@ -82,11 +103,20 @@ const styles = StyleSheet.create({
     ...typography.h1,
     color: colors.white,
   },
+  stampImage: {
+    width: 160,
+    height: 200,
+    borderRadius: borderRadius.lg,
+  },
   imagePlaceholder: {
     width: 160,
     height: 200,
     borderRadius: borderRadius.lg,
     backgroundColor: 'rgba(255,255,255,0.2)',
+  },
+  spotName: {
+    ...typography.h3,
+    color: colors.white,
   },
   countText: {
     ...typography.h3,

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -1,9 +1,29 @@
-import React, { useState } from 'react';
-import { StyleSheet, Text, View, ScrollView, TouchableOpacity, TextInput } from 'react-native';
+import React, { useRef, useState } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  ScrollView,
+  TextInput,
+  TouchableOpacity,
+  Platform,
+  KeyboardAvoidingView,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import DateTimePicker from '@react-native-community/datetimepicker';
 import { MaterialIcons } from '@expo/vector-icons';
 import { Button } from '@components/common/Button';
 import { Header } from '@components/common/Header';
+import { SpotSelector } from '@components/record/SpotSelector';
+import { PhotoSection } from '@components/record/PhotoSection';
+import { PhotoPickerModal } from '@components/record/PhotoPickerModal';
+import { SpotAddModal } from '@components/record/SpotAddModal';
+import { ConfirmModal } from '@components/record/ConfirmModal';
+import { useRecordForm } from '@hooks/useRecordForm';
+import { useNearbySpots } from '@hooks/useNearbySpots';
+import { useAuth } from '@hooks/useAuth';
+import { useLocation } from '@hooks/useLocation';
+import { getStampImageUrl } from '@services/stamps';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing, borderRadius } from '@theme/spacing';
@@ -11,74 +31,186 @@ import type { RootStackScreenProps } from '@/navigation/types';
 
 type Props = RootStackScreenProps<'Record'>;
 
-export function RecordScreen({ navigation }: Props) {
-  const [selectedSpot, setSelectedSpot] = useState<string | null>(null);
-  const [memo, setMemo] = useState('');
+export function RecordScreen({ navigation, route }: Props) {
+  const initialSpotId = route.params?.spotId;
+  const { user } = useAuth();
+  const { location } = useLocation();
+  const { filteredSpots, searchQuery, setSearchQuery } = useNearbySpots();
+  const form = useRecordForm(initialSpotId ? { initialSpotId } : undefined);
 
-  const today = new Date();
-  const formattedDate = `${today.getFullYear()}年${today.getMonth() + 1}月${today.getDate()}日`;
+  const scrollViewRef = useRef<ScrollView>(null);
+  const memoLayoutY = useRef(0);
 
-  const handleSelectSpot = () => {
-    setSelectedSpot('明治神宮');
+  const [showPhotoPicker, setShowPhotoPicker] = useState(false);
+  const [showSpotAdd, setShowSpotAdd] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [showDatePicker, setShowDatePicker] = useState(false);
+
+  const formattedDate = `${form.visitedAt.getFullYear()}年${form.visitedAt.getMonth() + 1}月${form.visitedAt.getDate()}日`;
+
+  const handleSavePress = () => {
+    if (!form.validate()) return;
+    setShowConfirm(true);
   };
 
-  const handleSave = () => {
-    navigation.navigate('RecordComplete');
+  const handleConfirm = async () => {
+    const result = await form.submit();
+    setShowConfirm(false);
+    if (result.success && result.stamp) {
+      navigation.navigate('RecordComplete', {
+        stampImageUrl: getStampImageUrl(result.stamp.image_path),
+        spotName: form.selectedSpot?.name,
+      });
+    }
+  };
+
+  const handleDateChange = (_event: unknown, selectedDate?: Date) => {
+    if (Platform.OS === 'android') {
+      setShowDatePicker(false);
+    }
+    if (selectedDate) {
+      form.setVisitedAt(selectedDate);
+    }
   };
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <Header title="御朱印を記録" variant="modal" onClose={() => navigation.goBack()} />
 
-      <ScrollView
+      <KeyboardAvoidingView
         style={styles.scrollView}
-        contentContainerStyle={styles.scrollContent}
-        keyboardShouldPersistTaps="handled"
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
       >
-        <Text style={styles.sectionLabel}>スポット</Text>
-        <TouchableOpacity
-          style={styles.spotSelector}
-          onPress={handleSelectSpot}
-          testID="spot-selector"
+        <ScrollView
+          ref={scrollViewRef}
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
         >
-          <MaterialIcons
-            name="place"
-            size={24}
-            color={selectedSpot ? colors.primary[500] : colors.gray[400]}
+          <Text style={styles.sectionLabel}>スポット</Text>
+          <SpotSelector
+            selectedSpot={form.selectedSpot}
+            nearbySpots={filteredSpots}
+            searchQuery={searchQuery}
+            onSearchQueryChange={setSearchQuery}
+            onSelectSpot={form.selectSpot}
+            onAddSpotPress={() => setShowSpotAdd(true)}
+            error={form.spotError}
           />
-          <Text style={[styles.spotText, !selectedSpot && styles.spotPlaceholder]}>
-            {selectedSpot ?? 'スポットを選択'}
-          </Text>
-          <MaterialIcons name="chevron-right" size={24} color={colors.gray[400]} />
-        </TouchableOpacity>
 
-        <Text style={styles.sectionLabel}>御朱印の写真</Text>
-        <TouchableOpacity style={styles.photoArea} testID="photo-area">
-          <MaterialIcons name="add-a-photo" size={48} color={colors.gray[400]} />
-          <Text style={styles.photoText}>御朱印の写真を追加</Text>
-        </TouchableOpacity>
+          <Text style={styles.sectionLabel}>御朱印の写真</Text>
+          <PhotoSection
+            imageUri={form.imageUri}
+            onPress={() => setShowPhotoPicker(true)}
+            error={form.imageError}
+          />
 
-        <Text style={styles.sectionLabel}>訪問日</Text>
-        <View style={styles.dateRow}>
-          <MaterialIcons name="calendar-today" size={20} color={colors.gray[500]} />
-          <Text style={styles.dateText}>{formattedDate}</Text>
-        </View>
+          <Text style={styles.sectionLabel}>訪問日</Text>
+          <TouchableOpacity
+            style={styles.dateRow}
+            onPress={() => setShowDatePicker(true)}
+            testID="date-picker-trigger"
+          >
+            <MaterialIcons name="calendar-today" size={20} color={colors.gray[500]} />
+            <Text style={styles.dateText}>{formattedDate}</Text>
+          </TouchableOpacity>
+          {showDatePicker && (
+            <View>
+              <DateTimePicker
+                value={form.visitedAt}
+                mode="date"
+                display={Platform.OS === 'ios' ? 'inline' : 'default'}
+                onChange={handleDateChange}
+                maximumDate={new Date()}
+                testID="date-picker"
+              />
+              {Platform.OS === 'ios' && (
+                <TouchableOpacity
+                  style={styles.dateConfirmButton}
+                  onPress={() => setShowDatePicker(false)}
+                >
+                  <Text style={styles.dateConfirmText}>完了</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          )}
 
-        <Text style={styles.sectionLabel}>メモ（任意）</Text>
-        <TextInput
-          style={styles.memoInput}
-          placeholder="メモを入力..."
-          placeholderTextColor={colors.gray[400]}
-          multiline
-          value={memo}
-          onChangeText={setMemo}
-          testID="memo-input"
-        />
-      </ScrollView>
+          <Text style={styles.sectionLabel}>メモ（任意）</Text>
+          <View
+            onLayout={e => {
+              memoLayoutY.current = e.nativeEvent.layout.y;
+            }}
+          >
+            <TextInput
+              style={styles.memoInput}
+              placeholder="メモを入力..."
+              placeholderTextColor={colors.gray[400]}
+              multiline
+              value={form.memo}
+              onChangeText={form.setMemo}
+              onFocus={() => {
+                setTimeout(() => {
+                  scrollViewRef.current?.scrollTo({
+                    y: memoLayoutY.current,
+                    animated: true,
+                  });
+                }, 300);
+              }}
+              testID="memo-input"
+            />
+          </View>
+
+          {form.submitError && (
+            <Text style={styles.submitError} testID="submit-error">
+              {form.submitError}
+            </Text>
+          )}
+        </ScrollView>
+      </KeyboardAvoidingView>
 
       <View style={styles.footer}>
-        <Button title="この内容で記録する" onPress={handleSave} variant="primary" />
+        <Button
+          title="この内容で記録する"
+          onPress={handleSavePress}
+          variant="primary"
+          disabled={form.isSubmitting}
+        />
       </View>
+
+      <PhotoPickerModal
+        visible={showPhotoPicker}
+        onClose={() => setShowPhotoPicker(false)}
+        onImageSelected={uri => {
+          form.setImageUri(uri);
+          setShowPhotoPicker(false);
+        }}
+      />
+
+      {user && (
+        <SpotAddModal
+          visible={showSpotAdd}
+          onClose={() => setShowSpotAdd(false)}
+          onSpotCreated={spot => {
+            form.selectSpot(spot);
+            setShowSpotAdd(false);
+          }}
+          userLocation={location}
+          userId={user.id}
+        />
+      )}
+
+      {form.selectedSpot && (
+        <ConfirmModal
+          visible={showConfirm}
+          onClose={() => setShowConfirm(false)}
+          onConfirm={handleConfirm}
+          spotName={form.selectedSpot.name}
+          spotType={form.selectedSpot.type}
+          visitedAt={form.visitedAt}
+          isSubmitting={form.isSubmitting}
+        />
+      )}
     </SafeAreaView>
   );
 }
@@ -100,39 +232,6 @@ const styles = StyleSheet.create({
     color: colors.gray[600],
     marginBottom: spacing.sm,
     marginTop: spacing.lg,
-  },
-  spotSelector: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: spacing.lg,
-    borderWidth: 1,
-    borderColor: colors.gray[200],
-    borderRadius: borderRadius.lg,
-    backgroundColor: colors.white,
-    gap: spacing.md,
-  },
-  spotText: {
-    ...typography.body,
-    color: colors.gray[800],
-    flex: 1,
-  },
-  spotPlaceholder: {
-    color: colors.gray[400],
-  },
-  photoArea: {
-    height: 200,
-    borderWidth: 2,
-    borderColor: colors.gray[300],
-    borderStyle: 'dashed',
-    borderRadius: borderRadius.lg,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: colors.gray[50],
-    gap: spacing.sm,
-  },
-  photoText: {
-    ...typography.bodySmall,
-    color: colors.gray[400],
   },
   dateRow: {
     flexDirection: 'row',
@@ -158,6 +257,23 @@ const styles = StyleSheet.create({
     backgroundColor: colors.white,
     textAlignVertical: 'top',
     color: colors.gray[800],
+  },
+  submitError: {
+    ...typography.bodySmall,
+    color: colors.error,
+    marginTop: spacing.md,
+    textAlign: 'center',
+  },
+  dateConfirmButton: {
+    alignSelf: 'flex-end',
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    marginTop: spacing.sm,
+  },
+  dateConfirmText: {
+    ...typography.body,
+    color: colors.primary[500],
+    fontWeight: '600',
   },
   footer: {
     padding: spacing.lg,

--- a/src/screens/SpotDetailScreen.tsx
+++ b/src/screens/SpotDetailScreen.tsx
@@ -40,7 +40,7 @@ export function SpotDetailScreen({ navigation, route }: Props) {
   const handleRecord = () => {
     const parent = navigation.getParent();
     if (parent) {
-      parent.navigate('Record');
+      parent.navigate('Record', { spotId });
     }
   };
 

--- a/src/screens/__tests__/RecordCompleteScreen.test.tsx
+++ b/src/screens/__tests__/RecordCompleteScreen.test.tsx
@@ -18,10 +18,20 @@ const mockNavigation = {
   getParent: jest.fn(() => ({ navigate: jest.fn() })),
 } as any;
 
-const mockRoute = {
+const mockRouteNoParams = {
   key: 'test',
   name: 'RecordComplete' as const,
   params: undefined,
+};
+
+const mockRouteWithParams = {
+  key: 'test',
+  name: 'RecordComplete' as const,
+  params: {
+    stampImageUrl: 'https://example.com/stamps/user-1/12345.jpg',
+    spotName: '大崎八幡宮',
+    visitCount: 5,
+  },
 };
 
 describe('RecordCompleteScreen', () => {
@@ -31,35 +41,35 @@ describe('RecordCompleteScreen', () => {
 
   it('renders without crashing', () => {
     const { getByText } = render(
-      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRouteNoParams} />
     );
     expect(getByText('登録完了！')).toBeTruthy();
   });
 
   it('renders checkmark animation', () => {
     const { getByTestId } = render(
-      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRouteNoParams} />
     );
     expect(getByTestId('checkmark-animation')).toBeTruthy();
   });
 
-  it('renders stamp image placeholder', () => {
+  it('renders stamp image placeholder when no params', () => {
     const { getByTestId } = render(
-      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRouteNoParams} />
     );
     expect(getByTestId('stamp-image-placeholder')).toBeTruthy();
   });
 
-  it('renders count text', () => {
+  it('renders default count text when no visitCount', () => {
     const { getByText } = render(
-      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRouteNoParams} />
     );
-    expect(getByText('33箇所目の御朱印！')).toBeTruthy();
+    expect(getByText('御朱印を記録しました！')).toBeTruthy();
   });
 
   it('renders badge animation', () => {
     const { getByTestId, getByText } = render(
-      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRouteNoParams} />
     );
     expect(getByTestId('badge-animation')).toBeTruthy();
     expect(getByText('初めての御朱印')).toBeTruthy();
@@ -67,7 +77,7 @@ describe('RecordCompleteScreen', () => {
 
   it('renders three action buttons', () => {
     const { getByText } = render(
-      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRouteNoParams} />
     );
     expect(getByText('もう1枚記録する')).toBeTruthy();
     expect(getByText('地図を見る')).toBeTruthy();
@@ -76,7 +86,7 @@ describe('RecordCompleteScreen', () => {
 
   it('navigates to Record on "record another" press', () => {
     const { getByTestId } = render(
-      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRouteNoParams} />
     );
     fireEvent.press(getByTestId('button-record-another'));
     expect(mockNavigation.navigate).toHaveBeenCalledWith('Record');
@@ -84,7 +94,7 @@ describe('RecordCompleteScreen', () => {
 
   it('navigates to MainTabs on "view map" press', () => {
     const { getByTestId } = render(
-      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRouteNoParams} />
     );
     fireEvent.press(getByTestId('button-view-map'));
     expect(mockNavigation.navigate).toHaveBeenCalledWith('MainTabs', {
@@ -95,11 +105,34 @@ describe('RecordCompleteScreen', () => {
 
   it('navigates to Collection on "view collection" press', () => {
     const { getByTestId } = render(
-      <RecordCompleteScreen navigation={mockNavigation} route={mockRoute} />
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRouteNoParams} />
     );
     fireEvent.press(getByTestId('button-view-collection'));
     expect(mockNavigation.navigate).toHaveBeenCalledWith('MainTabs', {
       screen: 'Collection',
+    });
+  });
+
+  describe('with params', () => {
+    it('renders stamp image when stampImageUrl is provided', () => {
+      const { getByTestId } = render(
+        <RecordCompleteScreen navigation={mockNavigation} route={mockRouteWithParams} />
+      );
+      expect(getByTestId('stamp-image')).toBeTruthy();
+    });
+
+    it('renders spot name when provided', () => {
+      const { getByText } = render(
+        <RecordCompleteScreen navigation={mockNavigation} route={mockRouteWithParams} />
+      );
+      expect(getByText('大崎八幡宮')).toBeTruthy();
+    });
+
+    it('renders visit count text when visitCount is provided', () => {
+      const { getByText } = render(
+        <RecordCompleteScreen navigation={mockNavigation} route={mockRouteWithParams} />
+      );
+      expect(getByText('5箇所目の御朱印！')).toBeTruthy();
     });
   });
 });

--- a/src/screens/__tests__/RecordScreen.test.tsx
+++ b/src/screens/__tests__/RecordScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { RecordScreen } from '@screens/RecordScreen';
+import type { Spot, Stamp } from '@/types/supabase';
 
 jest.mock('react-native-safe-area-context', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -9,6 +10,95 @@ jest.mock('react-native-safe-area-context', () => {
     SafeAreaView: View,
     SafeAreaProvider: View,
     useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+const mockSelectSpot = jest.fn();
+const mockSetImageUri = jest.fn();
+const mockSetVisitedAt = jest.fn();
+const mockSetMemo = jest.fn();
+const mockValidate = jest.fn(() => true);
+const mockSubmit = jest.fn();
+const mockReset = jest.fn();
+
+const fakeSpot: Spot = {
+  id: 'spot-1',
+  name: '大崎八幡宮',
+  lat: 38.2744,
+  lng: 140.8577,
+  type: 'shrine',
+  address: '宮城県仙台市青葉区八幡4-6-1',
+  status: 'active',
+  created_by_user_id: null,
+  merged_into_spot_id: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+};
+
+let mockFormState = {
+  selectedSpot: null as Spot | null,
+  imageUri: null as string | null,
+  visitedAt: new Date('2024-06-01'),
+  memo: '',
+  spotError: null as string | null,
+  imageError: null as string | null,
+  isSubmitting: false,
+  submitError: null as string | null,
+  selectSpot: mockSelectSpot,
+  setImageUri: mockSetImageUri,
+  setVisitedAt: mockSetVisitedAt,
+  setMemo: mockSetMemo,
+  validate: mockValidate,
+  submit: mockSubmit,
+  reset: mockReset,
+};
+
+jest.mock('@hooks/useRecordForm', () => ({
+  useRecordForm: () => mockFormState,
+}));
+
+jest.mock('@hooks/useNearbySpots', () => ({
+  useNearbySpots: () => ({
+    nearbySpots: [{ spot: fakeSpot, distanceKm: 1.2 }],
+    filteredSpots: [{ spot: fakeSpot, distanceKm: 1.2 }],
+    isLoading: false,
+    error: null,
+    searchQuery: '',
+    setSearchQuery: jest.fn(),
+  }),
+}));
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1' }, isAuthenticated: true }),
+}));
+
+jest.mock('@hooks/useLocation', () => ({
+  useLocation: () => ({
+    location: { latitude: 38.27, longitude: 140.86 },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('expo-image-picker', () => ({
+  launchCameraAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+jest.mock('@services/stamps', () => ({
+  getStampImageUrl: (path: string) => `https://example.com/stamps/${path}`,
+}));
+
+jest.mock('@services/spots', () => ({
+  createSpot: jest.fn(),
+}));
+
+jest.mock('@react-native-community/datetimepicker', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: View,
   };
 });
 
@@ -27,6 +117,23 @@ const mockRoute = {
 describe('RecordScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFormState = {
+      selectedSpot: null,
+      imageUri: null,
+      visitedAt: new Date('2024-06-01'),
+      memo: '',
+      spotError: null,
+      imageError: null,
+      isSubmitting: false,
+      submitError: null,
+      selectSpot: mockSelectSpot,
+      setImageUri: mockSetImageUri,
+      setVisitedAt: mockSetVisitedAt,
+      setMemo: mockSetMemo,
+      validate: mockValidate,
+      submit: mockSubmit,
+      reset: mockReset,
+    };
   });
 
   it('renders without crashing', () => {
@@ -42,20 +149,14 @@ describe('RecordScreen', () => {
     expect(getByText('メモ（任意）')).toBeTruthy();
   });
 
-  it('renders spot selector with placeholder', () => {
-    const { getByText, getByTestId } = render(
-      <RecordScreen navigation={mockNavigation} route={mockRoute} />
-    );
-    expect(getByTestId('spot-selector')).toBeTruthy();
-    expect(getByText('スポットを選択')).toBeTruthy();
+  it('renders spot selector trigger', () => {
+    const { getByTestId } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByTestId('spot-selector-trigger')).toBeTruthy();
   });
 
-  it('renders photo area', () => {
-    const { getByTestId, getByText } = render(
-      <RecordScreen navigation={mockNavigation} route={mockRoute} />
-    );
-    expect(getByTestId('photo-area')).toBeTruthy();
-    expect(getByText('御朱印の写真を追加')).toBeTruthy();
+  it('renders photo section', () => {
+    const { getByTestId } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByTestId('photo-section')).toBeTruthy();
   });
 
   it('renders memo input', () => {
@@ -74,11 +175,41 @@ describe('RecordScreen', () => {
     expect(mockNavigation.goBack).toHaveBeenCalled();
   });
 
-  it('selects spot on spot selector press', () => {
-    const { getByTestId, getByText } = render(
-      <RecordScreen navigation={mockNavigation} route={mockRoute} />
-    );
-    fireEvent.press(getByTestId('spot-selector'));
-    expect(getByText('明治神宮')).toBeTruthy();
+  it('calls submit and navigates to RecordComplete on success', async () => {
+    const fakeStamp: Stamp = {
+      id: 'stamp-1',
+      user_id: 'user-1',
+      spot_id: 'spot-1',
+      goshuincho_id: null,
+      visited_at: '2024-06-01T00:00:00.000Z',
+      image_path: 'user-1/12345.jpg',
+      memo: '',
+      created_at: '2024-06-01T00:00:00Z',
+      updated_at: '2024-06-01T00:00:00Z',
+    };
+
+    mockFormState.selectedSpot = fakeSpot;
+    mockFormState.imageUri = 'file:///photo.jpg';
+    mockSubmit.mockResolvedValue({ success: true, stamp: fakeStamp });
+
+    const { getByText } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+
+    // Press save button -> opens confirm modal
+    fireEvent.press(getByText('この内容で記録する'));
+
+    // Press confirm button inside modal
+    fireEvent.press(getByText('登録する'));
+
+    await waitFor(() => {
+      expect(mockSubmit).toHaveBeenCalled();
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('RecordComplete', expect.any(Object));
+    });
+  });
+
+  it('shows submit error when submit fails', async () => {
+    mockFormState.submitError = '保存に失敗しました';
+
+    const { getByText } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('保存に失敗しました')).toBeTruthy();
   });
 });

--- a/src/screens/__tests__/SpotDetailScreen.test.tsx
+++ b/src/screens/__tests__/SpotDetailScreen.test.tsx
@@ -355,4 +355,14 @@ describe('SpotDetailScreen', () => {
       expect(miniMap).toBeTruthy();
     });
   });
+
+  describe('record navigation', () => {
+    it('navigates to Record with spotId on record button press', () => {
+      const { getByText } = render(
+        <SpotDetailScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+      fireEvent.press(getByText('ここで記録する'));
+      expect(mockParentNavigate).toHaveBeenCalledWith('Record', { spotId: 'spot-1' });
+    });
+  });
 });

--- a/src/services/__tests__/spots-create.test.ts
+++ b/src/services/__tests__/spots-create.test.ts
@@ -1,0 +1,76 @@
+import { createSpot } from '@services/spots';
+
+const mockFrom = jest.fn();
+const mockInsert = jest.fn();
+const mockSelect = jest.fn();
+const mockSingle = jest.fn();
+
+jest.mock('@services/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+describe('createSpot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns Spot with status pending on success', async () => {
+    const mockSpot = {
+      id: 'spot-new',
+      name: 'Test Shrine',
+      lat: 38.26,
+      lng: 140.87,
+      type: 'shrine' as const,
+      address: null,
+      status: 'pending' as const,
+      created_by_user_id: 'user-1',
+      merged_into_spot_id: null,
+      created_at: '2024-06-01T00:00:00Z',
+      updated_at: '2024-06-01T00:00:00Z',
+    };
+
+    mockFrom.mockReturnValue({ insert: mockInsert });
+    mockInsert.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ single: mockSingle });
+    mockSingle.mockResolvedValue({ data: mockSpot, error: null });
+
+    const result = await createSpot({
+      name: 'Test Shrine',
+      type: 'shrine',
+      lat: 38.26,
+      lng: 140.87,
+      createdByUserId: 'user-1',
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith('spots');
+    expect(mockInsert).toHaveBeenCalledWith({
+      name: 'Test Shrine',
+      type: 'shrine',
+      lat: 38.26,
+      lng: 140.87,
+      status: 'pending',
+      created_by_user_id: 'user-1',
+    });
+    expect(result).toEqual(mockSpot);
+    expect(result.status).toBe('pending');
+  });
+
+  it('throws error when DB insert fails', async () => {
+    mockFrom.mockReturnValue({ insert: mockInsert });
+    mockInsert.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ single: mockSingle });
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'Insert failed' } });
+
+    await expect(
+      createSpot({
+        name: 'Test Temple',
+        type: 'temple',
+        lat: 35.0,
+        lng: 135.0,
+        createdByUserId: 'user-2',
+      })
+    ).rejects.toThrow('Insert failed');
+  });
+});

--- a/src/services/__tests__/stamps-create.test.ts
+++ b/src/services/__tests__/stamps-create.test.ts
@@ -1,0 +1,139 @@
+import { uploadStampImage, createStamp } from '@services/stamps';
+
+const mockFrom = jest.fn();
+const mockUpload = jest.fn();
+const mockInsert = jest.fn();
+const mockSelect = jest.fn();
+const mockSingle = jest.fn();
+
+jest.mock('@services/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    storage: {
+      from: () => ({
+        upload: (...args: unknown[]) => mockUpload(...args),
+      }),
+    },
+  },
+}));
+
+const mockFetch = jest.fn();
+(global as unknown as { fetch: jest.Mock }).fetch = mockFetch;
+
+describe('uploadStampImage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns uploaded path on success', async () => {
+    const mockBlob = new Blob(['image-data'], { type: 'image/jpeg' });
+    mockFetch.mockResolvedValue({ blob: () => Promise.resolve(mockBlob) });
+    mockUpload.mockResolvedValue({ data: { path: 'user-1/12345-abc.jpg' }, error: null });
+
+    const result = await uploadStampImage('user-1', 'file:///photo.jpg');
+
+    expect(mockFetch).toHaveBeenCalledWith('file:///photo.jpg');
+    expect(mockUpload).toHaveBeenCalledWith(
+      expect.stringMatching(/^user-1\/\d+-[a-z0-9]+\.jpg$/),
+      mockBlob,
+      { contentType: 'image/jpeg' }
+    );
+    expect(typeof result).toBe('string');
+    expect(result).toMatch(/^user-1\//);
+  });
+
+  it('throws error when upload fails', async () => {
+    const mockBlob = new Blob(['image-data'], { type: 'image/jpeg' });
+    mockFetch.mockResolvedValue({ blob: () => Promise.resolve(mockBlob) });
+    mockUpload.mockResolvedValue({ data: null, error: { message: 'Upload failed' } });
+
+    await expect(uploadStampImage('user-1', 'file:///photo.jpg')).rejects.toThrow('Upload failed');
+  });
+});
+
+describe('createStamp', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns Stamp on success', async () => {
+    const mockStamp = {
+      id: 'stamp-1',
+      user_id: 'user-1',
+      spot_id: 'spot-1',
+      goshuincho_id: null,
+      visited_at: '2024-06-01',
+      image_path: 'user-1/img.jpg',
+      memo: 'Great visit',
+      created_at: '2024-06-01T00:00:00Z',
+      updated_at: '2024-06-01T00:00:00Z',
+    };
+
+    mockFrom.mockReturnValue({ insert: mockInsert });
+    mockInsert.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ single: mockSingle });
+    mockSingle.mockResolvedValue({ data: mockStamp, error: null });
+
+    const result = await createStamp({
+      userId: 'user-1',
+      spotId: 'spot-1',
+      imagePath: 'user-1/img.jpg',
+      visitedAt: '2024-06-01',
+      memo: 'Great visit',
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith('stamps');
+    expect(mockInsert).toHaveBeenCalledWith({
+      user_id: 'user-1',
+      spot_id: 'spot-1',
+      image_path: 'user-1/img.jpg',
+      visited_at: '2024-06-01',
+      memo: 'Great visit',
+    });
+    expect(result).toEqual(mockStamp);
+  });
+
+  it('saves memo as null when omitted', async () => {
+    const mockStamp = {
+      id: 'stamp-2',
+      user_id: 'user-1',
+      spot_id: 'spot-1',
+      goshuincho_id: null,
+      visited_at: '2024-06-01',
+      image_path: 'user-1/img.jpg',
+      memo: null,
+      created_at: '2024-06-01T00:00:00Z',
+      updated_at: '2024-06-01T00:00:00Z',
+    };
+
+    mockFrom.mockReturnValue({ insert: mockInsert });
+    mockInsert.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ single: mockSingle });
+    mockSingle.mockResolvedValue({ data: mockStamp, error: null });
+
+    await createStamp({
+      userId: 'user-1',
+      spotId: 'spot-1',
+      imagePath: 'user-1/img.jpg',
+      visitedAt: '2024-06-01',
+    });
+
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ memo: null }));
+  });
+
+  it('throws error when DB insert fails', async () => {
+    mockFrom.mockReturnValue({ insert: mockInsert });
+    mockInsert.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ single: mockSingle });
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'DB error' } });
+
+    await expect(
+      createStamp({
+        userId: 'user-1',
+        spotId: 'spot-1',
+        imagePath: 'user-1/img.jpg',
+        visitedAt: '2024-06-01',
+      })
+    ).rejects.toThrow('DB error');
+  });
+});

--- a/src/services/spots.ts
+++ b/src/services/spots.ts
@@ -31,6 +31,33 @@ export async function fetchSpotById(id: string): Promise<Spot | null> {
   return data as Spot;
 }
 
+export async function createSpot(params: {
+  name: string;
+  type: 'shrine' | 'temple';
+  lat: number;
+  lng: number;
+  createdByUserId: string;
+}): Promise<Spot> {
+  const { data, error } = await supabase
+    .from('spots')
+    .insert({
+      name: params.name,
+      type: params.type,
+      lat: params.lat,
+      lng: params.lng,
+      status: 'pending' as const,
+      created_by_user_id: params.createdByUserId,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data as Spot;
+}
+
 export async function searchSpotsByName(query: string): Promise<Spot[]> {
   const { data, error } = await supabase
     .from('spots')

--- a/src/services/stamps.ts
+++ b/src/services/stamps.ts
@@ -27,7 +27,49 @@ export async function fetchStampsBySpotId(spotId: string): Promise<Stamp[]> {
   return data as Stamp[];
 }
 
+export async function uploadStampImage(userId: string, imageUri: string): Promise<string> {
+  const response = await fetch(imageUri);
+  const blob = await response.blob();
+  const filePath = `${userId}/${Date.now()}-${Math.random().toString(36).slice(2, 8)}.jpg`;
+
+  const { data, error } = await supabase.storage
+    .from('goshuin-images')
+    .upload(filePath, blob, { contentType: 'image/jpeg' });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data.path;
+}
+
+export async function createStamp(params: {
+  userId: string;
+  spotId: string;
+  imagePath: string;
+  visitedAt: string;
+  memo?: string;
+}): Promise<Stamp> {
+  const { data, error } = await supabase
+    .from('stamps')
+    .insert({
+      user_id: params.userId,
+      spot_id: params.spotId,
+      image_path: params.imagePath,
+      visited_at: params.visitedAt,
+      memo: params.memo ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data as Stamp;
+}
+
 export function getStampImageUrl(imagePath: string): string {
-  const { data } = supabase.storage.from('stamps').getPublicUrl(imagePath);
+  const { data } = supabase.storage.from('goshuin-images').getPublicUrl(imagePath);
   return data.publicUrl;
 }


### PR DESCRIPTION
## Summary
- カメラ/ギャラリー連携、Supabase画像アップロード・データ保存、スポット選択・新規追加・確認モーダル、バリデーション、日付選択を実装し、御朱印記録フローを完成
- サービス層（uploadStampImage, createStamp, createSpot）、hooks（useNearbySpots, useRecordForm）、5つのコンポーネント（SpotSelector, PhotoSection, PhotoPickerModal, SpotAddModal, ConfirmModal）を新規作成
- RecordScreen全面リライト、SpotDetailScreenからのspotIdパラメータ渡し、RecordCompleteScreenのパラメータ表示、ModalへのKeyboardAvoidingView追加

## Test plan
- [x] 全322テスト通過（39 suites）
- [x] Lint OK
- [x] 型チェック OK
- [x] 実機手動テスト済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)