### PR TITLE
feat: 登録完了画面の実装（バッジあり/なし）

### DIFF
--- a/docs/issues/issue-015-registration-complete.md
+++ b/docs/issues/issue-015-registration-complete.md
@@ -1,0 +1,251 @@
+# Issue #15: 登録完了画面の実装（バッジあり/なし）
+
+## 概要
+
+御朱印登録完了後に表示される達成感演出画面を実装する。現在の `RecordCompleteScreen` は骨格（スケルトン）のみ実装されており、以下の機能が不足している:
+
+1. **visitCount が RecordScreen から渡されていない** -- RecordScreen の `handleConfirm` で `visitCount` パラメータが未設定
+2. **バッジ獲得判定ロジックが存在しない** -- 現在はハードコードで「初めての御朱印」バッジを常時表示
+3. **バッジ表示/非表示の条件分岐がない** -- バッジなしパターンの画面が実装されていない
+4. **背景グラデーションが未実装** -- 仕様では orange-400 から orange-500 のグラデーションだが、現在は単色
+5. **紙吹雪演出がない** -- Rive 差し替え前の簡易アニメーション
+6. **地図画面に戻った際のピン出現アニメーションがない**
+
+## 関連ドキュメント
+
+- [要件定義](../product/requirements.md) -- 登録完了演出の仕様
+- [技術設計](../technical/tech-design.md) -- stamps テーブル構造
+- [UI設計 v6](../design/ui-design.md) -- セクション 4.6 登録完了画面
+
+## 詳細設計
+
+### 対象ファイル
+
+#### 新規作成
+
+| ファイル                                     | 説明                               |
+| -------------------------------------------- | ---------------------------------- |
+| `src/services/badges.ts`                     | バッジ定義とバッジ獲得判定ロジック |
+| `src/services/__tests__/badges.test.ts`      | badges サービスのテスト            |
+| `src/types/badge.ts`                         | バッジ関連の型定義                 |
+| `src/components/animated/ConfettiEffect.tsx` | 紙吹雪演出コンポーネント           |
+
+#### 変更
+
+| ファイル                                              | 変更内容                                                                |
+| ----------------------------------------------------- | ----------------------------------------------------------------------- |
+| `src/screens/RecordCompleteScreen.tsx`                | バッジ条件分岐、グラデーション背景、visitCount 表示改善、紙吹雪演出統合 |
+| `src/screens/__tests__/RecordCompleteScreen.test.tsx` | バッジあり/なしパターンのテスト拡充                                     |
+| `src/screens/RecordScreen.tsx`                        | handleConfirm で visitCount を取得して RecordComplete に渡す            |
+| `src/screens/__tests__/RecordScreen.test.tsx`         | visitCount パラメータ渡しのテスト追加                                   |
+| `src/components/animated/BadgeAnimation.tsx`          | アニメーション追加、表示/非表示の制御                                   |
+| `src/components/animated/CheckmarkAnimation.tsx`      | アニメーション追加（フェードイン + スケール）                           |
+| `src/components/__tests__/animated.test.tsx`          | ConfettiEffect テスト追加                                               |
+| `src/navigation/types.ts`                             | RecordComplete のパラメータに badge 情報を追加                          |
+
+### 実装方針
+
+#### コンポーネント構成
+
+```
+RecordCompleteScreen
+  +-- CheckmarkAnimation (フェードイン + スケールアニメーション)
+  +-- ConfettiEffect (紙吹雪演出、将来Rive差し替え)
+  +-- Image (御朱印画像)
+  +-- Text (スポット名)
+  +-- Text (訪問箇所数)
+  +-- BadgeAnimation (条件付き表示 + スケールインアニメーション)
+  +-- ActionButtons (もう1枚記録 / 地図を見る / コレクションを確認)
+```
+
+#### 状態管理・データフロー
+
+```
+RecordScreen
+  |-- submit() で stamp 作成
+  |-- fetchVisitedSpotIds() で記録前の訪問済みスポットID一覧を取得
+  |-- previousCount = visitedSpotIds.size
+  |-- stamp を作成
+  |-- isNewSpot = !visitedSpotIds.has(selectedSpot.id)
+  |-- currentCount = isNewSpot ? previousCount + 1 : previousCount
+  |-- evaluateNewBadge(previousCount, currentCount) でバッジ判定
+  |-- navigation.navigate('RecordComplete', {
+        stampImageUrl, spotName, visitCount: currentCount, badge
+      })
+
+RecordCompleteScreen
+  |-- route.params から受け取る
+  |-- badge が存在すれば BadgeAnimation を表示（バッジありパターン）
+  |-- badge が存在しなければ非表示（バッジなしパターン）
+```
+
+#### 背景グラデーション
+
+`expo-linear-gradient` を使用:
+
+```tsx
+<LinearGradient
+  colors={[colors.primary[400], colors.primary[500]]}
+  style={styles.container}
+>
+```
+
+### 型定義
+
+#### `src/types/badge.ts`
+
+```typescript
+export interface Badge {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  condition: BadgeCondition;
+}
+
+export interface BadgeCondition {
+  type: 'visit_count';
+  threshold: number;
+}
+
+export interface EarnedBadge {
+  badge: Badge;
+  earnedAt: string;
+}
+```
+
+#### navigation/types.ts の変更
+
+```typescript
+RecordComplete: {
+  stampImageUrl?: string;
+  spotName?: string;
+  visitCount?: number;
+  badge?: { name: string; description: string } | null;
+} | undefined;
+```
+
+### バッジ獲得判定ロジック
+
+MVP では訪問箇所数ベースの単純なバッジのみ:
+
+| バッジID    | 名前           | 閾値 |
+| ----------- | -------------- | ---- |
+| first-stamp | 初めての御朱印 | 1    |
+| visit-5     | 5箇所達成      | 5    |
+| visit-10    | 10箇所達成     | 10   |
+| visit-30    | 御朱印マスター | 30   |
+| visit-50    | 巡礼者         | 50   |
+| visit-100   | 全国制覇       | 100  |
+
+判定: `previousCount < threshold <= currentCount` のバッジのうち、最も高い閾値のものを1つ返す。
+
+### アニメーション設計
+
+- **CheckmarkAnimation**: フェードイン + スケール (0.3→1.0, 600ms)
+- **ConfettiEffect**: 10-15個の色付き矩形を上から降らせる (2000ms, 一回再生)
+- **BadgeAnimation**: 1000ms遅延後にスケールイン (0→1.1→1.0) + フェードイン
+
+## テスト方針
+
+### badges.ts
+
+- `evaluateNewBadge(0, 1)` -> 「初めての御朱印」
+- `evaluateNewBadge(4, 5)` -> 「5箇所達成」
+- `evaluateNewBadge(0, 10)` -> 「10箇所達成」（最も高い閾値のみ）
+- `evaluateNewBadge(5, 5)` -> null（再訪問）
+- `evaluateNewBadge(10, 11)` -> null（閾値を跨がない）
+
+### RecordCompleteScreen
+
+- バッジなし: BadgeAnimation が表示されない
+- バッジあり: バッジ名と説明が表示される
+- visitCount の正しい表示
+- グラデーション背景の存在確認
+- 3つのボタンの遷移先
+
+### RecordScreen
+
+- submit 成功後に visitCount と badge を含めて RecordComplete に遷移
+
+## チーム構成（3名）
+
+| メンバー    | サブエージェント      | 担当領域                                                            |
+| ----------- | --------------------- | ------------------------------------------------------------------- |
+| service-dev | `service-implementer` | バッジ判定サービス + 型定義 + RecordScreen の visitCount/badge 連携 |
+| ui-dev      | `ui-implementer`      | RecordCompleteScreen の UI 改修 + アニメーションコンポーネント      |
+| test-dev    | `test-writer`         | RecordCompleteScreen のテスト拡充                                   |
+
+### タスク分割
+
+#### service-dev: バッジ判定サービス + RecordScreen 連携
+
+担当ファイル:
+
+- `src/types/badge.ts` (新規)
+- `src/services/badges.ts` (新規)
+- `src/services/__tests__/badges.test.ts` (新規)
+- `src/navigation/types.ts` (変更)
+- `src/screens/RecordScreen.tsx` (変更)
+- `src/screens/__tests__/RecordScreen.test.tsx` (変更)
+
+タスク:
+
+1. Badge 型定義の作成
+2. バッジ定義と evaluateNewBadge ロジックの TDD 実装
+3. navigation/types.ts の RecordComplete パラメータ拡張
+4. RecordScreen の handleConfirm に visitCount 計算 + バッジ判定追加 + テスト更新
+5. getAllBadges 関数の実装
+
+#### ui-dev: 画面 UI + アニメーション
+
+担当ファイル:
+
+- `src/screens/RecordCompleteScreen.tsx` (変更)
+- `src/components/animated/CheckmarkAnimation.tsx` (変更)
+- `src/components/animated/BadgeAnimation.tsx` (変更)
+- `src/components/animated/ConfettiEffect.tsx` (新規)
+- `src/components/__tests__/animated.test.tsx` (変更)
+
+タスク:
+
+1. ConfettiEffect コンポーネントの TDD 実装
+2. CheckmarkAnimation のアニメーション拡張 + テスト
+3. BadgeAnimation の条件付き表示 + アニメーション拡張 + テスト
+4. RecordCompleteScreen にグラデーション背景を適用
+5. RecordCompleteScreen にバッジあり/なし条件分岐 + ConfettiEffect 統合
+6. RecordCompleteScreen のテスト更新
+
+#### test-dev: テスト拡充
+
+担当ファイル:
+
+- `src/screens/__tests__/RecordCompleteScreen.test.tsx` (変更)
+
+タスク:
+
+1. バッジなしパターンのテスト
+2. バッジありパターンのテスト
+3. visitCount の各パターンテスト
+4. グラデーション背景の存在確認テスト
+5. 全ボタンの遷移テスト
+
+### 依存関係
+
+```
+service-dev (型定義 + navigation/types.ts)
+    --> ui-dev (RecordCompleteScreen が badge params を参照)
+    --> test-dev (テストで badge params を使用)
+```
+
+service-dev のタスク 1-3 を最優先で完了させる。
+ui-dev はアニメーションコンポーネントの実装を先行開始可能。
+test-dev は既存テストの見直しを先行可能。
+
+## 注意事項
+
+1. `expo-linear-gradient` のインストール確認が必要
+2. Animated API で `useNativeDriver: true` を使用（ただし背景色等は false が必要）
+3. MVP ではバッジの獲得履歴をDBに保存しない（リアルタイム判定のみ）
+4. ピン出現アニメーションは MapScreen 改修を伴うため本 Issue スコープ外
+5. テスト内で `expo-linear-gradient` のモックが必要

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -105,6 +105,21 @@ jest.mock('react-native-maps', () => {
   return { __esModule: true, default: MockMapView, Marker: MockMarker, PROVIDER_GOOGLE: 'google' };
 });
 
+// expo-linear-gradient mock
+jest.mock('expo-linear-gradient', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    LinearGradient: React.forwardRef((props, ref) =>
+      React.createElement(
+        View,
+        { ...props, testID: props.testID || 'linear-gradient', ref },
+        props.children
+      )
+    ),
+  };
+});
+
 // expo-location mock
 jest.mock('expo-location', () => ({
   getForegroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo-camera": "~17.0.10",
         "expo-crypto": "~15.0.8",
         "expo-image-picker": "~17.0.10",
+        "expo-linear-gradient": "~15.0.8",
         "expo-location": "~19.0.8",
         "expo-sqlite": "~16.0.10",
         "expo-status-bar": "~3.0.9",
@@ -8070,6 +8071,17 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-15.0.8.tgz",
+      "integrity": "sha512-V2d8Wjn0VzhPHO+rrSBtcl+Fo+jUUccdlmQ6OoL9/XQB7Qk3d9lYrqKDJyccwDxmQT10JdST3Tmf2K52NLc3kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "expo-camera": "~17.0.10",
     "expo-crypto": "~15.0.8",
     "expo-image-picker": "~17.0.10",
+    "expo-linear-gradient": "~15.0.8",
     "expo-location": "~19.0.8",
     "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~3.0.9",

--- a/src/components/__tests__/animated.test.tsx
+++ b/src/components/__tests__/animated.test.tsx
@@ -5,6 +5,7 @@ import { CheckmarkAnimation } from '@components/animated/CheckmarkAnimation';
 import { BadgeAnimation } from '@components/animated/BadgeAnimation';
 import { OnboardingIcon } from '@components/animated/OnboardingIcon';
 import { ErrorIcon } from '@components/animated/ErrorIcon';
+import { ConfettiEffect } from '@components/animated/ConfettiEffect';
 
 describe('Animated Components', () => {
   describe('FABButton', () => {
@@ -38,6 +39,40 @@ describe('Animated Components', () => {
         <BadgeAnimation badgeName="初めての参拝" description="最初の御朱印を記録しました" />
       );
       expect(getByText('最初の御朱印を記録しました')).toBeTruthy();
+    });
+
+    it('renders nothing when badge is null', () => {
+      const { queryByTestId } = render(<BadgeAnimation badge={null} />);
+      expect(queryByTestId('badge-animation')).toBeNull();
+    });
+
+    it('renders nothing when badge is undefined', () => {
+      const { queryByTestId } = render(<BadgeAnimation badge={undefined} />);
+      expect(queryByTestId('badge-animation')).toBeNull();
+    });
+
+    it('renders with badge object', () => {
+      const badge = { name: '5箇所達成', description: '5つのスポットを訪問しました' };
+      const { getByTestId, getByText } = render(<BadgeAnimation badge={badge} />);
+      expect(getByTestId('badge-animation')).toBeTruthy();
+      expect(getByText('5箇所達成')).toBeTruthy();
+    });
+  });
+
+  describe('ConfettiEffect', () => {
+    it('renders without crashing', () => {
+      const { getByTestId } = render(<ConfettiEffect />);
+      expect(getByTestId('confetti-effect')).toBeTruthy();
+    });
+
+    it('renders when trigger is true', () => {
+      const { getByTestId } = render(<ConfettiEffect trigger={true} />);
+      expect(getByTestId('confetti-effect')).toBeTruthy();
+    });
+
+    it('renders when trigger is false', () => {
+      const { getByTestId } = render(<ConfettiEffect trigger={false} />);
+      expect(getByTestId('confetti-effect')).toBeTruthy();
     });
   });
 

--- a/src/components/animated/BadgeAnimation.tsx
+++ b/src/components/animated/BadgeAnimation.tsx
@@ -1,24 +1,77 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { View, Text, StyleSheet, Animated } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing } from '@theme/spacing';
 
-interface BadgeAnimationProps {
-  badgeName: string;
+interface BadgeData {
+  name: string;
   description?: string;
 }
 
-export const BadgeAnimation: React.FC<BadgeAnimationProps> = ({ badgeName, description }) => {
+interface BadgeAnimationProps {
+  // Legacy props (backward compat)
+  badgeName?: string;
+  description?: string;
+  // New unified prop
+  badge?: BadgeData | null;
+}
+
+export const BadgeAnimation: React.FC<BadgeAnimationProps> = ({
+  badgeName,
+  description,
+  badge,
+}) => {
+  const scale = useRef(new Animated.Value(0)).current;
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  const resolvedName = badge?.name ?? badgeName;
+  const resolvedDescription = badge?.description ?? description;
+
+  useEffect(() => {
+    if (!resolvedName) return;
+
+    scale.setValue(0);
+    opacity.setValue(0);
+
+    Animated.sequence([
+      Animated.delay(1000),
+      Animated.parallel([
+        Animated.sequence([
+          Animated.timing(scale, {
+            toValue: 1.1,
+            duration: 300,
+            useNativeDriver: true,
+          }),
+          Animated.timing(scale, {
+            toValue: 1.0,
+            duration: 150,
+            useNativeDriver: true,
+          }),
+        ]),
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 400,
+          useNativeDriver: true,
+        }),
+      ]),
+    ]).start();
+  }, [resolvedName, scale, opacity]);
+
+  if (!resolvedName) return null;
+
   return (
-    <View style={styles.container} testID="badge-animation">
+    <Animated.View
+      style={[styles.container, { transform: [{ scale }], opacity }]}
+      testID="badge-animation"
+    >
       <View style={styles.iconContainer}>
         <MaterialIcons name="military-tech" size={40} color={colors.warning} />
       </View>
-      <Text style={styles.name}>{badgeName}</Text>
-      {description && <Text style={styles.description}>{description}</Text>}
-    </View>
+      <Text style={styles.name}>{resolvedName}</Text>
+      {resolvedDescription && <Text style={styles.description}>{resolvedDescription}</Text>}
+    </Animated.View>
   );
 };
 

--- a/src/components/animated/CheckmarkAnimation.tsx
+++ b/src/components/animated/CheckmarkAnimation.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { colors } from '@theme/colors';
 
@@ -8,13 +8,35 @@ interface CheckmarkAnimationProps {
 }
 
 export const CheckmarkAnimation: React.FC<CheckmarkAnimationProps> = ({ size = 80 }) => {
+  const scale = useRef(new Animated.Value(0.3)).current;
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(scale, {
+        toValue: 1.0,
+        duration: 600,
+        useNativeDriver: true,
+      }),
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [scale, opacity]);
+
   return (
-    <View
-      style={[styles.container, { width: size, height: size, borderRadius: size / 2 }]}
+    <Animated.View
+      style={[
+        styles.container,
+        { width: size, height: size, borderRadius: size / 2 },
+        { transform: [{ scale }], opacity },
+      ]}
       testID="checkmark-animation"
     >
-      <MaterialIcons name="check" size={size * 0.6} color={colors.white} />
-    </View>
+      <MaterialIcons name="check" size={size * 0.6} color={colors.primary[500]} />
+    </Animated.View>
   );
 };
 
@@ -23,6 +45,5 @@ const styles = StyleSheet.create({
     backgroundColor: colors.white,
     alignItems: 'center',
     justifyContent: 'center',
-    opacity: 0.3,
   },
 });

--- a/src/components/animated/ConfettiEffect.tsx
+++ b/src/components/animated/ConfettiEffect.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Animated, StyleSheet, Dimensions } from 'react-native';
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+
+const CONFETTI_COLORS = [
+  '#F97316', // orange
+  '#EF4444', // red
+  '#A855F7', // purple
+  '#EAB308', // yellow
+  '#22C55E', // green
+  '#3B82F6', // blue
+];
+
+const CONFETTI_COUNT = 12;
+
+interface ConfettiPiece {
+  x: Animated.Value;
+  y: Animated.Value;
+  opacity: Animated.Value;
+  rotation: Animated.Value;
+  color: string;
+  left: number;
+}
+
+interface ConfettiEffectProps {
+  trigger?: boolean;
+}
+
+export const ConfettiEffect: React.FC<ConfettiEffectProps> = ({ trigger = true }) => {
+  const pieces = useRef<ConfettiPiece[]>(
+    Array.from({ length: CONFETTI_COUNT }, (_, i) => ({
+      x: new Animated.Value(0),
+      y: new Animated.Value(-20),
+      opacity: new Animated.Value(1),
+      rotation: new Animated.Value(0),
+      color: CONFETTI_COLORS[i % CONFETTI_COLORS.length],
+      left: Math.random() * SCREEN_WIDTH,
+    }))
+  ).current;
+
+  useEffect(() => {
+    if (!trigger) return;
+
+    const animations = pieces.map(piece => {
+      piece.x.setValue(0);
+      piece.y.setValue(-20);
+      piece.opacity.setValue(1);
+      piece.rotation.setValue(0);
+
+      const delay = Math.random() * 500;
+      const duration = 1500 + Math.random() * 500;
+
+      return Animated.parallel([
+        Animated.timing(piece.y, {
+          toValue: SCREEN_HEIGHT * 0.6,
+          duration,
+          delay,
+          useNativeDriver: true,
+        }),
+        Animated.timing(piece.x, {
+          toValue: (Math.random() - 0.5) * 100,
+          duration,
+          delay,
+          useNativeDriver: true,
+        }),
+        Animated.timing(piece.rotation, {
+          toValue: 360 * (Math.random() > 0.5 ? 1 : -1),
+          duration,
+          delay,
+          useNativeDriver: true,
+        }),
+        Animated.sequence([
+          Animated.delay(delay + duration * 0.7),
+          Animated.timing(piece.opacity, {
+            toValue: 0,
+            duration: duration * 0.3,
+            useNativeDriver: true,
+          }),
+        ]),
+      ]);
+    });
+
+    Animated.parallel(animations).start();
+  }, [trigger, pieces]);
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none" testID="confetti-effect">
+      {pieces.map((piece, i) => {
+        const rotate = piece.rotation.interpolate({
+          inputRange: [0, 360],
+          outputRange: ['0deg', '360deg'],
+        });
+        return (
+          <Animated.View
+            key={i}
+            style={[
+              styles.piece,
+              {
+                backgroundColor: piece.color,
+                left: piece.left,
+                transform: [{ translateX: piece.x }, { translateY: piece.y }, { rotate }],
+                opacity: piece.opacity,
+              },
+            ]}
+          />
+        );
+      })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  piece: {
+    position: 'absolute',
+    top: 0,
+    width: 8,
+    height: 8,
+    borderRadius: 2,
+  },
+});

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -8,7 +8,14 @@ export type RootStackParamList = {
   Onboarding: undefined;
   MainTabs: NavigatorScreenParams<MainTabParamList>;
   Record: { spotId?: string } | undefined;
-  RecordComplete: { stampImageUrl?: string; spotName?: string; visitCount?: number } | undefined;
+  RecordComplete:
+    | {
+        stampImageUrl?: string;
+        spotName?: string;
+        visitCount?: number;
+        badge?: { name: string; description: string } | null;
+      }
+    | undefined;
   Login: undefined;
   Error: { type: 'network' | 'location' | 'upload' };
 };

--- a/src/screens/RecordCompleteScreen.tsx
+++ b/src/screens/RecordCompleteScreen.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
-import { Image, StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+import React, { useState } from 'react';
+import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import { MaterialIcons } from '@expo/vector-icons';
 import { CheckmarkAnimation } from '@components/animated/CheckmarkAnimation';
 import { BadgeAnimation } from '@components/animated/BadgeAnimation';
+import { ConfettiEffect } from '@components/animated/ConfettiEffect';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing, borderRadius } from '@theme/spacing';
@@ -14,6 +17,8 @@ export function RecordCompleteScreen({ navigation, route }: Props) {
   const stampImageUrl = route.params?.stampImageUrl;
   const spotName = route.params?.spotName;
   const visitCount = route.params?.visitCount;
+  const badge = route.params?.badge;
+  const [imageError, setImageError] = useState(false);
 
   const handleRecordAnother = () => {
     navigation.navigate('Record');
@@ -28,69 +33,82 @@ export function RecordCompleteScreen({ navigation, route }: Props) {
   };
 
   return (
-    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
-      <View style={styles.content}>
-        <CheckmarkAnimation size={80} />
+    <LinearGradient
+      colors={[colors.primary[400], colors.primary[500]]}
+      style={styles.gradient}
+      testID="gradient-background"
+    >
+      <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+        <ConfettiEffect trigger={true} />
 
-        <Text style={styles.title}>登録完了！</Text>
+        <View style={styles.content}>
+          <CheckmarkAnimation size={80} />
 
-        {stampImageUrl ? (
-          <Image
-            source={{ uri: stampImageUrl }}
-            style={styles.stampImage}
-            resizeMode="cover"
-            testID="stamp-image"
-          />
-        ) : (
-          <View style={styles.imagePlaceholder} testID="stamp-image-placeholder" />
-        )}
+          <Text style={styles.title}>登録完了！</Text>
 
-        {spotName && (
-          <Text style={styles.spotName} testID="spot-name">
-            {spotName}
+          {stampImageUrl && !imageError ? (
+            <Image
+              source={{ uri: stampImageUrl }}
+              style={styles.stampImage}
+              resizeMode="cover"
+              testID="stamp-image"
+              onError={() => setImageError(true)}
+            />
+          ) : (
+            <View style={styles.imagePlaceholder} testID="stamp-image-placeholder">
+              <MaterialIcons name="photo" size={48} color="rgba(255,255,255,0.5)" />
+            </View>
+          )}
+
+          {spotName && (
+            <Text style={styles.spotName} testID="spot-name">
+              {spotName}
+            </Text>
+          )}
+
+          <Text style={styles.countText} testID="visit-count">
+            {visitCount ? `${visitCount}箇所目の御朱印！` : '御朱印を記録しました！'}
           </Text>
-        )}
 
-        <Text style={styles.countText} testID="visit-count">
-          {visitCount ? `${visitCount}箇所目の御朱印！` : '御朱印を記録しました！'}
-        </Text>
+          {badge && <BadgeAnimation badge={badge} />}
+        </View>
 
-        <BadgeAnimation badgeName="初めての御朱印" description="最初の御朱印を記録しました" />
-      </View>
+        <View style={styles.actions}>
+          <TouchableOpacity
+            style={styles.buttonRecordAnother}
+            onPress={handleRecordAnother}
+            testID="button-record-another"
+          >
+            <Text style={styles.buttonRecordAnotherText}>もう1枚記録する</Text>
+          </TouchableOpacity>
 
-      <View style={styles.actions}>
-        <TouchableOpacity
-          style={styles.buttonRecordAnother}
-          onPress={handleRecordAnother}
-          testID="button-record-another"
-        >
-          <Text style={styles.buttonRecordAnotherText}>もう1枚記録する</Text>
-        </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.buttonViewMap}
+            onPress={handleViewMap}
+            testID="button-view-map"
+          >
+            <Text style={styles.buttonViewMapText}>地図を見る</Text>
+          </TouchableOpacity>
 
-        <TouchableOpacity
-          style={styles.buttonViewMap}
-          onPress={handleViewMap}
-          testID="button-view-map"
-        >
-          <Text style={styles.buttonViewMapText}>地図を見る</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity
-          style={styles.buttonViewCollection}
-          onPress={handleViewCollection}
-          testID="button-view-collection"
-        >
-          <Text style={styles.buttonViewCollectionText}>コレクションを確認</Text>
-        </TouchableOpacity>
-      </View>
-    </SafeAreaView>
+          <TouchableOpacity
+            style={styles.buttonViewCollection}
+            onPress={handleViewCollection}
+            testID="button-view-collection"
+          >
+            <Text style={styles.buttonViewCollectionText}>コレクションを確認</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
+  gradient: {
+    flex: 1,
+  },
   container: {
     flex: 1,
-    backgroundColor: colors.primary[500],
   },
   content: {
     flex: 1,
@@ -107,12 +125,15 @@ const styles = StyleSheet.create({
     width: 160,
     height: 200,
     borderRadius: borderRadius.lg,
+    backgroundColor: 'rgba(255,255,255,0.2)',
   },
   imagePlaceholder: {
     width: 160,
     height: 200,
     borderRadius: borderRadius.lg,
     backgroundColor: 'rgba(255,255,255,0.2)',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   spotName: {
     ...typography.h3,

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -23,7 +23,8 @@ import { useRecordForm } from '@hooks/useRecordForm';
 import { useNearbySpots } from '@hooks/useNearbySpots';
 import { useAuth } from '@hooks/useAuth';
 import { useLocation } from '@hooks/useLocation';
-import { getStampImageUrl } from '@services/stamps';
+import { getStampImageUrl, fetchVisitedSpotIds } from '@services/stamps';
+import { evaluateNewBadge } from '@services/badges';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing, borderRadius } from '@theme/spacing';
@@ -54,12 +55,22 @@ export function RecordScreen({ navigation, route }: Props) {
   };
 
   const handleConfirm = async () => {
+    const visitedSpotIds = await fetchVisitedSpotIds();
+    const previousCount = visitedSpotIds.size;
+
     const result = await form.submit();
     setShowConfirm(false);
+
     if (result.success && result.stamp) {
+      const isNewSpot = form.selectedSpot ? !visitedSpotIds.has(form.selectedSpot.id) : false;
+      const currentCount = isNewSpot ? previousCount + 1 : previousCount;
+      const badge = evaluateNewBadge(previousCount, currentCount);
+
       navigation.navigate('RecordComplete', {
         stampImageUrl: getStampImageUrl(result.stamp.image_path),
         spotName: form.selectedSpot?.name,
+        visitCount: currentCount,
+        badge,
       });
     }
   };

--- a/src/screens/__tests__/RecordCompleteScreen.test.tsx
+++ b/src/screens/__tests__/RecordCompleteScreen.test.tsx
@@ -12,6 +12,18 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
+jest.mock('expo-linear-gradient', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    LinearGradient: ({ children, testID, ...props }: any) => (
+      <View testID={testID} {...props}>
+        {children}
+      </View>
+    ),
+  };
+});
+
 const mockNavigation = {
   navigate: jest.fn(),
   goBack: jest.fn(),
@@ -67,9 +79,26 @@ describe('RecordCompleteScreen', () => {
     expect(getByText('御朱印を記録しました！')).toBeTruthy();
   });
 
-  it('renders badge animation', () => {
-    const { getByTestId, getByText } = render(
+  it('does not render badge animation when no badge param', () => {
+    const { queryByTestId } = render(
       <RecordCompleteScreen navigation={mockNavigation} route={mockRouteNoParams} />
+    );
+    expect(queryByTestId('badge-animation')).toBeNull();
+  });
+
+  it('renders badge animation when badge param is provided', () => {
+    const routeWithBadge = {
+      key: 'test',
+      name: 'RecordComplete' as const,
+      params: {
+        stampImageUrl: undefined,
+        spotName: undefined,
+        visitCount: 1,
+        badge: { name: '初めての御朱印', description: '最初の御朱印を記録しました' },
+      },
+    };
+    const { getByTestId, getByText } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={routeWithBadge} />
     );
     expect(getByTestId('badge-animation')).toBeTruthy();
     expect(getByText('初めての御朱印')).toBeTruthy();
@@ -113,6 +142,41 @@ describe('RecordCompleteScreen', () => {
     });
   });
 
+  it('renders gradient background', () => {
+    const { getByTestId } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={mockRouteNoParams} />
+    );
+    expect(getByTestId('gradient-background')).toBeTruthy();
+  });
+
+  it('does not render badge animation when badge is null', () => {
+    const routeWithNullBadge = {
+      key: 'test',
+      name: 'RecordComplete' as const,
+      params: { visitCount: 5, badge: null },
+    };
+    const { queryByTestId } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={routeWithNullBadge} />
+    );
+    expect(queryByTestId('badge-animation')).toBeNull();
+  });
+
+  it('renders badge description when badge is provided', () => {
+    const routeWithBadge = {
+      key: 'test',
+      name: 'RecordComplete' as const,
+      params: {
+        visitCount: 1,
+        badge: { name: '初めての御朱印', description: '初めての御朱印を記録しました' },
+      },
+    };
+    const { getByText } = render(
+      <RecordCompleteScreen navigation={mockNavigation} route={routeWithBadge} />
+    );
+    expect(getByText('初めての御朱印')).toBeTruthy();
+    expect(getByText('初めての御朱印を記録しました')).toBeTruthy();
+  });
+
   describe('with params', () => {
     it('renders stamp image when stampImageUrl is provided', () => {
       const { getByTestId } = render(
@@ -133,6 +197,80 @@ describe('RecordCompleteScreen', () => {
         <RecordCompleteScreen navigation={mockNavigation} route={mockRouteWithParams} />
       );
       expect(getByText('5箇所目の御朱印！')).toBeTruthy();
+    });
+
+    it('renders "1箇所目の御朱印！" for visitCount=1', () => {
+      const routeCount1 = {
+        key: 'test',
+        name: 'RecordComplete' as const,
+        params: { visitCount: 1 },
+      };
+      const { getByText } = render(
+        <RecordCompleteScreen navigation={mockNavigation} route={routeCount1} />
+      );
+      expect(getByText('1箇所目の御朱印！')).toBeTruthy();
+    });
+
+    it('renders "33箇所目の御朱印！" for visitCount=33', () => {
+      const routeCount33 = {
+        key: 'test',
+        name: 'RecordComplete' as const,
+        params: { visitCount: 33 },
+      };
+      const { getByText } = render(
+        <RecordCompleteScreen navigation={mockNavigation} route={routeCount33} />
+      );
+      expect(getByText('33箇所目の御朱印！')).toBeTruthy();
+    });
+  });
+
+  describe('with badge', () => {
+    const mockRouteWithBadge = {
+      key: 'test',
+      name: 'RecordComplete' as const,
+      params: {
+        stampImageUrl: 'https://example.com/stamps/user-1/12345.jpg',
+        spotName: '大崎八幡宮',
+        visitCount: 1,
+        badge: { name: '初めての御朱印', description: '初めての御朱印を記録しました' },
+      },
+    };
+
+    it('navigates to Record when "record another" is pressed with badge', () => {
+      const { getByTestId } = render(
+        <RecordCompleteScreen navigation={mockNavigation} route={mockRouteWithBadge} />
+      );
+      fireEvent.press(getByTestId('button-record-another'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('Record');
+    });
+
+    it('navigates to Map when "view map" is pressed with badge', () => {
+      const { getByTestId } = render(
+        <RecordCompleteScreen navigation={mockNavigation} route={mockRouteWithBadge} />
+      );
+      fireEvent.press(getByTestId('button-view-map'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('MainTabs', {
+        screen: 'MapTab',
+        params: { screen: 'Map' },
+      });
+    });
+
+    it('navigates to Collection when "view collection" is pressed with badge', () => {
+      const { getByTestId } = render(
+        <RecordCompleteScreen navigation={mockNavigation} route={mockRouteWithBadge} />
+      );
+      fireEvent.press(getByTestId('button-view-collection'));
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('MainTabs', {
+        screen: 'Collection',
+      });
+    });
+
+    it('renders both badge animation and visit count when both are provided', () => {
+      const { getByTestId, getByText } = render(
+        <RecordCompleteScreen navigation={mockNavigation} route={mockRouteWithBadge} />
+      );
+      expect(getByText('1箇所目の御朱印！')).toBeTruthy();
+      expect(getByTestId('badge-animation')).toBeTruthy();
     });
   });
 });

--- a/src/screens/__tests__/RecordScreen.test.tsx
+++ b/src/screens/__tests__/RecordScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { RecordScreen } from '@screens/RecordScreen';
+import { evaluateNewBadge } from '@services/badges';
 import type { Spot, Stamp } from '@/types/supabase';
 
 jest.mock('react-native-safe-area-context', () => {
@@ -85,8 +86,15 @@ jest.mock('expo-image-picker', () => ({
   launchImageLibraryAsync: jest.fn(),
 }));
 
+const mockFetchVisitedSpotIds = jest.fn();
+
 jest.mock('@services/stamps', () => ({
   getStampImageUrl: (path: string) => `https://example.com/stamps/${path}`,
+  fetchVisitedSpotIds: (...args: unknown[]) => mockFetchVisitedSpotIds(...args),
+}));
+
+jest.mock('@services/badges', () => ({
+  evaluateNewBadge: jest.fn(() => null),
 }));
 
 jest.mock('@services/spots', () => ({
@@ -191,6 +199,7 @@ describe('RecordScreen', () => {
     mockFormState.selectedSpot = fakeSpot;
     mockFormState.imageUri = 'file:///photo.jpg';
     mockSubmit.mockResolvedValue({ success: true, stamp: fakeStamp });
+    mockFetchVisitedSpotIds.mockResolvedValue(new Set(['spot-2']));
 
     const { getByText } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
 
@@ -203,6 +212,107 @@ describe('RecordScreen', () => {
     await waitFor(() => {
       expect(mockSubmit).toHaveBeenCalled();
       expect(mockNavigation.navigate).toHaveBeenCalledWith('RecordComplete', expect.any(Object));
+    });
+  });
+
+  it('navigates to RecordComplete with visitCount when recording new spot', async () => {
+    const fakeStamp: Stamp = {
+      id: 'stamp-1',
+      user_id: 'user-1',
+      spot_id: 'spot-1',
+      goshuincho_id: null,
+      visited_at: '2024-06-01T00:00:00.000Z',
+      image_path: 'user-1/12345.jpg',
+      memo: '',
+      created_at: '2024-06-01T00:00:00Z',
+      updated_at: '2024-06-01T00:00:00Z',
+    };
+
+    mockFormState.selectedSpot = fakeSpot;
+    mockFormState.imageUri = 'file:///photo.jpg';
+    mockSubmit.mockResolvedValue({ success: true, stamp: fakeStamp });
+    // spot-1 is NOT in visited set -> new spot
+    mockFetchVisitedSpotIds.mockResolvedValue(new Set(['spot-2', 'spot-3']));
+
+    const { getByText } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(getByText('この内容で記録する'));
+    fireEvent.press(getByText('登録する'));
+
+    await waitFor(() => {
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        'RecordComplete',
+        expect.objectContaining({
+          visitCount: 3, // previousCount=2 + 1 new spot
+        })
+      );
+    });
+  });
+
+  it('navigates to RecordComplete with visitCount when re-visiting spot', async () => {
+    const fakeStamp: Stamp = {
+      id: 'stamp-2',
+      user_id: 'user-1',
+      spot_id: 'spot-1',
+      goshuincho_id: null,
+      visited_at: '2024-06-01T00:00:00.000Z',
+      image_path: 'user-1/12345.jpg',
+      memo: '',
+      created_at: '2024-06-01T00:00:00Z',
+      updated_at: '2024-06-01T00:00:00Z',
+    };
+
+    mockFormState.selectedSpot = fakeSpot;
+    mockFormState.imageUri = 'file:///photo.jpg';
+    mockSubmit.mockResolvedValue({ success: true, stamp: fakeStamp });
+    // spot-1 is already in visited set -> re-visit
+    mockFetchVisitedSpotIds.mockResolvedValue(new Set(['spot-1', 'spot-2']));
+
+    const { getByText } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(getByText('この内容で記録する'));
+    fireEvent.press(getByText('登録する'));
+
+    await waitFor(() => {
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        'RecordComplete',
+        expect.objectContaining({
+          visitCount: 2, // previousCount=2, no change for re-visit
+        })
+      );
+    });
+  });
+
+  it('navigates to RecordComplete with badge when badge is earned', async () => {
+    const fakeStamp: Stamp = {
+      id: 'stamp-1',
+      user_id: 'user-1',
+      spot_id: 'spot-1',
+      goshuincho_id: null,
+      visited_at: '2024-06-01T00:00:00.000Z',
+      image_path: 'user-1/12345.jpg',
+      memo: '',
+      created_at: '2024-06-01T00:00:00Z',
+      updated_at: '2024-06-01T00:00:00Z',
+    };
+
+    const mockBadge = { name: '初めての御朱印', description: '初めての御朱印を記録しました' };
+    (evaluateNewBadge as jest.Mock).mockReturnValue(mockBadge);
+
+    mockFormState.selectedSpot = fakeSpot;
+    mockFormState.imageUri = 'file:///photo.jpg';
+    mockSubmit.mockResolvedValue({ success: true, stamp: fakeStamp });
+    mockFetchVisitedSpotIds.mockResolvedValue(new Set());
+
+    const { getByText } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(getByText('この内容で記録する'));
+    fireEvent.press(getByText('登録する'));
+
+    await waitFor(() => {
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        'RecordComplete',
+        expect.objectContaining({
+          badge: mockBadge,
+        })
+      );
     });
   });
 

--- a/src/services/__tests__/badges.test.ts
+++ b/src/services/__tests__/badges.test.ts
@@ -1,0 +1,52 @@
+import { evaluateNewBadge, getAllBadges } from '@services/badges';
+
+describe('badges service', () => {
+  describe('evaluateNewBadge', () => {
+    it('returns "初めての御朱印" badge when visiting first spot', () => {
+      const result = evaluateNewBadge(0, 1);
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('初めての御朱印');
+    });
+
+    it('returns "5箇所達成" badge when reaching 5 spots', () => {
+      const result = evaluateNewBadge(4, 5);
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('5箇所達成');
+    });
+
+    it('returns only the highest threshold badge when skipping multiple thresholds', () => {
+      const result = evaluateNewBadge(0, 10);
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('10箇所達成');
+    });
+
+    it('returns null when count does not cross any threshold (re-visit)', () => {
+      const result = evaluateNewBadge(5, 5);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when count does not cross any threshold', () => {
+      const result = evaluateNewBadge(10, 11);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getAllBadges', () => {
+    it('returns all 6 badge definitions', () => {
+      const badges = getAllBadges();
+      expect(badges).toHaveLength(6);
+    });
+
+    it('includes badges with required fields', () => {
+      const badges = getAllBadges();
+      for (const badge of badges) {
+        expect(badge).toHaveProperty('id');
+        expect(badge).toHaveProperty('name');
+        expect(badge).toHaveProperty('description');
+        expect(badge).toHaveProperty('icon');
+        expect(badge.condition.type).toBe('visit_count');
+        expect(typeof badge.condition.threshold).toBe('number');
+      }
+    });
+  });
+});

--- a/src/services/__tests__/stamps-create.test.ts
+++ b/src/services/__tests__/stamps-create.test.ts
@@ -17,34 +17,26 @@ jest.mock('@services/supabase', () => ({
   },
 }));
 
-const mockFetch = jest.fn();
-(global as unknown as { fetch: jest.Mock }).fetch = mockFetch;
-
 describe('uploadStampImage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('returns uploaded path on success', async () => {
-    const mockBlob = new Blob(['image-data'], { type: 'image/jpeg' });
-    mockFetch.mockResolvedValue({ blob: () => Promise.resolve(mockBlob) });
     mockUpload.mockResolvedValue({ data: { path: 'user-1/12345-abc.jpg' }, error: null });
 
     const result = await uploadStampImage('user-1', 'file:///photo.jpg');
 
-    expect(mockFetch).toHaveBeenCalledWith('file:///photo.jpg');
     expect(mockUpload).toHaveBeenCalledWith(
       expect.stringMatching(/^user-1\/\d+-[a-z0-9]+\.jpg$/),
-      mockBlob,
-      { contentType: 'image/jpeg' }
+      expect.any(FormData),
+      { contentType: 'multipart/form-data' }
     );
     expect(typeof result).toBe('string');
     expect(result).toMatch(/^user-1\//);
   });
 
   it('throws error when upload fails', async () => {
-    const mockBlob = new Blob(['image-data'], { type: 'image/jpeg' });
-    mockFetch.mockResolvedValue({ blob: () => Promise.resolve(mockBlob) });
     mockUpload.mockResolvedValue({ data: null, error: { message: 'Upload failed' } });
 
     await expect(uploadStampImage('user-1', 'file:///photo.jpg')).rejects.toThrow('Upload failed');

--- a/src/services/badges.ts
+++ b/src/services/badges.ts
@@ -1,0 +1,66 @@
+import type { Badge } from '@/types/badge';
+
+export const BADGE_DEFINITIONS: Badge[] = [
+  {
+    id: 'first-stamp',
+    name: '初めての御朱印',
+    description: '初めての御朱印を記録しました',
+    icon: '🎊',
+    condition: { type: 'visit_count', threshold: 1 },
+  },
+  {
+    id: 'visit-5',
+    name: '5箇所達成',
+    description: '5箇所の神社仏閣を訪れました',
+    icon: '⛩️',
+    condition: { type: 'visit_count', threshold: 5 },
+  },
+  {
+    id: 'visit-10',
+    name: '10箇所達成',
+    description: '10箇所の神社仏閣を訪れました',
+    icon: '🏆',
+    condition: { type: 'visit_count', threshold: 10 },
+  },
+  {
+    id: 'visit-30',
+    name: '御朱印マスター',
+    description: '30箇所の神社仏閣を訪れました',
+    icon: '🌟',
+    condition: { type: 'visit_count', threshold: 30 },
+  },
+  {
+    id: 'visit-50',
+    name: '巡礼者',
+    description: '50箇所の神社仏閣を訪れました',
+    icon: '🗾',
+    condition: { type: 'visit_count', threshold: 50 },
+  },
+  {
+    id: 'visit-100',
+    name: '全国制覇',
+    description: '100箇所の神社仏閣を訪れました',
+    icon: '👑',
+    condition: { type: 'visit_count', threshold: 100 },
+  },
+];
+
+export function evaluateNewBadge(
+  previousCount: number,
+  currentCount: number
+): { name: string; description: string } | null {
+  const earned = BADGE_DEFINITIONS.filter(
+    badge => previousCount < badge.condition.threshold && badge.condition.threshold <= currentCount
+  );
+
+  if (earned.length === 0) return null;
+
+  // Return the highest threshold badge
+  const highest = earned.reduce((a, b) => (a.condition.threshold > b.condition.threshold ? a : b));
+
+  return { name: highest.name, description: highest.description };
+}
+
+export function getAllBadges(): Badge[] {
+  return BADGE_DEFINITIONS;
+}

--- a/src/services/stamps.ts
+++ b/src/services/stamps.ts
@@ -28,13 +28,20 @@ export async function fetchStampsBySpotId(spotId: string): Promise<Stamp[]> {
 }
 
 export async function uploadStampImage(userId: string, imageUri: string): Promise<string> {
-  const response = await fetch(imageUri);
-  const blob = await response.blob();
   const filePath = `${userId}/${Date.now()}-${Math.random().toString(36).slice(2, 8)}.jpg`;
+
+  // React Native では fetch(localUri).blob() が空の Blob を返すため、
+  // FormData を使ってアップロードする
+  const formData = new FormData();
+  formData.append('', {
+    uri: imageUri,
+    name: filePath.split('/').pop(),
+    type: 'image/jpeg',
+  } as unknown as Blob);
 
   const { data, error } = await supabase.storage
     .from('goshuin-images')
-    .upload(filePath, blob, { contentType: 'image/jpeg' });
+    .upload(filePath, formData, { contentType: 'multipart/form-data' });
 
   if (error) {
     throw new Error(error.message);

--- a/src/types/badge.ts
+++ b/src/types/badge.ts
@@ -1,0 +1,17 @@
+export interface Badge {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  condition: BadgeCondition;
+}
+
+export interface BadgeCondition {
+  type: 'visit_count';
+  threshold: number;
+}
+
+export interface EarnedBadge {
+  badge: Badge;
+  earnedAt: string;
+}


### PR DESCRIPTION
## Summary
- 御朱印登録完了後の達成感演出画面を実装（バッジあり/なしの2パターン）
- バッジ獲得判定ロジック（訪問箇所数ベース、6段階）を追加
- 画像アップロードのFormData修正（React Nativeのfetch().blob()が空を返す問題を解消）

## Changes
- `src/types/badge.ts` - バッジ型定義
- `src/services/badges.ts` - バッジ定義と獲得判定ロジック（evaluateNewBadge / getAllBadges）
- `src/screens/RecordCompleteScreen.tsx` - グラデーション背景、紙吹雪演出、バッジ条件分岐、画像表示
- `src/screens/RecordScreen.tsx` - visitCount計算 + バッジ判定をhandleConfirmに追加
- `src/components/animated/ConfettiEffect.tsx` - 紙吹雪演出コンポーネント（将来Rive差し替え用）
- `src/components/animated/CheckmarkAnimation.tsx` - フェードイン + スケールアニメーション追加
- `src/components/animated/BadgeAnimation.tsx` - 条件付き表示 + スケールインアニメーション追加
- `src/services/stamps.ts` - uploadStampImageをFormDataベースに修正
- `src/navigation/types.ts` - RecordCompleteパラメータにbadge/visitCount追加

## Test plan
- [x] テスト: 348件全パス
- [x] Lint: エラー0件
- [x] 型チェック: エラー0件
- [x] Expo Go実機確認: 登録完了画面の表示、画像表示、紙吹雪演出、チェックマーク、ボタン遷移

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)