### PR TITLE
feat(gallery): ギャラリー画面・御朱印詳細画面の実装

### DIFF
--- a/docs/issues/issue-016-gallery-screen.md
+++ b/docs/issues/issue-016-gallery-screen.md
@@ -1,0 +1,123 @@
+# Issue #16: ギャラリー画面の実装
+
+## 概要
+
+記録した御朱印を3列グリッド表示するギャラリー画面を実装する。
+現在の `GalleryScreen` はMOCKデータのスケルトン実装のみで、以下の機能が不足:
+
+1. Supabaseからの実データ取得（スポット名JOIN含む）
+2. 実際のソートロジック（日付順/スポット名あいうえお順）
+3. 実画像表示（Image コンポーネント）
+4. ローディング状態の表示
+5. 空の状態表示
+6. 無料版制限（直近20件）とプレミアム誘導バナー
+7. StampDetailScreen のスタンプ詳細の実データ表示
+
+## 関連ドキュメント
+
+- [要件定義](../product/requirements.md)
+- [技術設計](../technical/tech-design.md)
+- [UI設計 v6](../design/ui-design.md) - セクション 4.7 ギャラリー画面
+
+## 詳細設計
+
+### 対象ファイル
+
+#### 新規作成
+
+| ファイル                                       | 説明                             |
+| ---------------------------------------------- | -------------------------------- |
+| `src/hooks/useGalleryStamps.ts`                | ギャラリー用スタンプ一覧取得Hook |
+| `src/hooks/__tests__/useGalleryStamps.test.ts` | useGalleryStamps のテスト        |
+
+#### 変更
+
+| ファイル                                           | 変更内容                                                                  |
+| -------------------------------------------------- | ------------------------------------------------------------------------- |
+| `src/services/stamps.ts`                           | `fetchAllStamps` / `fetchStampById` 関数追加                              |
+| `src/services/__tests__/stamps.test.ts`            | 新規関数のテスト追加                                                      |
+| `src/screens/GalleryScreen.tsx`                    | MOCK撤廃・実データ接続・Image表示・ローディング・空表示・プレミアムバナー |
+| `src/screens/__tests__/GalleryScreen.test.tsx`     | 実データ対応テスト追加                                                    |
+| `src/screens/StampDetailScreen.tsx`                | stampId から実データ取得・Image表示                                       |
+| `src/screens/__tests__/StampDetailScreen.test.tsx` | 実データ対応テスト追加                                                    |
+| `src/types/supabase.ts`                            | `StampWithSpot` 型定義追加                                                |
+
+### サービス層設計
+
+#### fetchAllStamps
+
+```typescript
+export interface StampWithSpot extends Stamp {
+  spots: { name: string; type: SpotType };
+}
+
+export async function fetchAllStamps(userId: string): Promise<StampWithSpot[]> {
+  const { data, error } = await supabase
+    .from('stamps')
+    .select('*, spots!inner(name, type)')
+    .eq('user_id', userId)
+    .order('visited_at', { ascending: false });
+}
+```
+
+#### fetchStampById
+
+```typescript
+export async function fetchStampById(stampId: string): Promise<StampWithSpot | null> {
+  const { data, error } = await supabase
+    .from('stamps')
+    .select('*, spots!inner(name, type)')
+    .eq('id', stampId)
+    .single();
+}
+```
+
+### useGalleryStamps Hook
+
+```typescript
+type SortOrder = 'date' | 'spot';
+
+interface UseGalleryStampsReturn {
+  stamps: StampWithSpot[];
+  totalCount: number;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useGalleryStamps(sortOrder: SortOrder): UseGalleryStampsReturn;
+```
+
+ロジック:
+
+- `useAuth` で userId 取得
+- `fetchAllStamps(userId)` 呼び出し
+- `sortOrder === 'spot'` → `localeCompare('ja')` でソート
+- `totalCount = allStamps.length`
+- `stamps = sorted.slice(0, 20)` で無料版制限
+
+### チーム構成
+
+2名構成:
+
+#### service-implementer
+
+- `src/services/stamps.ts` (fetchAllStamps / fetchStampById 追加)
+- `src/services/__tests__/stamps.test.ts`
+- `src/hooks/useGalleryStamps.ts` (新規)
+- `src/hooks/__tests__/useGalleryStamps.test.ts` (新規)
+- `src/types/supabase.ts` (StampWithSpot 型追加)
+
+#### ui-implementer
+
+- `src/screens/GalleryScreen.tsx`
+- `src/screens/__tests__/GalleryScreen.test.tsx`
+- `src/screens/StampDetailScreen.tsx`
+- `src/screens/__tests__/StampDetailScreen.test.tsx`
+
+### 注意事項
+
+1. StampWithSpot 型は `src/types/supabase.ts` に追加
+2. Image の uri: `getStampImageUrl(stamp.image_path)` で Supabase Storage URL生成
+3. 日付フォーマット: `visited_at` → `YYYY/MM/DD` 形式
+4. プレミアムバナーのアップグレードボタン: MVP では Alert.alert で代替
+5. FlatList `numColumns=3` + `key={sortOrder}` でソート切替時のクラッシュ防止

--- a/src/hooks/__tests__/useGalleryStamps.test.ts
+++ b/src/hooks/__tests__/useGalleryStamps.test.ts
@@ -1,0 +1,131 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useGalleryStamps } from '@hooks/useGalleryStamps';
+import type { StampWithSpot } from '@/types/supabase';
+
+const mockFetchAllStamps = jest.fn();
+
+jest.mock('@services/stamps', () => ({
+  fetchAllStamps: (...args: unknown[]) => mockFetchAllStamps(...args),
+}));
+
+let mockUser: { id: string } | null = null;
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: mockUser,
+  }),
+}));
+
+const makeStampWithSpot = (overrides: Partial<StampWithSpot> = {}): StampWithSpot => ({
+  id: 'stamp-1',
+  user_id: 'user-1',
+  spot_id: 'spot-1',
+  goshuincho_id: null,
+  visited_at: '2024-06-01',
+  image_path: 'img/1.jpg',
+  memo: null,
+  created_at: '2024-06-01',
+  updated_at: '2024-06-01',
+  spots: { name: '伊勢神宮', type: 'shrine' },
+  ...overrides,
+});
+
+describe('useGalleryStamps', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = null;
+  });
+
+  it('未認証時: 空配列を返し isLoading=false になる', async () => {
+    mockUser = null;
+
+    const { result } = renderHook(() => useGalleryStamps('date'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.stamps).toEqual([]);
+    expect(result.current.totalCount).toBe(0);
+    expect(mockFetchAllStamps).not.toHaveBeenCalled();
+  });
+
+  it('認証済み: fetchAllStamps が userId で呼ばれる', async () => {
+    mockUser = { id: 'user-1' };
+    mockFetchAllStamps.mockResolvedValue([makeStampWithSpot()]);
+
+    const { result } = renderHook(() => useGalleryStamps('date'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockFetchAllStamps).toHaveBeenCalledWith('user-1');
+  });
+
+  it('日付順: API のソート順のまま返る', async () => {
+    mockUser = { id: 'user-1' };
+    const stamps = [
+      makeStampWithSpot({ id: 'stamp-1', visited_at: '2024-06-01' }),
+      makeStampWithSpot({ id: 'stamp-2', visited_at: '2024-01-15' }),
+    ];
+    mockFetchAllStamps.mockResolvedValue(stamps);
+
+    const { result } = renderHook(() => useGalleryStamps('date'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.stamps[0].id).toBe('stamp-1');
+    expect(result.current.stamps[1].id).toBe('stamp-2');
+  });
+
+  it('スポット順: localeCompare("ja") でソートされる', async () => {
+    mockUser = { id: 'user-1' };
+    const stamps = [
+      makeStampWithSpot({ id: 'stamp-1', spots: { name: '浅草寺', type: 'temple' } }),
+      makeStampWithSpot({ id: 'stamp-2', spots: { name: '伊勢神宮', type: 'shrine' } }),
+      makeStampWithSpot({ id: 'stamp-3', spots: { name: '金閣寺', type: 'temple' } }),
+    ];
+    mockFetchAllStamps.mockResolvedValue(stamps);
+
+    const { result } = renderHook(() => useGalleryStamps('spot'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const names = result.current.stamps.map(s => s.spots.name);
+    expect(names).toEqual(['伊勢神宮', '金閣寺', '浅草寺']);
+  });
+
+  it('20件超: 20件に制限、totalCount は全件数', async () => {
+    mockUser = { id: 'user-1' };
+    const stamps = Array.from({ length: 25 }, (_, i) => makeStampWithSpot({ id: `stamp-${i}` }));
+    mockFetchAllStamps.mockResolvedValue(stamps);
+
+    const { result } = renderHook(() => useGalleryStamps('date'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.stamps).toHaveLength(20);
+    expect(result.current.totalCount).toBe(25);
+  });
+
+  it('フェッチエラー: error がセットされる', async () => {
+    mockUser = { id: 'user-1' };
+    mockFetchAllStamps.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useGalleryStamps('date'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.stamps).toEqual([]);
+    expect(result.current.error).toBe('Network error');
+  });
+});

--- a/src/hooks/useGalleryStamps.ts
+++ b/src/hooks/useGalleryStamps.ts
@@ -1,0 +1,70 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useAuth } from '@hooks/useAuth';
+import { fetchAllStamps } from '@services/stamps';
+import type { StampWithSpot } from '@/types/supabase';
+
+export type SortOrder = 'date' | 'spot';
+
+const FREE_LIMIT = 20;
+
+interface UseGalleryStampsReturn {
+  stamps: StampWithSpot[];
+  totalCount: number;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useGalleryStamps(sortOrder: SortOrder): UseGalleryStampsReturn {
+  const { user } = useAuth();
+  const [allStamps, setAllStamps] = useState<StampWithSpot[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      setAllStamps([]);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        setIsLoading(true);
+        const data = await fetchAllStamps(user.id);
+        if (!cancelled) {
+          setAllStamps(data);
+          setError(null);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setAllStamps([]);
+          setError(e instanceof Error ? e.message : '取得に失敗しました');
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const stamps = useMemo(() => {
+    const sorted = [...allStamps];
+    if (sortOrder === 'spot') {
+      sorted.sort((a, b) => a.spots.name.localeCompare(b.spots.name, 'ja'));
+    }
+    // date order is already sorted from API (visited_at DESC)
+    return sorted.slice(0, FREE_LIMIT);
+  }, [allStamps, sortOrder]);
+
+  return {
+    stamps,
+    totalCount: allStamps.length,
+    isLoading,
+    error,
+  };
+}

--- a/src/navigation/__tests__/TabNavigator.test.tsx
+++ b/src/navigation/__tests__/TabNavigator.test.tsx
@@ -86,6 +86,28 @@ jest.mock('@services/stamps', () => ({
   getStampImageUrl: (path: string) => `https://example.com/stamps/${path}`,
 }));
 
+jest.mock('@hooks/useGalleryStamps', () => ({
+  useGalleryStamps: () => ({
+    stamps: [
+      {
+        id: 'stamp-1',
+        user_id: 'user-1',
+        spot_id: 'spot-1',
+        goshuincho_id: null,
+        visited_at: '2024-06-01',
+        image_path: 'img/1.jpg',
+        memo: null,
+        created_at: '2024-06-01',
+        updated_at: '2024-06-01',
+        spots: { name: '明治神宮', type: 'shrine' },
+      },
+    ],
+    totalCount: 1,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
 // Wrap TabNavigator in a RootStack to support Login navigation
 const Stack = createNativeStackNavigator<RootStackParamList>();
 

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -1,30 +1,26 @@
 import React, { useState } from 'react';
-import { StyleSheet, Text, View, FlatList, TouchableOpacity, Dimensions } from 'react-native';
+import {
+  StyleSheet,
+  Text,
+  View,
+  FlatList,
+  TouchableOpacity,
+  Dimensions,
+  Image,
+  ActivityIndicator,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { MaterialIcons } from '@expo/vector-icons';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing, borderRadius } from '@theme/spacing';
+import { useGalleryStamps } from '@hooks/useGalleryStamps';
+import { getStampImageUrl } from '@services/stamps';
+import type { StampWithSpot } from '@/types/supabase';
 import type { GalleryStackScreenProps } from '@/navigation/types';
 
 type Props = GalleryStackScreenProps<'Gallery'>;
-
-interface GalleryItem {
-  id: string;
-  spotName: string;
-  date: string;
-}
-
-const MOCK_DATA: GalleryItem[] = [
-  { id: '1', spotName: '明治神宮', date: '2024/01/15' },
-  { id: '2', spotName: '浅草寺', date: '2024/01/10' },
-  { id: '3', spotName: '伏見稲荷大社', date: '2024/01/05' },
-  { id: '4', spotName: '東京大神宮', date: '2023/12/28' },
-  { id: '5', spotName: '鶴岡八幡宮', date: '2023/12/20' },
-  { id: '6', spotName: '清水寺', date: '2023/12/15' },
-  { id: '7', spotName: '出雲大社', date: '2023/12/10' },
-  { id: '8', spotName: '厳島神社', date: '2023/12/05' },
-  { id: '9', spotName: '金閣寺', date: '2023/11/30' },
-];
+type SortOrder = 'date' | 'spot';
 
 const NUM_COLUMNS = 3;
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -32,29 +28,40 @@ const ITEM_MARGIN = spacing.xs;
 const ITEM_SIZE = (SCREEN_WIDTH - spacing.lg * 2 - ITEM_MARGIN * (NUM_COLUMNS - 1)) / NUM_COLUMNS;
 
 export function GalleryScreen({ navigation }: Props) {
-  const [sortLabel, setSortLabel] = useState('日付順');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('date');
+  const { stamps, totalCount, isLoading } = useGalleryStamps(sortOrder);
+
+  const sortLabel = sortOrder === 'date' ? '日付順' : 'スポット順';
 
   const handleToggleSort = () => {
-    setSortLabel(prev => (prev === '日付順' ? 'スポット順' : '日付順'));
+    setSortOrder(prev => (prev === 'date' ? 'spot' : 'date'));
   };
 
-  const handleItemPress = (item: GalleryItem) => {
-    navigation.navigate('StampDetail', { stampId: item.id });
+  const handleItemPress = (stamp: StampWithSpot) => {
+    navigation.navigate('StampDetail', { stampId: stamp.id });
   };
 
-  const renderItem = ({ item, index }: { item: GalleryItem; index: number }) => {
+  const formatDate = (dateStr: string) => dateStr.replace(/-/g, '/');
+
+  const renderItem = ({ item, index }: { item: StampWithSpot; index: number }) => {
     const isMiddleColumn = index % NUM_COLUMNS === 1;
+    const imageUrl = getStampImageUrl(item.image_path);
+
     return (
       <TouchableOpacity
         style={[styles.gridItem, isMiddleColumn && styles.gridItemMiddle]}
         onPress={() => handleItemPress(item)}
         testID={`gallery-item-${item.id}`}
       >
-        <View style={styles.imagePlaceholder} />
+        <Image
+          source={{ uri: imageUrl }}
+          style={styles.stampImage}
+          testID={`stamp-image-${item.id}`}
+        />
         <Text style={styles.itemSpotName} numberOfLines={1}>
-          {item.spotName}
+          {item.spots.name}
         </Text>
-        <Text style={styles.itemDate}>{item.date}</Text>
+        {sortOrder === 'date' && <Text style={styles.itemDate}>{formatDate(item.visited_at)}</Text>}
       </TouchableOpacity>
     );
   };
@@ -71,14 +78,34 @@ export function GalleryScreen({ navigation }: Props) {
         </TouchableOpacity>
       </View>
 
-      <FlatList
-        data={MOCK_DATA}
-        renderItem={renderItem}
-        keyExtractor={item => item.id}
-        numColumns={NUM_COLUMNS}
-        contentContainerStyle={styles.listContent}
-        testID="gallery-list"
-      />
+      {isLoading ? (
+        <View style={styles.centerContainer}>
+          <ActivityIndicator size="large" color={colors.primary[500]} testID="loading-indicator" />
+        </View>
+      ) : stamps.length === 0 ? (
+        <View style={styles.centerContainer} testID="empty-state">
+          <MaterialIcons name="photo-library" size={48} color={colors.gray[400]} />
+          <Text style={styles.emptyText}>御朱印がまだありません</Text>
+          <Text style={styles.emptySubText}>御朱印を記録して、コレクションを始めましょう</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={stamps}
+          renderItem={renderItem}
+          keyExtractor={item => item.id}
+          numColumns={NUM_COLUMNS}
+          key={sortOrder}
+          contentContainerStyle={styles.listContent}
+          testID="gallery-list"
+        />
+      )}
+
+      {totalCount > 20 && (
+        <View style={styles.premiumBanner} testID="premium-banner">
+          <MaterialIcons name="lock" size={16} color={colors.primary[600]} />
+          <Text style={styles.premiumBannerText}>直近20件のみ表示中。プレミアムで全件表示</Text>
+        </View>
+      )}
     </SafeAreaView>
   );
 }
@@ -117,7 +144,7 @@ const styles = StyleSheet.create({
   gridItemMiddle: {
     marginHorizontal: ITEM_MARGIN,
   },
-  imagePlaceholder: {
+  stampImage: {
     width: ITEM_SIZE,
     height: ITEM_SIZE,
     backgroundColor: colors.gray[200],
@@ -131,5 +158,38 @@ const styles = StyleSheet.create({
   itemDate: {
     ...typography.caption,
     color: colors.gray[400],
+  },
+  centerContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  emptyText: {
+    ...typography.h3,
+    color: colors.gray[600],
+    marginTop: spacing.md,
+    textAlign: 'center',
+  },
+  emptySubText: {
+    ...typography.bodySmall,
+    color: colors.gray[400],
+    marginTop: spacing.sm,
+    textAlign: 'center',
+  },
+  premiumBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    backgroundColor: colors.primary[50],
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.primary[200],
+  },
+  premiumBannerText: {
+    ...typography.bodySmall,
+    color: colors.primary[700],
+    flex: 1,
   },
 });

--- a/src/screens/StampDetailScreen.tsx
+++ b/src/screens/StampDetailScreen.tsx
@@ -1,5 +1,13 @@
-import React from 'react';
-import { StyleSheet, Text, View, ScrollView, TouchableOpacity } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  ScrollView,
+  TouchableOpacity,
+  Image,
+  ActivityIndicator,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialIcons } from '@expo/vector-icons';
 import { Badge } from '@components/common/Badge';
@@ -7,11 +15,33 @@ import { Card } from '@components/common/Card';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing } from '@theme/spacing';
+import { fetchStampById, getStampImageUrl } from '@services/stamps';
+import type { StampWithSpot } from '@/types/supabase';
 import type { GalleryStackScreenProps } from '@/navigation/types';
 
 type Props = GalleryStackScreenProps<'StampDetail'>;
 
-export function StampDetailScreen({ navigation }: Props) {
+export function StampDetailScreen({ navigation, route }: Props) {
+  const { stampId } = route.params;
+  const [stamp, setStamp] = useState<StampWithSpot | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchStampById(stampId)
+      .then(data => {
+        setStamp(data);
+      })
+      .catch(err => {
+        setError(err instanceof Error ? err.message : '取得に失敗しました');
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [stampId]);
+
+  const formatDate = (dateStr: string) => dateStr.replace(/-/g, '/');
+
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.header}>
@@ -26,22 +56,37 @@ export function StampDetailScreen({ navigation }: Props) {
         <View style={styles.headerButton} />
       </View>
 
-      <ScrollView contentContainerStyle={styles.scrollContent}>
-        <View style={styles.imageArea} testID="stamp-image">
-          <MaterialIcons name="image" size={48} color={colors.gray[400]} />
+      {isLoading ? (
+        <View style={styles.centerContainer}>
+          <ActivityIndicator size="large" color={colors.primary[500]} testID="loading-indicator" />
         </View>
-
-        <View style={styles.infoSection}>
-          <Text style={styles.spotName}>明治神宮</Text>
-          <Badge type="shrine" />
-          <Text style={styles.visitDate}>2024年1月15日</Text>
+      ) : error || !stamp ? (
+        <View style={styles.centerContainer} testID="error-state">
+          <MaterialIcons name="error-outline" size={48} color={colors.error} />
+          <Text style={styles.errorText}>データを取得できませんでした</Text>
         </View>
+      ) : (
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          <Image
+            source={{ uri: getStampImageUrl(stamp.image_path) }}
+            style={styles.stampImage}
+            testID="stamp-image"
+          />
 
-        <Card style={styles.memoCard}>
-          <Text style={styles.memoLabel}>メモ</Text>
-          <Text style={styles.memoText}>初めての御朱印。天気が良くて気持ちの良い参拝でした。</Text>
-        </Card>
-      </ScrollView>
+          <View style={styles.infoSection}>
+            <Text style={styles.spotName}>{stamp.spots.name}</Text>
+            <Badge type={stamp.spots.type} />
+            <Text style={styles.visitDate}>{formatDate(stamp.visited_at)}</Text>
+          </View>
+
+          {stamp.memo && (
+            <Card style={styles.memoCard}>
+              <Text style={styles.memoLabel}>メモ</Text>
+              <Text style={styles.memoText}>{stamp.memo}</Text>
+            </Card>
+          )}
+        </ScrollView>
+      )}
     </SafeAreaView>
   );
 }
@@ -70,15 +115,25 @@ const styles = StyleSheet.create({
     ...typography.h3,
     color: colors.gray[800],
   },
+  centerContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  errorText: {
+    ...typography.body,
+    color: colors.error,
+    marginTop: spacing.md,
+    textAlign: 'center',
+  },
   scrollContent: {
     paddingBottom: spacing['3xl'],
   },
-  imageArea: {
+  stampImage: {
     width: '100%',
     height: 300,
     backgroundColor: colors.gray[200],
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   infoSection: {
     padding: spacing.lg,

--- a/src/screens/__tests__/GalleryScreen.test.tsx
+++ b/src/screens/__tests__/GalleryScreen.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { GalleryScreen } from '@screens/GalleryScreen';
+import { useGalleryStamps } from '@hooks/useGalleryStamps';
+import type { StampWithSpot } from '@/types/supabase';
 
 jest.mock('react-native-safe-area-context', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -11,6 +13,16 @@ jest.mock('react-native-safe-area-context', () => {
     useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
   };
 });
+
+jest.mock('@hooks/useGalleryStamps', () => ({
+  useGalleryStamps: jest.fn(),
+}));
+
+jest.mock('@services/stamps', () => ({
+  getStampImageUrl: jest.fn((path: string) => `https://example.com/${path}`),
+}));
+
+const mockUseGalleryStamps = useGalleryStamps as jest.MockedFunction<typeof useGalleryStamps>;
 
 const mockNavigation = {
   navigate: jest.fn(),
@@ -24,22 +36,107 @@ const mockRoute = {
   params: undefined,
 };
 
+const makeStamp = (overrides: Partial<StampWithSpot> = {}): StampWithSpot => ({
+  id: '1',
+  user_id: 'user-1',
+  spot_id: 'spot-1',
+  goshuincho_id: null,
+  visited_at: '2024-01-15',
+  image_path: 'user-1/stamp-1.jpg',
+  memo: null,
+  created_at: '2024-01-15T00:00:00Z',
+  updated_at: '2024-01-15T00:00:00Z',
+  spots: { name: '明治神宮', type: 'shrine' },
+  ...overrides,
+});
+
 describe('GalleryScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders without crashing', () => {
-    const { getByText } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
-    expect(getByText('ギャラリー')).toBeTruthy();
-  });
+  it('ローディング中に ActivityIndicator を表示する', () => {
+    mockUseGalleryStamps.mockReturnValue({
+      stamps: [],
+      totalCount: 0,
+      isLoading: true,
+      error: null,
+    });
 
-  it('renders sort button', () => {
     const { getByTestId } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
-    expect(getByTestId('sort-button')).toBeTruthy();
+    expect(getByTestId('loading-indicator')).toBeTruthy();
   });
 
-  it('toggles sort label on press', () => {
+  it('スタンプデータがある場合にスポット名を表示する', () => {
+    mockUseGalleryStamps.mockReturnValue({
+      stamps: [makeStamp({ id: '1', spots: { name: '明治神宮', type: 'shrine' } })],
+      totalCount: 1,
+      isLoading: false,
+      error: null,
+    });
+
+    const { getByText } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByText('明治神宮')).toBeTruthy();
+  });
+
+  it('スタンプデータがある場合に画像を表示する', () => {
+    mockUseGalleryStamps.mockReturnValue({
+      stamps: [makeStamp({ id: '1', image_path: 'user-1/stamp-1.jpg' })],
+      totalCount: 1,
+      isLoading: false,
+      error: null,
+    });
+
+    const { getByTestId } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByTestId('stamp-image-1')).toBeTruthy();
+  });
+
+  it('スタンプがない場合に空状態メッセージを表示する', () => {
+    mockUseGalleryStamps.mockReturnValue({
+      stamps: [],
+      totalCount: 0,
+      isLoading: false,
+      error: null,
+    });
+
+    const { getByTestId } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByTestId('empty-state')).toBeTruthy();
+  });
+
+  it('totalCount が 20 を超える場合にプレミアムバナーを表示する', () => {
+    mockUseGalleryStamps.mockReturnValue({
+      stamps: [makeStamp()],
+      totalCount: 21,
+      isLoading: false,
+      error: null,
+    });
+
+    const { getByTestId } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(getByTestId('premium-banner')).toBeTruthy();
+  });
+
+  it('totalCount が 20 以下の場合にプレミアムバナーを表示しない', () => {
+    mockUseGalleryStamps.mockReturnValue({
+      stamps: [makeStamp()],
+      totalCount: 20,
+      isLoading: false,
+      error: null,
+    });
+
+    const { queryByTestId } = render(
+      <GalleryScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(queryByTestId('premium-banner')).toBeNull();
+  });
+
+  it('ソートボタンを押すと sortOrder が切り替わる', () => {
+    mockUseGalleryStamps.mockReturnValue({
+      stamps: [],
+      totalCount: 0,
+      isLoading: false,
+      error: null,
+    });
+
     const { getByTestId, getByText } = render(
       <GalleryScreen navigation={mockNavigation} route={mockRoute} />
     );
@@ -48,20 +145,44 @@ describe('GalleryScreen', () => {
     expect(getByText('スポット順 ▼')).toBeTruthy();
   });
 
-  it('renders gallery list', () => {
-    const { getByTestId } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
-    expect(getByTestId('gallery-list')).toBeTruthy();
-  });
+  it('date ソート時に訪問日を表示する', () => {
+    mockUseGalleryStamps.mockReturnValue({
+      stamps: [makeStamp({ id: '1', visited_at: '2024-01-15' })],
+      totalCount: 1,
+      isLoading: false,
+      error: null,
+    });
 
-  it('renders mock gallery items', () => {
     const { getByText } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
-    expect(getByText('明治神宮')).toBeTruthy();
-    expect(getByText('浅草寺')).toBeTruthy();
+    // デフォルトは date 順
+    expect(getByText('2024/01/15')).toBeTruthy();
   });
 
-  it('navigates to StampDetail on item press', () => {
+  it('spot ソート時に訪問日を表示しない', () => {
+    mockUseGalleryStamps.mockReturnValue({
+      stamps: [makeStamp({ id: '1', visited_at: '2024-01-15' })],
+      totalCount: 1,
+      isLoading: false,
+      error: null,
+    });
+
+    const { getByTestId, queryByText } = render(
+      <GalleryScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('sort-button'));
+    expect(queryByText('2024/01/15')).toBeNull();
+  });
+
+  it('アイテムタップで StampDetail に遷移する', () => {
+    mockUseGalleryStamps.mockReturnValue({
+      stamps: [makeStamp({ id: 'stamp-abc' })],
+      totalCount: 1,
+      isLoading: false,
+      error: null,
+    });
+
     const { getByTestId } = render(<GalleryScreen navigation={mockNavigation} route={mockRoute} />);
-    fireEvent.press(getByTestId('gallery-item-1'));
-    expect(mockNavigation.navigate).toHaveBeenCalledWith('StampDetail', { stampId: '1' });
+    fireEvent.press(getByTestId('gallery-item-stamp-abc'));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('StampDetail', { stampId: 'stamp-abc' });
   });
 });

--- a/src/screens/__tests__/StampDetailScreen.test.tsx
+++ b/src/screens/__tests__/StampDetailScreen.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { StampDetailScreen } from '@screens/StampDetailScreen';
+import { fetchStampById, getStampImageUrl } from '@services/stamps';
+import type { StampWithSpot } from '@/types/supabase';
 
 jest.mock('react-native-safe-area-context', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -12,6 +14,14 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
+jest.mock('@services/stamps', () => ({
+  fetchStampById: jest.fn(),
+  getStampImageUrl: jest.fn((path: string) => `https://example.com/${path}`),
+}));
+
+const mockFetchStampById = fetchStampById as jest.MockedFunction<typeof fetchStampById>;
+const mockGetStampImageUrl = getStampImageUrl as jest.MockedFunction<typeof getStampImageUrl>;
+
 const mockNavigation = {
   navigate: jest.fn(),
   goBack: jest.fn(),
@@ -21,58 +31,122 @@ const mockNavigation = {
 const mockRoute = {
   key: 'test',
   name: 'StampDetail' as const,
-  params: { stampId: '1' },
+  params: { stampId: 'stamp-1' },
+};
+
+const mockStamp: StampWithSpot = {
+  id: 'stamp-1',
+  user_id: 'user-1',
+  spot_id: 'spot-1',
+  goshuincho_id: null,
+  visited_at: '2024-01-15',
+  image_path: 'user-1/stamp-1.jpg',
+  memo: '初めての御朱印。天気が良くて気持ちの良い参拝でした。',
+  created_at: '2024-01-15T00:00:00Z',
+  updated_at: '2024-01-15T00:00:00Z',
+  spots: { name: '明治神宮', type: 'shrine' },
 };
 
 describe('StampDetailScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetStampImageUrl.mockImplementation((path: string) => `https://example.com/${path}`);
   });
 
-  it('renders without crashing', () => {
-    const { getByText } = render(
-      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
-    );
-    expect(getByText('御朱印詳細')).toBeTruthy();
-  });
+  it('ローディング中に ActivityIndicator を表示する', () => {
+    // fetchStampById が解決しない Promise を返す
+    mockFetchStampById.mockReturnValue(new Promise(() => {}));
 
-  it('renders stamp image area', () => {
     const { getByTestId } = render(
       <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
     );
-    expect(getByTestId('stamp-image')).toBeTruthy();
+    expect(getByTestId('loading-indicator')).toBeTruthy();
   });
 
-  it('renders spot name', () => {
+  it('データが取得できた場合にスポット名を表示する', async () => {
+    mockFetchStampById.mockResolvedValue(mockStamp);
+
     const { getByText } = render(
       <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
     );
-    expect(getByText('明治神宮')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('明治神宮')).toBeTruthy();
+    });
   });
 
-  it('renders shrine badge', () => {
+  it('データが取得できた場合に訪問日を表示する（YYYY/MM/DD 形式）', async () => {
+    mockFetchStampById.mockResolvedValue(mockStamp);
+
+    const { getByText } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    await waitFor(() => {
+      expect(getByText('2024/01/15')).toBeTruthy();
+    });
+  });
+
+  it('データが取得できた場合にメモを表示する', async () => {
+    mockFetchStampById.mockResolvedValue(mockStamp);
+
+    const { getByText } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    await waitFor(() => {
+      expect(getByText('初めての御朱印。天気が良くて気持ちの良い参拝でした。')).toBeTruthy();
+    });
+  });
+
+  it('データが取得できた場合に画像を表示する', async () => {
+    mockFetchStampById.mockResolvedValue(mockStamp);
+
     const { getByTestId } = render(
       <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
     );
-    expect(getByTestId('badge-shrine')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByTestId('stamp-image')).toBeTruthy();
+    });
   });
 
-  it('renders visit date', () => {
-    const { getByText } = render(
+  it('神社の場合に shrine バッジを表示する', async () => {
+    mockFetchStampById.mockResolvedValue(mockStamp);
+
+    const { getByTestId } = render(
       <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
     );
-    expect(getByText('2024年1月15日')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByTestId('badge-shrine')).toBeTruthy();
+    });
   });
 
-  it('renders memo section', () => {
-    const { getByText } = render(
+  it('寺院の場合に temple バッジを表示する', async () => {
+    const templeStamp: StampWithSpot = {
+      ...mockStamp,
+      spots: { name: '浅草寺', type: 'temple' },
+    };
+    mockFetchStampById.mockResolvedValue(templeStamp);
+
+    const { getByTestId } = render(
       <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
     );
-    expect(getByText('メモ')).toBeTruthy();
-    expect(getByText('初めての御朱印。天気が良くて気持ちの良い参拝でした。')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByTestId('badge-temple')).toBeTruthy();
+    });
   });
 
-  it('navigates back on back button press', () => {
+  it('データが取得できない場合にエラーメッセージを表示する', async () => {
+    mockFetchStampById.mockRejectedValue(new Error('Not found'));
+
+    const { getByTestId } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    await waitFor(() => {
+      expect(getByTestId('error-state')).toBeTruthy();
+    });
+  });
+
+  it('戻るボタンで goBack を呼ぶ', () => {
+    mockFetchStampById.mockReturnValue(new Promise(() => {}));
+
     const { getByTestId } = render(
       <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
     );

--- a/src/services/__tests__/stamps.test.ts
+++ b/src/services/__tests__/stamps.test.ts
@@ -1,4 +1,10 @@
-import { fetchVisitedSpotIds, fetchStampsBySpotId, getStampImageUrl } from '@services/stamps';
+import {
+  fetchVisitedSpotIds,
+  fetchStampsBySpotId,
+  getStampImageUrl,
+  fetchAllStamps,
+  fetchStampById,
+} from '@services/stamps';
 
 const mockSelect = jest.fn();
 const mockEq = jest.fn();
@@ -76,6 +82,82 @@ describe('stamps service', () => {
 
       const result = await fetchStampsBySpotId('spot-1');
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('fetchAllStamps', () => {
+    it('returns stamps with spots for a given user', async () => {
+      const mockStamps = [
+        {
+          id: 'stamp-1',
+          user_id: 'user-1',
+          spot_id: 'spot-1',
+          visited_at: '2024-06-01',
+          image_path: 'img/1.jpg',
+          spots: { name: '伊勢神宮', type: 'shrine' },
+        },
+        {
+          id: 'stamp-2',
+          user_id: 'user-1',
+          spot_id: 'spot-2',
+          visited_at: '2024-01-15',
+          image_path: 'img/2.jpg',
+          spots: { name: '浅草寺', type: 'temple' },
+        },
+      ];
+      mockFrom.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValue({ order: mockOrder });
+      mockOrder.mockReturnValue({ data: mockStamps, error: null });
+
+      const result = await fetchAllStamps('user-1');
+      expect(mockFrom).toHaveBeenCalledWith('stamps');
+      expect(mockSelect).toHaveBeenCalledWith('*, spots!inner(name, type)');
+      expect(mockEq).toHaveBeenCalledWith('user_id', 'user-1');
+      expect(mockOrder).toHaveBeenCalledWith('visited_at', { ascending: false });
+      expect(result).toEqual(mockStamps);
+    });
+
+    it('returns empty array on error', async () => {
+      mockFrom.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValue({ order: mockOrder });
+      mockOrder.mockReturnValue({ data: null, error: { message: 'error' } });
+
+      const result = await fetchAllStamps('user-1');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('fetchStampById', () => {
+    it('returns a single stamp with spot', async () => {
+      const mockStamp = {
+        id: 'stamp-1',
+        user_id: 'user-1',
+        spot_id: 'spot-1',
+        visited_at: '2024-06-01',
+        image_path: 'img/1.jpg',
+        spots: { name: '伊勢神宮', type: 'shrine' },
+      };
+      const mockSingle = jest.fn().mockReturnValue({ data: mockStamp, error: null });
+      mockFrom.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValue({ single: mockSingle });
+
+      const result = await fetchStampById('stamp-1');
+      expect(mockFrom).toHaveBeenCalledWith('stamps');
+      expect(mockSelect).toHaveBeenCalledWith('*, spots!inner(name, type)');
+      expect(mockEq).toHaveBeenCalledWith('id', 'stamp-1');
+      expect(result).toEqual(mockStamp);
+    });
+
+    it('throws on error', async () => {
+      const mockSingle = jest.fn().mockReturnValue({ data: null, error: { message: 'not found' } });
+      mockFrom.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValue({ single: mockSingle });
+
+      await expect(fetchStampById('stamp-1')).rejects.toThrow('not found');
     });
   });
 

--- a/src/services/stamps.ts
+++ b/src/services/stamps.ts
@@ -1,5 +1,5 @@
 import { supabase } from '@services/supabase';
-import type { Stamp } from '@/types/supabase';
+import type { Stamp, StampWithSpot } from '@/types/supabase';
 
 export async function fetchVisitedSpotIds(): Promise<Set<string>> {
   const { data, error } = await supabase.from('stamps').select('spot_id');
@@ -74,6 +74,33 @@ export async function createStamp(params: {
   }
 
   return data as Stamp;
+}
+
+export async function fetchAllStamps(userId: string): Promise<StampWithSpot[]> {
+  const { data, error } = await supabase
+    .from('stamps')
+    .select('*, spots!inner(name, type)')
+    .eq('user_id', userId)
+    .order('visited_at', { ascending: false });
+
+  if (error) {
+    console.warn('fetchAllStamps error:', error.message);
+    return [];
+  }
+  return data as StampWithSpot[];
+}
+
+export async function fetchStampById(stampId: string): Promise<StampWithSpot> {
+  const { data, error } = await supabase
+    .from('stamps')
+    .select('*, spots!inner(name, type)')
+    .eq('id', stampId)
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+  return data as StampWithSpot;
 }
 
 export function getStampImageUrl(imagePath: string): string {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -39,6 +39,13 @@ export interface Stamp {
   updated_at: string;
 }
 
+export interface StampWithSpot extends Stamp {
+  spots: {
+    name: string;
+    type: SpotType;
+  };
+}
+
 export interface Goshuincho {
   id: string;
   user_id: string;


### PR DESCRIPTION
## Summary
- ギャラリー画面を MOCK データから Supabase 実データ接続に改修
- 御朱印詳細画面を実データ取得・表示に改修
- useGalleryStamps Hook（ソート機能・無料版20件制限）を新規実装
- fetchAllStamps / fetchStampById サービス関数を追加

## Changes
- `src/types/supabase.ts`: StampWithSpot 型追加
- `src/services/stamps.ts`: fetchAllStamps / fetchStampById 追加
- `src/hooks/useGalleryStamps.ts`: 新規（ソート・無料版制限）
- `src/screens/GalleryScreen.tsx`: 実データ接続・画像表示・ローディング・空状態・プレミアムバナー
- `src/screens/StampDetailScreen.tsx`: 実データ取得・画像/バッジ/訪問日/メモ表示
- 全テスト TDD で実装（364 tests passed）

## Test plan
- [x] 全テスト通過（364 passed, 41 suites）
- [x] Lint チェック通過（0 errors）
- [x] 型チェック通過
- [x] iPhone 実機で UI 目視確認済み

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)