### PR TITLE
fix(navigation): スポット詳細画面のヘッダー二重表示を修正

### DIFF
--- a/src/navigation/MapStack.tsx
+++ b/src/navigation/MapStack.tsx
@@ -13,7 +13,7 @@ export function MapStack() {
       <Stack.Screen
         name="SpotDetail"
         component={SpotDetailScreen}
-        options={{ title: 'スポット詳細' }}
+        options={{ headerShown: false }}
       />
     </Stack.Navigator>
   );


### PR DESCRIPTION
## Summary
- スポット詳細画面でReact NavigationのデフォルトヘッダーとカスタムHeaderコンポーネントが二重表示されていた問題を修正
- `MapStack.tsx` の SpotDetail 画面に `headerShown: false` を設定

## Test plan
- [x] `npm run typecheck` 通過
- [x] テスト全件パス (824 tests)
- [x] Expo Go でスポット詳細画面のヘッダーが1つだけ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)