### PR TITLE
feat(stamp-detail): 御朱印詳細画面に編集・削除・ピンチズーム機能を追加

### DIFF
--- a/docs/issues/issue-017-goshuin-detail.md
+++ b/docs/issues/issue-017-goshuin-detail.md
@@ -1,0 +1,206 @@
+# Issue #17: 御朱印詳細画面の機能拡充（編集・削除・ピンチズーム）
+
+## 概要
+
+既存の `StampDetailScreen` は読み取り専用の基本表示のみ実装済み。本 Issue では以下の機能を追加する:
+
+1. **ピンチズーム対応**のフルサイズ画像表示
+2. **編集機能**: 訪問日・メモの更新
+3. **削除機能**: 確認ダイアログ付き、Supabase からデータ・画像の完全削除
+
+## 関連ドキュメント
+
+- [要件定義](../product/requirements.md)
+- [技術設計](../technical/tech-design.md)
+- [UI設計 v6](../design/ui-design.md) - セクション 4.8 御朱印詳細
+
+## 現状の実装状況
+
+`StampDetailScreen` は Issue #16 で以下が実装済み:
+
+- `fetchStampById` でデータ取得
+- 画像表示（`Image` コンポーネント、固定高さ 300px）
+- スポット名、種別バッジ（`Badge` コンポーネント）、訪問日、メモ表示
+- ローディング・エラー状態
+- ナビゲーション（`GalleryStack` の `StampDetail` ルート、`stampId` パラメータ）
+
+## 詳細設計
+
+### 対象ファイル
+
+#### 新規作成
+
+| ファイル                                                            | 説明                                                       |
+| ------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `src/components/stamp-detail/DeleteConfirmModal.tsx`                | 削除確認モーダル                                           |
+| `src/components/stamp-detail/EditStampModal.tsx`                    | 編集モーダル（訪問日・メモ）                               |
+| `src/components/stamp-detail/__tests__/DeleteConfirmModal.test.tsx` | 削除確認モーダルのテスト                                   |
+| `src/components/stamp-detail/__tests__/EditStampModal.test.tsx`     | 編集モーダルのテスト                                       |
+| `src/hooks/useStampDetail.ts`                                       | スタンプ詳細のデータ取得・更新・削除を管理するカスタムhook |
+| `src/hooks/__tests__/useStampDetail.test.ts`                        | useStampDetail のテスト                                    |
+
+#### 変更
+
+| ファイル                                           | 変更内容                                                   |
+| -------------------------------------------------- | ---------------------------------------------------------- |
+| `src/services/stamps.ts`                           | `updateStamp`, `deleteStamp`, `deleteStampImage` 関数追加  |
+| `src/services/__tests__/stamps.test.ts`            | 新規関数のテスト追加                                       |
+| `src/screens/StampDetailScreen.tsx`                | ピンチズーム画像、ヘッダーに編集・削除ボタン追加、Hook移行 |
+| `src/screens/__tests__/StampDetailScreen.test.tsx` | 編集・削除の操作テスト追加                                 |
+
+### サービス層設計
+
+#### updateStamp
+
+```typescript
+export async function updateStamp(
+  stampId: string,
+  params: { visited_at?: string; memo?: string | null }
+): Promise<StampWithSpot> {
+  const { data, error } = await supabase
+    .from('stamps')
+    .update(params)
+    .eq('id', stampId)
+    .select('*, spots!inner(name, type)')
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data as StampWithSpot;
+}
+```
+
+#### deleteStampImage
+
+```typescript
+export async function deleteStampImage(imagePath: string): Promise<void> {
+  const { error } = await supabase.storage.from('goshuin-images').remove([imagePath]);
+
+  if (error) throw new Error(error.message);
+}
+```
+
+#### deleteStamp
+
+```typescript
+export async function deleteStamp(stampId: string, imagePath: string): Promise<void> {
+  // 1. Storage から画像を削除
+  await deleteStampImage(imagePath);
+  // 2. DB からレコードを削除
+  const { error } = await supabase.from('stamps').delete().eq('id', stampId);
+
+  if (error) throw new Error(error.message);
+}
+```
+
+### useStampDetail Hook
+
+```typescript
+interface UseStampDetailReturn {
+  stamp: StampWithSpot | null;
+  isLoading: boolean;
+  error: string | null;
+  isUpdating: boolean;
+  isDeleting: boolean;
+  handleUpdate: (params: { visited_at?: string; memo?: string | null }) => Promise<boolean>;
+  handleDelete: () => Promise<boolean>;
+  refresh: () => void;
+}
+
+export function useStampDetail(stampId: string): UseStampDetailReturn;
+```
+
+### コンポーネント設計
+
+#### StampDetailScreen の改修
+
+**ヘッダー**: 既存の Header コンポーネントを使用し、`rightElement` に編集・削除アイコンを配置
+
+```
+[←] [御朱印詳細] [pencil trash]
+```
+
+**画像エリア**: `ScrollView` の `maximumZoomScale`/`minimumZoomScale` でピンチズーム対応
+
+```tsx
+<ScrollView
+  maximumZoomScale={3}
+  minimumZoomScale={1}
+  centerContent
+  contentContainerStyle={styles.zoomContainer}
+>
+  <Image source={{ uri }} style={styles.stampImage} resizeMode="contain" />
+</ScrollView>
+```
+
+#### DeleteConfirmModal
+
+Props:
+
+```typescript
+interface DeleteConfirmModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isDeleting: boolean;
+  spotName: string;
+}
+```
+
+#### EditStampModal
+
+Props:
+
+```typescript
+interface EditStampModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSave: (params: { visited_at: string; memo: string | null }) => void;
+  isUpdating: boolean;
+  initialVisitedAt: string;
+  initialMemo: string | null;
+}
+```
+
+## テスト方針
+
+### サービス層テスト
+
+- `updateStamp`: 正常更新、エラー時の throw
+- `deleteStampImage`: 正常削除、エラー時の throw
+- `deleteStamp`: 画像削除 + DB 削除の順序確認
+
+### Hook テスト
+
+- 初期ロード → データ取得完了
+- `handleUpdate` 成功/失敗
+- `handleDelete` 成功/失敗
+
+### コンポーネントテスト
+
+- `DeleteConfirmModal`: 表示/非表示、onConfirm 呼び出し、isDeleting 中の disabled
+- `EditStampModal`: 表示/非表示、初期値反映、onSave 呼び出し
+- `StampDetailScreen`: 編集・削除アイコンタップでモーダル表示
+
+## チーム構成（2名）
+
+### service-implementer
+
+1. `src/services/stamps.ts` — updateStamp, deleteStamp, deleteStampImage 追加
+2. `src/services/__tests__/stamps.test.ts` — テスト追加
+3. `src/hooks/useStampDetail.ts` — 新規作成
+4. `src/hooks/__tests__/useStampDetail.test.ts` — テスト
+
+### ui-implementer
+
+1. `src/components/stamp-detail/DeleteConfirmModal.tsx` + テスト
+2. `src/components/stamp-detail/EditStampModal.tsx` + テスト
+3. `src/screens/StampDetailScreen.tsx` — 改修（ピンチズーム、編集・削除ボタン、useStampDetail hook 移行）
+4. `src/screens/__tests__/StampDetailScreen.test.tsx` — テスト追加
+
+## 注意事項
+
+1. ピンチズームは `ScrollView` の `maximumZoomScale` を使う簡易方式（Expo Go 互換）
+2. 削除は Storage → DB の順序で実行（画像孤立防止）
+3. RLS は Supabase Auth が自動適用
+4. 日付入力は MVP では TextInput で YYYY-MM-DD 形式
+5. 削除ボタンは `colors.error`（赤）で破壊的操作を視覚的に示す

--- a/src/components/stamp-detail/DeleteConfirmModal.tsx
+++ b/src/components/stamp-detail/DeleteConfirmModal.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Modal } from '@components/common/Modal';
+import { Button } from '@components/common/Button';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
+
+interface DeleteConfirmModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isDeleting: boolean;
+  spotName: string;
+}
+
+export function DeleteConfirmModal({
+  visible,
+  onClose,
+  onConfirm,
+  isDeleting,
+  spotName,
+}: DeleteConfirmModalProps) {
+  return (
+    <Modal visible={visible} onClose={onClose} variant="center" title="御朱印を削除">
+      <Text style={styles.spotName}>{spotName}</Text>
+      <Text style={styles.message}>この御朱印を削除しますか？この操作は元に戻せません。</Text>
+      <View style={styles.buttons}>
+        <Button title="キャンセル" onPress={onClose} variant="outline" style={styles.button} />
+        <Button
+          title={isDeleting ? '削除中...' : '削除する'}
+          onPress={onConfirm}
+          variant="primary"
+          disabled={isDeleting}
+          style={{ flex: 1, backgroundColor: colors.error }}
+        />
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  spotName: {
+    ...typography.body,
+    color: colors.gray[800],
+    fontWeight: '600',
+    marginBottom: spacing.sm,
+  },
+  message: {
+    ...typography.body,
+    color: colors.gray[600],
+    marginBottom: spacing.lg,
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  button: {
+    flex: 1,
+  },
+});

--- a/src/components/stamp-detail/EditStampModal.tsx
+++ b/src/components/stamp-detail/EditStampModal.tsx
@@ -1,0 +1,193 @@
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { MaterialIcons } from '@expo/vector-icons';
+import { Modal } from '@components/common/Modal';
+import { Button } from '@components/common/Button';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+
+interface EditStampModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSave: (params: { visited_at: string; memo: string | null }) => void;
+  isUpdating: boolean;
+  initialVisitedAt: string;
+  initialMemo: string | null;
+}
+
+export function EditStampModal({
+  visible,
+  onClose,
+  onSave,
+  isUpdating,
+  initialVisitedAt,
+  initialMemo,
+}: EditStampModalProps) {
+  const [visitedAt, setVisitedAt] = useState(initialVisitedAt);
+  const [memo, setMemo] = useState(initialMemo ?? '');
+  const [showDatePicker, setShowDatePicker] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setVisitedAt(initialVisitedAt);
+      setMemo(initialMemo ?? '');
+      setShowDatePicker(false);
+    }
+  }, [visible, initialVisitedAt, initialMemo]);
+
+  const visitedAtDate = (() => {
+    const [y, m, d] = visitedAt.split('-').map(Number);
+    return new Date(y, m - 1, d);
+  })();
+
+  const formattedDate = visitedAt.replace(/-/g, '/');
+
+  const handleDateChange = (_event: unknown, selectedDate?: Date) => {
+    if (Platform.OS === 'android') {
+      setShowDatePicker(false);
+    }
+    if (selectedDate) {
+      const y = selectedDate.getFullYear();
+      const m = String(selectedDate.getMonth() + 1).padStart(2, '0');
+      const d = String(selectedDate.getDate()).padStart(2, '0');
+      setVisitedAt(`${y}-${m}-${d}`);
+    }
+  };
+
+  const handleSave = () => {
+    onSave({
+      visited_at: visitedAt,
+      memo: memo.trim() === '' ? null : memo,
+    });
+  };
+
+  return (
+    <Modal visible={visible} onClose={onClose} variant="bottom" title="御朱印を編集">
+      <ScrollView style={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        <View style={styles.field}>
+          <Text style={styles.label}>訪問日</Text>
+          <TouchableOpacity
+            style={styles.dateRow}
+            onPress={() => setShowDatePicker(!showDatePicker)}
+            testID="date-picker-trigger"
+          >
+            <MaterialIcons name="calendar-today" size={20} color={colors.gray[500]} />
+            <Text style={styles.dateText}>{formattedDate}</Text>
+          </TouchableOpacity>
+          {showDatePicker && (
+            <View>
+              <DateTimePicker
+                value={visitedAtDate}
+                mode="date"
+                display={Platform.OS === 'ios' ? 'inline' : 'default'}
+                onChange={handleDateChange}
+                maximumDate={new Date()}
+                themeVariant="light"
+                testID="date-picker"
+              />
+              {Platform.OS === 'ios' && (
+                <TouchableOpacity
+                  style={styles.dateConfirmButton}
+                  onPress={() => setShowDatePicker(false)}
+                  testID="date-confirm-button"
+                >
+                  <Text style={styles.dateConfirmText}>完了</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          )}
+        </View>
+        <View style={styles.field}>
+          <Text style={styles.label}>メモ</Text>
+          <TextInput
+            style={[styles.input, styles.memoInput]}
+            value={memo}
+            onChangeText={setMemo}
+            placeholder="メモを入力"
+            multiline
+          />
+        </View>
+      </ScrollView>
+      <View style={styles.buttons}>
+        <Button title="キャンセル" onPress={onClose} variant="outline" style={styles.button} />
+        <Button
+          title={isUpdating ? '保存中...' : '保存'}
+          onPress={handleSave}
+          variant="primary"
+          disabled={isUpdating}
+          style={styles.button}
+        />
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    maxHeight: 420,
+  },
+  field: {
+    marginBottom: spacing.lg,
+  },
+  label: {
+    ...typography.label,
+    color: colors.gray[500],
+    marginBottom: spacing.xs,
+  },
+  input: {
+    ...typography.body,
+    color: colors.gray[800],
+    borderWidth: 1,
+    borderColor: colors.gray[300],
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  memoInput: {
+    minHeight: 80,
+    textAlignVertical: 'top',
+  },
+  dateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    padding: spacing.lg,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.white,
+  },
+  dateText: {
+    ...typography.body,
+    color: colors.gray[800],
+  },
+  dateConfirmButton: {
+    alignSelf: 'flex-end',
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    marginTop: spacing.sm,
+  },
+  dateConfirmText: {
+    ...typography.body,
+    color: colors.primary[500],
+    fontWeight: '600',
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  button: {
+    flex: 1,
+  },
+});

--- a/src/components/stamp-detail/__tests__/DeleteConfirmModal.test.tsx
+++ b/src/components/stamp-detail/__tests__/DeleteConfirmModal.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { DeleteConfirmModal } from '../DeleteConfirmModal';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: View,
+    SafeAreaProvider: View,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+describe('DeleteConfirmModal', () => {
+  const defaultProps = {
+    visible: true,
+    onClose: jest.fn(),
+    onConfirm: jest.fn(),
+    isDeleting: false,
+    spotName: '伊勢神宮',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('visible=true で表示される', () => {
+    const { getByTestId } = render(<DeleteConfirmModal {...defaultProps} />);
+    expect(getByTestId('modal-content')).toBeTruthy();
+  });
+
+  it('スポット名が表示される', () => {
+    const { getByText } = render(<DeleteConfirmModal {...defaultProps} />);
+    expect(getByText('伊勢神宮')).toBeTruthy();
+  });
+
+  it('キャンセルボタンで onClose が呼ばれる', () => {
+    const onClose = jest.fn();
+    const { getByText } = render(<DeleteConfirmModal {...defaultProps} onClose={onClose} />);
+    fireEvent.press(getByText('キャンセル'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('削除ボタンで onConfirm が呼ばれる', () => {
+    const onConfirm = jest.fn();
+    const { getByText } = render(<DeleteConfirmModal {...defaultProps} onConfirm={onConfirm} />);
+    fireEvent.press(getByText('削除する'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('isDeleting=true で「削除中...」表示 + ボタン disabled', () => {
+    const { getByText, getByTestId } = render(
+      <DeleteConfirmModal {...defaultProps} isDeleting={true} />
+    );
+    expect(getByText('削除中...')).toBeTruthy();
+    const deleteButton = getByTestId('button-primary');
+    expect(deleteButton.props.accessibilityState?.disabled).toBe(true);
+  });
+});

--- a/src/components/stamp-detail/__tests__/EditStampModal.test.tsx
+++ b/src/components/stamp-detail/__tests__/EditStampModal.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { EditStampModal } from '../EditStampModal';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: View,
+    SafeAreaProvider: View,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock('@react-native-community/datetimepicker', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: (props: { testID?: string; onChange?: (event: unknown, date?: Date) => void }) => (
+      <View testID={props.testID} />
+    ),
+  };
+});
+
+describe('EditStampModal', () => {
+  const defaultProps = {
+    visible: true,
+    onClose: jest.fn(),
+    onSave: jest.fn(),
+    isUpdating: false,
+    initialVisitedAt: '2024-01-15',
+    initialMemo: 'テストメモ',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('visible=true で表示される', () => {
+    const { getByTestId } = render(<EditStampModal {...defaultProps} />);
+    expect(getByTestId('modal-content')).toBeTruthy();
+  });
+
+  it('初期値が訪問日フィールドに反映される', () => {
+    const { getByText } = render(<EditStampModal {...defaultProps} />);
+    expect(getByText('2024/01/15')).toBeTruthy();
+  });
+
+  it('初期値がメモフィールドに反映される', () => {
+    const { getByDisplayValue } = render(<EditStampModal {...defaultProps} />);
+    expect(getByDisplayValue('テストメモ')).toBeTruthy();
+  });
+
+  it('initialMemo が null のとき空文字で表示される', () => {
+    const { getByPlaceholderText } = render(
+      <EditStampModal {...defaultProps} initialMemo={null} />
+    );
+    expect(getByPlaceholderText('メモを入力')).toBeTruthy();
+  });
+
+  it('メモを変更して保存ボタンで onSave が正しいパラメータで呼ばれる', () => {
+    const onSave = jest.fn();
+    const { getByDisplayValue, getByText } = render(
+      <EditStampModal {...defaultProps} onSave={onSave} />
+    );
+
+    fireEvent.changeText(getByDisplayValue('テストメモ'), '更新メモ');
+    fireEvent.press(getByText('保存'));
+
+    expect(onSave).toHaveBeenCalledWith({
+      visited_at: '2024-01-15',
+      memo: '更新メモ',
+    });
+  });
+
+  it('日付ピッカートリガーをタップするとDateTimePickerが表示される', () => {
+    const { getByTestId, queryByTestId } = render(<EditStampModal {...defaultProps} />);
+    expect(queryByTestId('date-picker')).toBeNull();
+    fireEvent.press(getByTestId('date-picker-trigger'));
+    expect(getByTestId('date-picker')).toBeTruthy();
+  });
+
+  it('メモを空にして保存すると memo が null で渡される', () => {
+    const onSave = jest.fn();
+    const { getByDisplayValue, getByText } = render(
+      <EditStampModal {...defaultProps} onSave={onSave} />
+    );
+
+    fireEvent.changeText(getByDisplayValue('テストメモ'), '');
+    fireEvent.press(getByText('保存'));
+
+    expect(onSave).toHaveBeenCalledWith({
+      visited_at: '2024-01-15',
+      memo: null,
+    });
+  });
+
+  it('保存時に現在の日付がonSaveに渡される', () => {
+    const onSave = jest.fn();
+    const { getByText } = render(
+      <EditStampModal {...defaultProps} onSave={onSave} initialMemo={null} />
+    );
+
+    fireEvent.press(getByText('保存'));
+
+    expect(onSave).toHaveBeenCalledWith({
+      visited_at: '2024-01-15',
+      memo: null,
+    });
+  });
+
+  it('キャンセルボタンで onClose が呼ばれる', () => {
+    const onClose = jest.fn();
+    const { getByText } = render(<EditStampModal {...defaultProps} onClose={onClose} />);
+    fireEvent.press(getByText('キャンセル'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('isUpdating=true で「保存中...」表示 + ボタン disabled', () => {
+    const { getByText, getByTestId } = render(
+      <EditStampModal {...defaultProps} isUpdating={true} />
+    );
+    expect(getByText('保存中...')).toBeTruthy();
+    const saveButton = getByTestId('button-primary');
+    expect(saveButton.props.accessibilityState?.disabled).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/useGalleryStamps.test.ts
+++ b/src/hooks/__tests__/useGalleryStamps.test.ts
@@ -8,6 +8,14 @@ jest.mock('@services/stamps', () => ({
   fetchAllStamps: (...args: unknown[]) => mockFetchAllStamps(...args),
 }));
 
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (cb: () => void) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const { useEffect } = require('react');
+    useEffect(cb, [cb]);
+  },
+}));
+
 let mockUser: { id: string } | null = null;
 
 jest.mock('@hooks/useAuth', () => ({

--- a/src/hooks/__tests__/useStampDetail.test.ts
+++ b/src/hooks/__tests__/useStampDetail.test.ts
@@ -1,0 +1,160 @@
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+import { useStampDetail } from '@hooks/useStampDetail';
+import type { StampWithSpot } from '@/types/supabase';
+
+const mockFetchStampById = jest.fn();
+const mockUpdateStamp = jest.fn();
+const mockDeleteStamp = jest.fn();
+
+jest.mock('@services/stamps', () => ({
+  fetchStampById: (...args: unknown[]) => mockFetchStampById(...args),
+  updateStamp: (...args: unknown[]) => mockUpdateStamp(...args),
+  deleteStamp: (...args: unknown[]) => mockDeleteStamp(...args),
+}));
+
+const fakeStamp: StampWithSpot = {
+  id: 'stamp-1',
+  user_id: 'user-1',
+  spot_id: 'spot-1',
+  goshuincho_id: null,
+  visited_at: '2024-06-01',
+  image_path: 'img/1.jpg',
+  memo: 'テストメモ',
+  created_at: '2024-06-01T00:00:00Z',
+  updated_at: '2024-06-01T00:00:00Z',
+  spots: { name: '伊勢神宮', type: 'shrine' },
+};
+
+describe('useStampDetail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('初期ロード時に isLoading が true になり、データ取得後に false になる', async () => {
+    mockFetchStampById.mockResolvedValue(fakeStamp);
+
+    const { result } = renderHook(() => useStampDetail('stamp-1'));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.stamp).toEqual(fakeStamp);
+    expect(result.current.error).toBeNull();
+    expect(mockFetchStampById).toHaveBeenCalledWith('stamp-1');
+  });
+
+  it('フェッチ失敗時に error が設定される', async () => {
+    mockFetchStampById.mockRejectedValue(new Error('fetch error'));
+
+    const { result } = renderHook(() => useStampDetail('stamp-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.stamp).toBeNull();
+    expect(result.current.error).toBe('fetch error');
+  });
+
+  it('handleUpdate 成功時に stamp state が更新される', async () => {
+    mockFetchStampById.mockResolvedValue(fakeStamp);
+    const updatedStamp: StampWithSpot = { ...fakeStamp, memo: '更新メモ' };
+    mockUpdateStamp.mockResolvedValue(updatedStamp);
+
+    const { result } = renderHook(() => useStampDetail('stamp-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    let success: boolean;
+    await act(async () => {
+      success = await result.current.handleUpdate({ memo: '更新メモ' });
+    });
+
+    expect(success!).toBe(true);
+    expect(result.current.stamp).toEqual(updatedStamp);
+    expect(result.current.error).toBeNull();
+    expect(mockUpdateStamp).toHaveBeenCalledWith('stamp-1', { memo: '更新メモ' });
+  });
+
+  it('handleUpdate 失敗時に error が設定される', async () => {
+    mockFetchStampById.mockResolvedValue(fakeStamp);
+    mockUpdateStamp.mockRejectedValue(new Error('update failed'));
+
+    const { result } = renderHook(() => useStampDetail('stamp-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    let success: boolean;
+    await act(async () => {
+      success = await result.current.handleUpdate({ memo: '更新メモ' });
+    });
+
+    expect(success!).toBe(false);
+    expect(result.current.error).toBe('update failed');
+  });
+
+  it('handleDelete 成功時に true が返る', async () => {
+    mockFetchStampById.mockResolvedValue(fakeStamp);
+    mockDeleteStamp.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useStampDetail('stamp-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    let success: boolean;
+    await act(async () => {
+      success = await result.current.handleDelete();
+    });
+
+    expect(success!).toBe(true);
+    expect(mockDeleteStamp).toHaveBeenCalledWith('stamp-1', 'img/1.jpg');
+  });
+
+  it('handleDelete 失敗時に false が返り error が設定される', async () => {
+    mockFetchStampById.mockResolvedValue(fakeStamp);
+    mockDeleteStamp.mockRejectedValue(new Error('delete failed'));
+
+    const { result } = renderHook(() => useStampDetail('stamp-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    let success: boolean;
+    await act(async () => {
+      success = await result.current.handleDelete();
+    });
+
+    expect(success!).toBe(false);
+    expect(result.current.error).toBe('delete failed');
+  });
+
+  it('refresh 呼び出しでデータが再取得される', async () => {
+    mockFetchStampById.mockResolvedValue(fakeStamp);
+
+    const { result } = renderHook(() => useStampDetail('stamp-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockFetchStampById).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(mockFetchStampById).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/hooks/useGalleryStamps.ts
+++ b/src/hooks/useGalleryStamps.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import { useAuth } from '@hooks/useAuth';
 import { fetchAllStamps } from '@services/stamps';
 import type { StampWithSpot } from '@/types/supabase';
@@ -20,37 +21,39 @@ export function useGalleryStamps(sortOrder: SortOrder): UseGalleryStampsReturn {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!user) {
-      setAllStamps([]);
-      setIsLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-
-    (async () => {
-      try {
-        setIsLoading(true);
-        const data = await fetchAllStamps(user.id);
-        if (!cancelled) {
-          setAllStamps(data);
-          setError(null);
-        }
-      } catch (e) {
-        if (!cancelled) {
-          setAllStamps([]);
-          setError(e instanceof Error ? e.message : '取得に失敗しました');
-        }
-      } finally {
-        if (!cancelled) setIsLoading(false);
+  useFocusEffect(
+    useCallback(() => {
+      if (!user) {
+        setAllStamps([]);
+        setIsLoading(false);
+        return;
       }
-    })();
 
-    return () => {
-      cancelled = true;
-    };
-  }, [user]);
+      let cancelled = false;
+
+      (async () => {
+        try {
+          setIsLoading(true);
+          const data = await fetchAllStamps(user.id);
+          if (!cancelled) {
+            setAllStamps(data);
+            setError(null);
+          }
+        } catch (e) {
+          if (!cancelled) {
+            setAllStamps([]);
+            setError(e instanceof Error ? e.message : '取得に失敗しました');
+          }
+        } finally {
+          if (!cancelled) setIsLoading(false);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+    }, [user])
+  );
 
   const stamps = useMemo(() => {
     const sorted = [...allStamps];

--- a/src/hooks/useStampDetail.ts
+++ b/src/hooks/useStampDetail.ts
@@ -1,0 +1,88 @@
+import { useState, useEffect, useCallback } from 'react';
+import { fetchStampById, updateStamp, deleteStamp } from '@services/stamps';
+import type { StampWithSpot } from '@/types/supabase';
+
+interface UseStampDetailReturn {
+  stamp: StampWithSpot | null;
+  isLoading: boolean;
+  error: string | null;
+  isUpdating: boolean;
+  isDeleting: boolean;
+  handleUpdate: (params: { visited_at?: string; memo?: string | null }) => Promise<boolean>;
+  handleDelete: () => Promise<boolean>;
+  refresh: () => void;
+}
+
+export function useStampDetail(stampId: string): UseStampDetailReturn {
+  const [stamp, setStamp] = useState<StampWithSpot | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const data = await fetchStampById(stampId);
+        if (!cancelled) {
+          setStamp(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unknown error');
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [stampId, refreshTrigger]);
+
+  const handleUpdate = useCallback(
+    async (params: { visited_at?: string; memo?: string | null }): Promise<boolean> => {
+      setIsUpdating(true);
+      setError(null);
+      try {
+        const updated = await updateStamp(stampId, params);
+        setStamp(updated);
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error');
+        return false;
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [stampId]
+  );
+
+  const handleDelete = useCallback(async (): Promise<boolean> => {
+    if (!stamp) return false;
+    setIsDeleting(true);
+    setError(null);
+    try {
+      await deleteStamp(stampId, stamp.image_path);
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+      return false;
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [stampId, stamp]);
+
+  const refresh = useCallback(() => {
+    setRefreshTrigger(prev => prev + 1);
+  }, []);
+
+  return { stamp, isLoading, error, isUpdating, isDeleting, handleUpdate, handleDelete, refresh };
+}

--- a/src/screens/StampDetailScreen.tsx
+++ b/src/screens/StampDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   StyleSheet,
   Text,
@@ -15,32 +15,38 @@ import { Card } from '@components/common/Card';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing } from '@theme/spacing';
-import { fetchStampById, getStampImageUrl } from '@services/stamps';
-import type { StampWithSpot } from '@/types/supabase';
+import { getStampImageUrl } from '@services/stamps';
+import { useStampDetail } from '@hooks/useStampDetail';
+import { DeleteConfirmModal } from '@components/stamp-detail/DeleteConfirmModal';
+import { EditStampModal } from '@components/stamp-detail/EditStampModal';
 import type { GalleryStackScreenProps } from '@/navigation/types';
 
 type Props = GalleryStackScreenProps<'StampDetail'>;
 
 export function StampDetailScreen({ navigation, route }: Props) {
   const { stampId } = route.params;
-  const [stamp, setStamp] = useState<StampWithSpot | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { stamp, isLoading, error, isUpdating, isDeleting, handleUpdate, handleDelete } =
+    useStampDetail(stampId);
 
-  useEffect(() => {
-    fetchStampById(stampId)
-      .then(data => {
-        setStamp(data);
-      })
-      .catch(err => {
-        setError(err instanceof Error ? err.message : '取得に失敗しました');
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, [stampId]);
+  const [editModalVisible, setEditModalVisible] = useState(false);
+  const [deleteModalVisible, setDeleteModalVisible] = useState(false);
 
   const formatDate = (dateStr: string) => dateStr.replace(/-/g, '/');
+
+  const onSave = async (params: { visited_at: string; memo: string | null }) => {
+    const success = await handleUpdate(params);
+    if (success) {
+      setEditModalVisible(false);
+    }
+  };
+
+  const onConfirmDelete = async () => {
+    const success = await handleDelete();
+    if (success) {
+      setDeleteModalVisible(false);
+      navigation.goBack();
+    }
+  };
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
@@ -53,7 +59,26 @@ export function StampDetailScreen({ navigation, route }: Props) {
           <MaterialIcons name="arrow-back" size={24} color={colors.gray[800]} />
         </TouchableOpacity>
         <Text style={styles.headerTitle}>御朱印詳細</Text>
-        <View style={styles.headerButton} />
+        <View style={styles.headerActions}>
+          {stamp && (
+            <>
+              <TouchableOpacity
+                onPress={() => setEditModalVisible(true)}
+                style={styles.actionButton}
+                testID="edit-button"
+              >
+                <MaterialIcons name="edit" size={22} color={colors.gray[700]} />
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={() => setDeleteModalVisible(true)}
+                style={styles.actionButton}
+                testID="delete-button"
+              >
+                <MaterialIcons name="delete" size={22} color={colors.error} />
+              </TouchableOpacity>
+            </>
+          )}
+        </View>
       </View>
 
       {isLoading ? (
@@ -66,26 +91,54 @@ export function StampDetailScreen({ navigation, route }: Props) {
           <Text style={styles.errorText}>データを取得できませんでした</Text>
         </View>
       ) : (
-        <ScrollView contentContainerStyle={styles.scrollContent}>
-          <Image
-            source={{ uri: getStampImageUrl(stamp.image_path) }}
-            style={styles.stampImage}
-            testID="stamp-image"
+        <>
+          <ScrollView contentContainerStyle={styles.scrollContent}>
+            <ScrollView
+              maximumZoomScale={3}
+              minimumZoomScale={1}
+              centerContent
+              style={styles.imageScrollView}
+              contentContainerStyle={styles.zoomContainer}
+            >
+              <Image
+                source={{ uri: getStampImageUrl(stamp.image_path) }}
+                style={styles.stampImage}
+                resizeMode="contain"
+                testID="stamp-image"
+              />
+            </ScrollView>
+
+            <View style={styles.infoSection}>
+              <Text style={styles.spotName}>{stamp.spots.name}</Text>
+              <Badge type={stamp.spots.type} />
+              <Text style={styles.visitDate}>{formatDate(stamp.visited_at)}</Text>
+            </View>
+
+            {stamp.memo && (
+              <Card style={styles.memoCard}>
+                <Text style={styles.memoLabel}>メモ</Text>
+                <Text style={styles.memoText}>{stamp.memo}</Text>
+              </Card>
+            )}
+          </ScrollView>
+
+          <EditStampModal
+            visible={editModalVisible}
+            onClose={() => setEditModalVisible(false)}
+            onSave={onSave}
+            isUpdating={isUpdating}
+            initialVisitedAt={stamp.visited_at}
+            initialMemo={stamp.memo}
           />
 
-          <View style={styles.infoSection}>
-            <Text style={styles.spotName}>{stamp.spots.name}</Text>
-            <Badge type={stamp.spots.type} />
-            <Text style={styles.visitDate}>{formatDate(stamp.visited_at)}</Text>
-          </View>
-
-          {stamp.memo && (
-            <Card style={styles.memoCard}>
-              <Text style={styles.memoLabel}>メモ</Text>
-              <Text style={styles.memoText}>{stamp.memo}</Text>
-            </Card>
-          )}
-        </ScrollView>
+          <DeleteConfirmModal
+            visible={deleteModalVisible}
+            onClose={() => setDeleteModalVisible(false)}
+            onConfirm={onConfirmDelete}
+            isDeleting={isDeleting}
+            spotName={stamp.spots.name}
+          />
+        </>
       )}
     </SafeAreaView>
   );
@@ -115,6 +168,16 @@ const styles = StyleSheet.create({
     ...typography.h3,
     color: colors.gray[800],
   },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  actionButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   centerContainer: {
     flex: 1,
     alignItems: 'center',
@@ -130,10 +193,18 @@ const styles = StyleSheet.create({
   scrollContent: {
     paddingBottom: spacing['3xl'],
   },
+  imageScrollView: {
+    height: 300,
+    backgroundColor: colors.gray[100],
+  },
+  zoomContainer: {
+    height: 300,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   stampImage: {
     width: '100%',
     height: 300,
-    backgroundColor: colors.gray[200],
   },
   infoSection: {
     padding: spacing.lg,

--- a/src/screens/__tests__/StampDetailScreen.test.tsx
+++ b/src/screens/__tests__/StampDetailScreen.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { StampDetailScreen } from '@screens/StampDetailScreen';
-import { fetchStampById, getStampImageUrl } from '@services/stamps';
+import { fetchStampById, getStampImageUrl, updateStamp, deleteStamp } from '@services/stamps';
 import type { StampWithSpot } from '@/types/supabase';
 
 jest.mock('react-native-safe-area-context', () => {
@@ -17,10 +17,14 @@ jest.mock('react-native-safe-area-context', () => {
 jest.mock('@services/stamps', () => ({
   fetchStampById: jest.fn(),
   getStampImageUrl: jest.fn((path: string) => `https://example.com/${path}`),
+  updateStamp: jest.fn(),
+  deleteStamp: jest.fn(),
 }));
 
 const mockFetchStampById = fetchStampById as jest.MockedFunction<typeof fetchStampById>;
 const mockGetStampImageUrl = getStampImageUrl as jest.MockedFunction<typeof getStampImageUrl>;
+const mockUpdateStamp = updateStamp as jest.MockedFunction<typeof updateStamp>;
+const mockDeleteStamp = deleteStamp as jest.MockedFunction<typeof deleteStamp>;
 
 const mockNavigation = {
   navigate: jest.fn(),
@@ -152,5 +156,78 @@ describe('StampDetailScreen', () => {
     );
     fireEvent.press(getByTestId('back-button'));
     expect(mockNavigation.goBack).toHaveBeenCalled();
+  });
+
+  it('編集ボタンタップで EditStampModal が表示される', async () => {
+    mockFetchStampById.mockResolvedValue(mockStamp);
+
+    const { getByTestId } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    await waitFor(() => {
+      expect(getByTestId('edit-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('edit-button'));
+    await waitFor(() => {
+      expect(getByTestId('modal-content')).toBeTruthy();
+    });
+  });
+
+  it('削除ボタンタップで DeleteConfirmModal が表示される', async () => {
+    mockFetchStampById.mockResolvedValue(mockStamp);
+
+    const { getByTestId, getAllByTestId } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    await waitFor(() => {
+      expect(getByTestId('delete-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('delete-button'));
+    await waitFor(() => {
+      const contents = getAllByTestId('modal-content');
+      expect(contents.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('EditStampModal で保存すると updateStamp が呼ばれ、モーダルが閉じる', async () => {
+    mockFetchStampById.mockResolvedValue(mockStamp);
+    const updatedStamp = { ...mockStamp, visited_at: '2024-03-01' };
+    mockUpdateStamp.mockResolvedValue(updatedStamp);
+
+    const { getByTestId, getByText } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    await waitFor(() => {
+      expect(getByTestId('edit-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('edit-button'));
+    await waitFor(() => {
+      expect(getByText('保存')).toBeTruthy();
+    });
+    fireEvent.press(getByText('保存'));
+    await waitFor(() => {
+      expect(mockUpdateStamp).toHaveBeenCalled();
+    });
+  });
+
+  it('DeleteConfirmModal で削除すると deleteStamp が呼ばれ、goBack する', async () => {
+    mockFetchStampById.mockResolvedValue(mockStamp);
+    mockDeleteStamp.mockResolvedValue(undefined);
+
+    const { getByTestId, getByText } = render(
+      <StampDetailScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    await waitFor(() => {
+      expect(getByTestId('delete-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('delete-button'));
+    await waitFor(() => {
+      expect(getByText('削除する')).toBeTruthy();
+    });
+    fireEvent.press(getByText('削除する'));
+    await waitFor(() => {
+      expect(mockDeleteStamp).toHaveBeenCalledWith('stamp-1', 'user-1/stamp-1.jpg');
+      expect(mockNavigation.goBack).toHaveBeenCalled();
+    });
   });
 });

--- a/src/services/__tests__/stamps.test.ts
+++ b/src/services/__tests__/stamps.test.ts
@@ -4,6 +4,9 @@ import {
   getStampImageUrl,
   fetchAllStamps,
   fetchStampById,
+  updateStamp,
+  deleteStampImage,
+  deleteStamp,
 } from '@services/stamps';
 
 const mockSelect = jest.fn();
@@ -11,14 +14,16 @@ const mockEq = jest.fn();
 const mockOrder = jest.fn();
 const mockFrom = jest.fn();
 const mockGetPublicUrl = jest.fn();
+const mockUpdate = jest.fn();
+const mockDelete = jest.fn();
+const mockRemove = jest.fn();
+const mockStorageFrom = jest.fn();
 
 jest.mock('@services/supabase', () => ({
   supabase: {
     from: (...args: unknown[]) => mockFrom(...args),
     storage: {
-      from: () => ({
-        getPublicUrl: (...args: unknown[]) => mockGetPublicUrl(...args),
-      }),
+      from: (...args: unknown[]) => mockStorageFrom(...args),
     },
   },
 }));
@@ -163,6 +168,7 @@ describe('stamps service', () => {
 
   describe('getStampImageUrl', () => {
     it('returns public URL for stamp image', () => {
+      mockStorageFrom.mockReturnValue({ getPublicUrl: mockGetPublicUrl });
       mockGetPublicUrl.mockReturnValue({
         data: { publicUrl: 'https://example.com/stamps/img/1.jpg' },
       });
@@ -170,6 +176,98 @@ describe('stamps service', () => {
       const result = getStampImageUrl('img/1.jpg');
       expect(mockGetPublicUrl).toHaveBeenCalledWith('img/1.jpg');
       expect(result).toBe('https://example.com/stamps/img/1.jpg');
+    });
+  });
+
+  describe('updateStamp', () => {
+    it('returns updated stamp with spot', async () => {
+      const mockStamp = {
+        id: 'stamp-1',
+        user_id: 'user-1',
+        spot_id: 'spot-1',
+        visited_at: '2024-06-02',
+        image_path: 'img/1.jpg',
+        memo: '更新したメモ',
+        spots: { name: '伊勢神宮', type: 'shrine' },
+      };
+      const mockSingle = jest.fn().mockReturnValue({ data: mockStamp, error: null });
+      mockFrom.mockReturnValue({ update: mockUpdate });
+      mockUpdate.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ single: mockSingle });
+
+      const result = await updateStamp('stamp-1', {
+        visited_at: '2024-06-02',
+        memo: '更新したメモ',
+      });
+      expect(mockFrom).toHaveBeenCalledWith('stamps');
+      expect(mockUpdate).toHaveBeenCalledWith({ visited_at: '2024-06-02', memo: '更新したメモ' });
+      expect(mockEq).toHaveBeenCalledWith('id', 'stamp-1');
+      expect(mockSelect).toHaveBeenCalledWith('*, spots!inner(name, type)');
+      expect(result).toEqual(mockStamp);
+    });
+
+    it('throws on error', async () => {
+      const mockSingle = jest
+        .fn()
+        .mockReturnValue({ data: null, error: { message: 'update failed' } });
+      mockFrom.mockReturnValue({ update: mockUpdate });
+      mockUpdate.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ single: mockSingle });
+
+      await expect(updateStamp('stamp-1', { memo: null })).rejects.toThrow('update failed');
+    });
+  });
+
+  describe('deleteStampImage', () => {
+    it('removes image from storage', async () => {
+      mockStorageFrom.mockReturnValue({ remove: mockRemove });
+      mockRemove.mockReturnValue({ error: null });
+
+      await deleteStampImage('img/1.jpg');
+      expect(mockStorageFrom).toHaveBeenCalledWith('goshuin-images');
+      expect(mockRemove).toHaveBeenCalledWith(['img/1.jpg']);
+    });
+
+    it('throws on error', async () => {
+      mockStorageFrom.mockReturnValue({ remove: mockRemove });
+      mockRemove.mockReturnValue({ error: { message: 'storage error' } });
+
+      await expect(deleteStampImage('img/1.jpg')).rejects.toThrow('storage error');
+    });
+  });
+
+  describe('deleteStamp', () => {
+    it('deletes image then DB record', async () => {
+      mockStorageFrom.mockReturnValue({ remove: mockRemove });
+      mockRemove.mockReturnValue({ error: null });
+      mockFrom.mockReturnValue({ delete: mockDelete });
+      mockDelete.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValue({ error: null });
+
+      await deleteStamp('stamp-1', 'img/1.jpg');
+      expect(mockRemove).toHaveBeenCalledWith(['img/1.jpg']);
+      expect(mockFrom).toHaveBeenCalledWith('stamps');
+      expect(mockDelete).toHaveBeenCalled();
+      expect(mockEq).toHaveBeenCalledWith('id', 'stamp-1');
+    });
+
+    it('throws if image deletion fails', async () => {
+      mockStorageFrom.mockReturnValue({ remove: mockRemove });
+      mockRemove.mockReturnValue({ error: { message: 'image delete error' } });
+
+      await expect(deleteStamp('stamp-1', 'img/1.jpg')).rejects.toThrow('image delete error');
+    });
+
+    it('throws if DB deletion fails', async () => {
+      mockStorageFrom.mockReturnValue({ remove: mockRemove });
+      mockRemove.mockReturnValue({ error: null });
+      mockFrom.mockReturnValue({ delete: mockDelete });
+      mockDelete.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValue({ error: { message: 'db delete error' } });
+
+      await expect(deleteStamp('stamp-1', 'img/1.jpg')).rejects.toThrow('db delete error');
     });
   });
 });

--- a/src/services/stamps.ts
+++ b/src/services/stamps.ts
@@ -107,3 +107,28 @@ export function getStampImageUrl(imagePath: string): string {
   const { data } = supabase.storage.from('goshuin-images').getPublicUrl(imagePath);
   return data.publicUrl;
 }
+
+export async function updateStamp(
+  stampId: string,
+  params: { visited_at?: string; memo?: string | null }
+): Promise<StampWithSpot> {
+  const { data, error } = await supabase
+    .from('stamps')
+    .update(params)
+    .eq('id', stampId)
+    .select('*, spots!inner(name, type)')
+    .single();
+  if (error) throw new Error(error.message);
+  return data as StampWithSpot;
+}
+
+export async function deleteStampImage(imagePath: string): Promise<void> {
+  const { error } = await supabase.storage.from('goshuin-images').remove([imagePath]);
+  if (error) throw new Error(error.message);
+}
+
+export async function deleteStamp(stampId: string, imagePath: string): Promise<void> {
+  await deleteStampImage(imagePath);
+  const { error } = await supabase.from('stamps').delete().eq('id', stampId);
+  if (error) throw new Error(error.message);
+}


### PR DESCRIPTION
## Summary
- 御朱印詳細画面に編集（訪問日・メモ）・削除（確認ダイアログ付き）・ピンチズーム機能を追加
- サービス層に `updateStamp`, `deleteStamp`, `deleteStampImage` を追加
- `useStampDetail` カスタムHookで詳細画面のデータ管理を一元化
- ギャラリー画面で `useFocusEffect` を使い、削除後の再フェッチに対応

## Changes
- `src/services/stamps.ts` — updateStamp, deleteStamp, deleteStampImage 追加
- `src/hooks/useStampDetail.ts` — 新規作成
- `src/components/stamp-detail/EditStampModal.tsx` — カレンダーUI付き日付編集モーダル
- `src/components/stamp-detail/DeleteConfirmModal.tsx` — 削除確認モーダル
- `src/screens/StampDetailScreen.tsx` — ピンチズーム、編集・削除ボタン、useStampDetail統合
- `src/hooks/useGalleryStamps.ts` — useEffect → useFocusEffect（削除後の再フェッチ対応）

## Test plan
- [x] 397テスト全通過
- [x] Lint エラー0
- [x] 型チェック通過
- [x] Expo Go で実機確認済み（編集・削除・ピンチズーム動作確認）

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)