### PR TITLE
feat(search): マップ画面に専用検索画面を追加

### DIFF
--- a/src/components/common/FilterChips.tsx
+++ b/src/components/common/FilterChips.tsx
@@ -15,6 +15,7 @@ export const FilterChips: React.FC<FilterChipsProps> = ({ options, selectedKey, 
     <ScrollView
       horizontal
       showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
       contentContainerStyle={styles.container}
     >
       {options.map(option => {

--- a/src/components/common/FilterChips.tsx
+++ b/src/components/common/FilterChips.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { ScrollView, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { borderRadius, spacing } from '@theme/spacing';
+
+interface FilterChipsProps {
+  options: { key: string; label: string }[];
+  selectedKey: string;
+  onSelect: (key: string) => void;
+}
+
+export const FilterChips: React.FC<FilterChipsProps> = ({ options, selectedKey, onSelect }) => {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.container}
+    >
+      {options.map(option => {
+        const isSelected = option.key === selectedKey;
+        return (
+          <TouchableOpacity
+            key={option.key}
+            testID={`filter-chip-${option.key}`}
+            accessibilityState={{ selected: isSelected }}
+            onPress={() => onSelect(option.key)}
+            style={[styles.chip, isSelected ? styles.chipActive : styles.chipInactive]}
+          >
+            <Text style={[styles.label, isSelected ? styles.labelActive : styles.labelInactive]}>
+              {option.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    gap: spacing.sm,
+  },
+  chip: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.full,
+  },
+  chipActive: {
+    backgroundColor: colors.primary[500],
+  },
+  chipInactive: {
+    backgroundColor: colors.gray[100],
+  },
+  label: {
+    ...typography.bodySmall,
+  },
+  labelActive: {
+    color: colors.white,
+  },
+  labelInactive: {
+    color: colors.gray[700],
+  },
+});

--- a/src/components/common/FilterChips.tsx
+++ b/src/components/common/FilterChips.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { ScrollView, TouchableOpacity, Text, StyleSheet, Keyboard } from 'react-native';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { borderRadius, spacing } from '@theme/spacing';
@@ -25,7 +25,10 @@ export const FilterChips: React.FC<FilterChipsProps> = ({ options, selectedKey, 
             key={option.key}
             testID={`filter-chip-${option.key}`}
             accessibilityState={{ selected: isSelected }}
-            onPress={() => onSelect(option.key)}
+            onPress={() => {
+              Keyboard.dismiss();
+              onSelect(option.key);
+            }}
             style={[styles.chip, isSelected ? styles.chipActive : styles.chipInactive]}
           >
             <Text style={[styles.label, isSelected ? styles.labelActive : styles.labelInactive]}>

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, TextInput, StyleSheet, TouchableOpacity, Pressable } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
@@ -13,6 +13,11 @@ interface SearchBarProps {
   onFocus?: () => void;
   onClear?: () => void;
   showClearButton?: boolean;
+  editable?: boolean;
+  onPress?: () => void;
+  autoFocus?: boolean;
+  leftIcon?: 'search' | 'back';
+  onLeftIconPress?: () => void;
 }
 
 export const SearchBar: React.FC<SearchBarProps> = ({
@@ -22,24 +27,56 @@ export const SearchBar: React.FC<SearchBarProps> = ({
   onFocus,
   onClear,
   showClearButton = false,
+  editable = true,
+  onPress,
+  autoFocus = false,
+  leftIcon = 'search',
+  onLeftIconPress,
 }) => {
-  return (
-    <View style={styles.container} testID="search-bar">
-      <MaterialIcons name="search" size={20} color={colors.gray[400]} />
-      <TextInput
-        style={styles.input}
-        placeholder={placeholder}
-        placeholderTextColor={colors.gray[400]}
-        value={value}
-        onChangeText={onChangeText}
-        onFocus={onFocus}
-        testID="search-input"
-      />
+  const iconName = leftIcon === 'back' ? 'arrow-back' : 'search';
+  const iconElement = onLeftIconPress ? (
+    <TouchableOpacity onPress={onLeftIconPress} testID="search-left-icon" activeOpacity={0.7}>
+      <MaterialIcons name={iconName} size={20} color={colors.gray[400]} />
+    </TouchableOpacity>
+  ) : (
+    <MaterialIcons name={iconName} size={20} color={colors.gray[400]} />
+  );
+
+  const content = (
+    <>
+      {iconElement}
+      <View style={styles.inputWrapper} pointerEvents={editable ? 'auto' : 'none'}>
+        <TextInput
+          style={styles.input}
+          placeholder={placeholder}
+          placeholderTextColor={colors.gray[400]}
+          value={value}
+          onChangeText={onChangeText}
+          onFocus={onFocus}
+          editable={editable}
+          autoFocus={autoFocus}
+          testID="search-input"
+        />
+      </View>
       {showClearButton && (
         <TouchableOpacity onPress={onClear} testID="search-clear-button" activeOpacity={0.7}>
           <MaterialIcons name="close" size={20} color={colors.gray[400]} />
         </TouchableOpacity>
       )}
+    </>
+  );
+
+  if (!editable && onPress) {
+    return (
+      <Pressable style={styles.container} testID="search-bar" onPress={onPress}>
+        {content}
+      </Pressable>
+    );
+  }
+
+  return (
+    <View style={styles.container} testID="search-bar">
+      {content}
     </View>
   );
 };
@@ -55,8 +92,10 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
     ...shadows.sm,
   },
-  input: {
+  inputWrapper: {
     flex: 1,
+  },
+  input: {
     ...typography.body,
     color: colors.gray[800],
     padding: 0,

--- a/src/components/common/__tests__/FilterChips.test.tsx
+++ b/src/components/common/__tests__/FilterChips.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { FilterChips } from '../FilterChips';
+
+const options = [
+  { key: 'all', label: 'すべて' },
+  { key: 'shrine', label: '神社' },
+  { key: 'temple', label: 'お寺' },
+];
+
+describe('FilterChips', () => {
+  it('options が正しくレンダリングされる', () => {
+    const { getByText } = render(
+      <FilterChips options={options} selectedKey="all" onSelect={jest.fn()} />
+    );
+    expect(getByText('すべて')).toBeTruthy();
+    expect(getByText('神社')).toBeTruthy();
+    expect(getByText('お寺')).toBeTruthy();
+  });
+
+  it('selectedKey のチップがアクティブスタイルを持つ', () => {
+    const { getByTestId } = render(
+      <FilterChips options={options} selectedKey="shrine" onSelect={jest.fn()} />
+    );
+    const shrineChip = getByTestId('filter-chip-shrine');
+    // アクティブなチップは active スタイルを持つ
+    expect(shrineChip.props.accessibilityState?.selected).toBe(true);
+  });
+
+  it('非選択のチップは selected でない', () => {
+    const { getByTestId } = render(
+      <FilterChips options={options} selectedKey="shrine" onSelect={jest.fn()} />
+    );
+    const allChip = getByTestId('filter-chip-all');
+    expect(allChip.props.accessibilityState?.selected).toBeFalsy();
+  });
+
+  it('チップタップで onSelect が呼ばれる', () => {
+    const onSelect = jest.fn();
+    const { getByTestId } = render(
+      <FilterChips options={options} selectedKey="all" onSelect={onSelect} />
+    );
+    fireEvent.press(getByTestId('filter-chip-shrine'));
+    expect(onSelect).toHaveBeenCalledWith('shrine');
+  });
+});

--- a/src/components/common/__tests__/SearchBar.test.tsx
+++ b/src/components/common/__tests__/SearchBar.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { SearchBar } from '../SearchBar';
+
+describe('SearchBar', () => {
+  it('デフォルトでは TextInput が入力可能', () => {
+    const { getByTestId } = render(<SearchBar />);
+    const input = getByTestId('search-input');
+    expect(input.props.editable).not.toBe(false);
+  });
+
+  it('editable={false} + onPress 指定時、タップで onPress が呼ばれる', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(<SearchBar editable={false} onPress={onPress} />);
+    fireEvent.press(getByTestId('search-bar'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('editable={false} の場合 TextInput に editable={false} が設定される', () => {
+    const { getByTestId } = render(<SearchBar editable={false} />);
+    const input = getByTestId('search-input');
+    expect(input.props.editable).toBe(false);
+  });
+
+  it('autoFocus={true} が TextInput に渡される', () => {
+    const { getByTestId } = render(<SearchBar autoFocus={true} />);
+    const input = getByTestId('search-input');
+    expect(input.props.autoFocus).toBe(true);
+  });
+
+  it('autoFocus 未指定時は false', () => {
+    const { getByTestId } = render(<SearchBar />);
+    const input = getByTestId('search-input');
+    expect(input.props.autoFocus).toBeFalsy();
+  });
+});

--- a/src/components/search/SearchResultCard.tsx
+++ b/src/components/search/SearchResultCard.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { Spot } from '@/types/supabase';
+import { formatDistance } from '@/utils/geo';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { borderRadius, spacing } from '@theme/spacing';
+
+interface SearchResultCardProps {
+  spot: Spot;
+  distance: number;
+  query: string;
+  onPress: () => void;
+}
+
+function HighlightedText({ text, query }: { text: string; query: string }) {
+  if (!query) {
+    return <Text style={styles.spotName}>{text}</Text>;
+  }
+
+  const parts = text.split(query);
+  if (parts.length === 1) {
+    return <Text style={styles.spotName}>{text}</Text>;
+  }
+
+  return (
+    <Text style={styles.spotName}>
+      {parts.map((part, index) => (
+        <React.Fragment key={index}>
+          {part}
+          {index < parts.length - 1 && (
+            <Text testID={`highlight-${query}`} style={styles.highlight}>
+              {query}
+            </Text>
+          )}
+        </React.Fragment>
+      ))}
+    </Text>
+  );
+}
+
+export const SearchResultCard: React.FC<SearchResultCardProps> = ({
+  spot,
+  distance,
+  query,
+  onPress,
+}) => {
+  const isShrine = spot.type === 'shrine';
+
+  return (
+    <Pressable testID="search-result-card" onPress={onPress} style={styles.container}>
+      <View
+        testID={`spot-icon-${spot.type}`}
+        style={[styles.iconContainer, isShrine ? styles.iconShrine : styles.iconTemple]}
+      >
+        <MaterialIcons
+          name={isShrine ? 'temple-hindu' : 'temple-buddhist'}
+          size={36}
+          color={isShrine ? colors.shrine[600] : colors.temple[600]}
+        />
+      </View>
+
+      <View style={styles.info}>
+        <HighlightedText text={spot.name} query={query} />
+        <Text style={styles.address} numberOfLines={1}>
+          {spot.address || ''}
+        </Text>
+        <Text style={styles.distance}>{formatDistance(distance)}</Text>
+      </View>
+
+      <MaterialIcons name="chevron-right" size={24} color={colors.gray[400]} />
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    gap: spacing.md,
+  },
+  iconContainer: {
+    width: 80,
+    height: 80,
+    borderRadius: borderRadius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  iconShrine: {
+    backgroundColor: colors.shrine[100],
+  },
+  iconTemple: {
+    backgroundColor: colors.temple[100],
+  },
+  info: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  spotName: {
+    ...typography.body,
+    color: colors.gray[800],
+    fontWeight: '600',
+  },
+  highlight: {
+    color: colors.primary[500],
+  },
+  address: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+  },
+  distance: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+  },
+});

--- a/src/components/search/__tests__/SearchResultCard.test.tsx
+++ b/src/components/search/__tests__/SearchResultCard.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { SearchResultCard } from '../SearchResultCard';
+import { Spot } from '@/types/supabase';
+
+const shrineSpot: Spot = {
+  id: '1',
+  name: '仙台東照宮',
+  lat: 38.268,
+  lng: 140.869,
+  type: 'shrine',
+  address: '宮城県仙台市青葉区東照宮1-6-1',
+  status: 'active',
+  created_by_user_id: null,
+  merged_into_spot_id: null,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
+const templeSpot: Spot = {
+  ...shrineSpot,
+  id: '2',
+  name: '輪王寺',
+  type: 'temple',
+};
+
+describe('SearchResultCard', () => {
+  it('スポット名が表示される', () => {
+    const { getByText } = render(
+      <SearchResultCard spot={shrineSpot} distance={0.5} query="" onPress={jest.fn()} />
+    );
+    expect(getByText('仙台東照宮')).toBeTruthy();
+  });
+
+  it('住所が表示される', () => {
+    const { getByText } = render(
+      <SearchResultCard spot={shrineSpot} distance={0.5} query="" onPress={jest.fn()} />
+    );
+    expect(getByText('宮城県仙台市青葉区東照宮1-6-1')).toBeTruthy();
+  });
+
+  it('距離が正しくフォーマットされる（500m）', () => {
+    const { getByText } = render(
+      <SearchResultCard spot={shrineSpot} distance={0.5} query="" onPress={jest.fn()} />
+    );
+    expect(getByText('500m')).toBeTruthy();
+  });
+
+  it('距離が正しくフォーマットされる（1.5km）', () => {
+    const { getByText } = render(
+      <SearchResultCard spot={shrineSpot} distance={1.5} query="" onPress={jest.fn()} />
+    );
+    expect(getByText('1.5km')).toBeTruthy();
+  });
+
+  it('タップで onPress が呼ばれる', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <SearchResultCard spot={shrineSpot} distance={0.5} query="" onPress={onPress} />
+    );
+    fireEvent.press(getByTestId('search-result-card'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('query に一致する部分がハイライトされる', () => {
+    const { getByTestId } = render(
+      <SearchResultCard spot={shrineSpot} distance={0.5} query="東照" onPress={jest.fn()} />
+    );
+    expect(getByTestId('highlight-東照')).toBeTruthy();
+  });
+
+  it('shrine のとき shrine アイコンコンテナが表示される', () => {
+    const { getByTestId } = render(
+      <SearchResultCard spot={shrineSpot} distance={0.5} query="" onPress={jest.fn()} />
+    );
+    expect(getByTestId('spot-icon-shrine')).toBeTruthy();
+  });
+
+  it('temple のとき temple アイコンコンテナが表示される', () => {
+    const { getByTestId } = render(
+      <SearchResultCard spot={templeSpot} distance={0.5} query="" onPress={jest.fn()} />
+    );
+    expect(getByTestId('spot-icon-temple')).toBeTruthy();
+  });
+});

--- a/src/hooks/__tests__/useSearchScreen.test.ts
+++ b/src/hooks/__tests__/useSearchScreen.test.ts
@@ -1,0 +1,156 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useSearchScreen } from '@hooks/useSearchScreen';
+import type { Spot } from '@/types/supabase';
+
+import { useSpots } from '@hooks/useSpots';
+import { useLocation } from '@hooks/useLocation';
+
+// モック（supabase 初期化を回避するため useSpots, useLocation をモック）
+jest.mock('@services/spots', () => ({
+  fetchSpotsByBounds: jest.fn(),
+}));
+jest.mock('@hooks/useSpots');
+jest.mock('@hooks/useLocation');
+
+const mockUseSpots = useSpots as jest.MockedFunction<typeof useSpots>;
+const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
+
+const makeFakeSpot = (overrides: Partial<Spot> = {}): Spot => ({
+  id: 'spot-1',
+  name: 'Test Shrine',
+  lat: 38.27,
+  lng: 140.87,
+  type: 'shrine',
+  address: null,
+  status: 'active',
+  created_by_user_id: null,
+  merged_into_spot_id: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+  ...overrides,
+});
+
+const allSpots: Spot[] = [
+  makeFakeSpot({ id: '1', name: 'Aoba Shrine', lat: 38.269, lng: 140.87, type: 'shrine' }),
+  makeFakeSpot({ id: '2', name: 'Sendai Temple', lat: 38.28, lng: 140.88, type: 'temple' }),
+  makeFakeSpot({ id: '3', name: 'Zuihoden Temple', lat: 38.25, lng: 140.86, type: 'temple' }),
+];
+
+const userLocation = { latitude: 38.2682, longitude: 140.8694 };
+
+beforeEach(() => {
+  mockUseLocation.mockReturnValue({
+    location: userLocation,
+    isLoading: false,
+    error: null,
+    permissionStatus: null,
+    refreshLocation: jest.fn(),
+  });
+  mockUseSpots.mockReturnValue({
+    spots: allSpots,
+    allSpots,
+    isLoading: false,
+    error: null,
+  });
+});
+
+describe('useSearchScreen', () => {
+  it('初期状態で query が空、results が空、nearbySpots が返る', () => {
+    const { result } = renderHook(() => useSearchScreen());
+    expect(result.current.query).toBe('');
+    expect(result.current.results).toEqual([]);
+    expect(result.current.nearbySpots).toHaveLength(3);
+    expect(result.current.filterType).toBe('all');
+  });
+
+  it('setQuery でテキスト入力 → 300ms 後に results が更新される', () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() => useSearchScreen());
+
+    act(() => {
+      result.current.setQuery('Temple');
+    });
+
+    // デバウンス前は results が空
+    expect(result.current.results).toEqual([]);
+
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    expect(result.current.results.length).toBe(2);
+    expect(result.current.results.every(r => r.spot.name.includes('Temple'))).toBe(true);
+    jest.useRealTimers();
+  });
+
+  it('filterType を shrine に変更 → results が神社のみに絞り込まれる', () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() => useSearchScreen());
+
+    act(() => {
+      result.current.setQuery('a');
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    // filterType を shrine に変更
+    act(() => {
+      result.current.setFilterType('shrine');
+    });
+
+    expect(result.current.results.every(r => r.spot.type === 'shrine')).toBe(true);
+    jest.useRealTimers();
+  });
+
+  it('clearSearch で query と filterType がリセットされる', () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() => useSearchScreen());
+
+    act(() => {
+      result.current.setQuery('Temple');
+      result.current.setFilterType('temple');
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    expect(result.current.results.length).toBe(2);
+
+    act(() => {
+      result.current.clearSearch();
+    });
+
+    expect(result.current.query).toBe('');
+    expect(result.current.filterType).toBe('all');
+    expect(result.current.results).toEqual([]);
+    jest.useRealTimers();
+  });
+
+  it('nearbySpots は filterType を適用しない（常に最寄り3件）', () => {
+    const { result } = renderHook(() => useSearchScreen());
+
+    act(() => {
+      result.current.setFilterType('shrine');
+    });
+
+    // filterType が shrine でも nearbySpots は全種別の最寄り3件
+    expect(result.current.nearbySpots).toHaveLength(3);
+  });
+
+  it('results は距離順にソートされる', () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() => useSearchScreen());
+
+    act(() => {
+      result.current.setQuery('');
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    // query が空なので results は空
+    expect(result.current.results).toEqual([]);
+    jest.useRealTimers();
+  });
+});

--- a/src/hooks/useSearchScreen.ts
+++ b/src/hooks/useSearchScreen.ts
@@ -1,0 +1,78 @@
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { useSpots } from '@hooks/useSpots';
+import { useLocation } from '@hooks/useLocation';
+import { calculateDistance } from '@utils/geo';
+import type { Spot } from '@/types/supabase';
+
+interface SpotWithDistance {
+  spot: Spot;
+  distance: number;
+}
+
+export interface UseSearchScreenReturn {
+  query: string;
+  setQuery: (text: string) => void;
+  results: SpotWithDistance[];
+  nearbySpots: SpotWithDistance[];
+  filterType: 'all' | 'shrine' | 'temple';
+  setFilterType: (type: 'all' | 'shrine' | 'temple') => void;
+  clearSearch: () => void;
+}
+
+const DEBOUNCE_MS = 300;
+const MAX_NEARBY = 3;
+
+export function useSearchScreen(): UseSearchScreenReturn {
+  const { location } = useLocation();
+  const { allSpots } = useSpots(location, 'all', new Set());
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [filterType, setFilterType] = useState<'all' | 'shrine' | 'temple'>('all');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      setDebouncedQuery(query);
+    }, DEBOUNCE_MS);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [query]);
+
+  const spotsWithDistance = useMemo(() => {
+    if (!location) return allSpots.map(spot => ({ spot, distance: 0 }));
+    return allSpots
+      .map(spot => ({
+        spot,
+        distance: calculateDistance(location.latitude, location.longitude, spot.lat, spot.lng),
+      }))
+      .sort((a, b) => a.distance - b.distance);
+  }, [allSpots, location]);
+
+  const nearbySpots = useMemo(() => spotsWithDistance.slice(0, MAX_NEARBY), [spotsWithDistance]);
+
+  const results = useMemo(() => {
+    if (!debouncedQuery) return [];
+    const lower = debouncedQuery.toLowerCase();
+    return spotsWithDistance
+      .filter(s => s.spot.name.toLowerCase().includes(lower))
+      .filter(s => filterType === 'all' || s.spot.type === filterType);
+  }, [debouncedQuery, spotsWithDistance, filterType]);
+
+  const clearSearch = useCallback(() => {
+    setQuery('');
+    setDebouncedQuery('');
+    setFilterType('all');
+  }, []);
+
+  return {
+    query,
+    setQuery,
+    results,
+    nearbySpots,
+    filterType,
+    setFilterType,
+    clearSearch,
+  };
+}

--- a/src/navigation/MapStack.tsx
+++ b/src/navigation/MapStack.tsx
@@ -1,6 +1,7 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import { MapScreen } from '@screens/MapScreen';
+import { SearchScreen } from '@screens/SearchScreen';
 import { SpotDetailScreen } from '@screens/SpotDetailScreen';
 import type { MapStackParamList } from '@/navigation/types';
 
@@ -10,6 +11,11 @@ export function MapStack() {
   return (
     <Stack.Navigator>
       <Stack.Screen name="Map" component={MapScreen} options={{ headerShown: false }} />
+      <Stack.Screen
+        name="Search"
+        component={SearchScreen}
+        options={{ headerShown: false, animation: 'none' }}
+      />
       <Stack.Screen
         name="SpotDetail"
         component={SpotDetailScreen}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -30,6 +30,7 @@ export type MainTabParamList = {
 export type MapStackParamList = {
   Map: undefined;
   SpotDetail: { spotId: string };
+  Search: undefined;
 };
 
 export type GalleryStackParamList = {

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback } from 'react';
-import { FlatList, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import MapView, { Marker, type Region } from 'react-native-maps';
 import { MaterialIcons } from '@expo/vector-icons';
@@ -13,7 +13,6 @@ import { useAuth } from '@hooks/useAuth';
 import { useLocation } from '@hooks/useLocation';
 import { useSpots } from '@hooks/useSpots';
 import { useUserStamps } from '@hooks/useUserStamps';
-import { useMapSearch } from '@hooks/useMapSearch';
 import type { MapStackScreenProps } from '@/navigation/types';
 import type { Spot } from '@/types/supabase';
 import { colors } from '@theme/colors';
@@ -33,26 +32,12 @@ function getPinColor(spot: Spot, visitedSpotIds: Set<string>): string {
   return spot.type === 'shrine' ? colors.pin.shrineVisited : colors.pin.templeVisited;
 }
 
-function formatDistance(km: number): string {
-  if (km < 1) return `${Math.round(km * 1000)}m`;
-  return `${km.toFixed(1)}km`;
-}
-
 export function MapScreen({ navigation }: Props) {
   const { isAuthenticated } = useAuth();
   const { location } = useLocation();
   const { visitedSpotIds } = useUserStamps();
   const [filterMode, setFilterMode] = useState<FilterMode>('all');
-  const { spots, allSpots } = useSpots(location, filterMode, visitedSpotIds);
-  const {
-    query,
-    setQuery,
-    suggestions,
-    showSuggestions,
-    setShowSuggestions,
-    nearbySpots,
-    clearSearch,
-  } = useMapSearch(allSpots, location);
+  const { spots } = useSpots(location, filterMode, visitedSpotIds);
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [showFilter, setShowFilter] = useState(false);
   const [currentLatitudeDelta, setCurrentLatitudeDelta] = useState(LATITUDE_DELTA);
@@ -93,19 +78,6 @@ export function MapScreen({ navigation }: Props) {
     [navigation]
   );
 
-  const handleSuggestionPress = useCallback(
-    (spotId: string) => {
-      setShowSuggestions(false);
-      clearSearch();
-      navigation.navigate('SpotDetail', { spotId });
-    },
-    [navigation, setShowSuggestions, clearSearch]
-  );
-
-  const handleSearchFocus = () => {
-    setShowSuggestions(true);
-  };
-
   const handleFilterPress = () => {
     setShowFilter(!showFilter);
   };
@@ -124,19 +96,11 @@ export function MapScreen({ navigation }: Props) {
       }
     : undefined;
 
-  const displaySuggestions = query ? suggestions : nearbySpots;
-
   return (
     <View style={styles.container} testID="map-screen">
       <View style={[styles.searchRow, { top: searchRowTop }]}>
         <View style={styles.searchBarWrapper}>
-          <SearchBar
-            value={query}
-            onChangeText={setQuery}
-            onFocus={handleSearchFocus}
-            showClearButton={query.length > 0}
-            onClear={clearSearch}
-          />
+          <SearchBar editable={false} onPress={() => navigation.navigate('Search')} />
         </View>
         {isAuthenticated && (
           <TouchableOpacity
@@ -153,33 +117,6 @@ export function MapScreen({ navigation }: Props) {
           </TouchableOpacity>
         )}
       </View>
-
-      {showSuggestions && displaySuggestions.length > 0 && (
-        <View
-          style={[styles.suggestionsContainer, { top: searchRowTop + 52 }]}
-          testID="suggestions-list"
-        >
-          <FlatList
-            data={displaySuggestions}
-            keyExtractor={item => item.spot.id}
-            keyboardShouldPersistTaps="handled"
-            renderItem={({ item }) => (
-              <Pressable
-                style={styles.suggestionItem}
-                onPress={() => handleSuggestionPress(item.spot.id)}
-                testID={`suggestion-${item.spot.id}`}
-              >
-                <View style={styles.suggestionContent}>
-                  <Text style={styles.suggestionName} numberOfLines={1}>
-                    {item.spot.name}
-                  </Text>
-                  <Text style={styles.suggestionDistance}>{formatDistance(item.distance)}</Text>
-                </View>
-              </Pressable>
-            )}
-          />
-        </View>
-      )}
 
       {showFilter && (
         <Pressable
@@ -305,37 +242,6 @@ const styles = StyleSheet.create({
   filterButtonActive: {
     borderWidth: 2,
     borderColor: colors.primary[500],
-  },
-  suggestionsContainer: {
-    position: 'absolute',
-    left: spacing.lg,
-    right: spacing.lg,
-    zIndex: 20,
-    backgroundColor: colors.white,
-    borderRadius: borderRadius.lg,
-    maxHeight: 200,
-    ...shadows.md,
-  },
-  suggestionItem: {
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.md,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.gray[200],
-  },
-  suggestionContent: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  suggestionName: {
-    ...typography.body,
-    color: colors.gray[800],
-    flex: 1,
-  },
-  suggestionDistance: {
-    ...typography.bodySmall,
-    color: colors.gray[400],
-    marginLeft: spacing.sm,
   },
   filterOverlay: {
     position: 'absolute',

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -46,18 +46,27 @@ export function SearchScreen({ navigation }: Props) {
         </View>
       </View>
 
-      <View style={{ marginTop: searchRowTop + 52 }}>
-        <FilterChips
-          options={FILTER_OPTIONS}
-          selectedKey={filterType}
-          onSelect={key => setFilterType(key as 'all' | 'shrine' | 'temple')}
-        />
-
+      <View style={{ marginTop: searchRowTop + 52, flex: 1 }}>
         {showEmpty ? (
-          <View style={styles.emptyContainer}>
-            <MaterialIcons name="search-off" size={48} color={colors.gray[300]} />
-            <Text style={styles.emptyText}>見つかりませんでした</Text>
-          </View>
+          <FlatList
+            data={[]}
+            renderItem={() => null}
+            keyboardShouldPersistTaps="handled"
+            keyboardDismissMode="on-drag"
+            ListHeaderComponent={
+              <>
+                <FilterChips
+                  options={FILTER_OPTIONS}
+                  selectedKey={filterType}
+                  onSelect={key => setFilterType(key as 'all' | 'shrine' | 'temple')}
+                />
+                <View style={styles.emptyContainer}>
+                  <MaterialIcons name="search-off" size={48} color={colors.gray[300]} />
+                  <Text style={styles.emptyText}>見つかりませんでした</Text>
+                </View>
+              </>
+            }
+          />
         ) : (
           <FlatList
             data={displayData}
@@ -65,7 +74,14 @@ export function SearchScreen({ navigation }: Props) {
             keyboardShouldPersistTaps="handled"
             keyboardDismissMode="on-drag"
             ListHeaderComponent={
-              <Text style={styles.sectionTitle}>{hasQuery ? '検索結果' : '近くのスポット'}</Text>
+              <>
+                <FilterChips
+                  options={FILTER_OPTIONS}
+                  selectedKey={filterType}
+                  onSelect={key => setFilterType(key as 'all' | 'shrine' | 'temple')}
+                />
+                <Text style={styles.sectionTitle}>{hasQuery ? '検索結果' : '近くのスポット'}</Text>
+              </>
             }
             renderItem={({ item }) => (
               <SearchResultCard

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { FlatList, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { MaterialIcons } from '@expo/vector-icons';
+
+import { SearchBar } from '@components/common/SearchBar';
+import { FilterChips } from '@components/common/FilterChips';
+import { SearchResultCard } from '@components/search/SearchResultCard';
+import { useSearchScreen } from '@hooks/useSearchScreen';
+import type { MapStackScreenProps } from '@/navigation/types';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
+
+type Props = MapStackScreenProps<'Search'>;
+
+const FILTER_OPTIONS = [
+  { key: 'all', label: 'すべて' },
+  { key: 'shrine', label: '神社' },
+  { key: 'temple', label: '寺院' },
+];
+
+export function SearchScreen({ navigation }: Props) {
+  const { query, setQuery, results, nearbySpots, filterType, setFilterType, clearSearch } =
+    useSearchScreen();
+  const insets = useSafeAreaInsets();
+
+  const searchRowTop = insets.top + spacing.xs;
+  const hasQuery = query.length > 0;
+  const displayData = hasQuery ? results : nearbySpots;
+  const showEmpty = hasQuery && results.length === 0;
+
+  return (
+    <View style={styles.container} testID="search-screen">
+      <View style={[styles.searchRow, { top: searchRowTop }]}>
+        <View style={styles.searchBarWrapper}>
+          <SearchBar
+            value={query}
+            onChangeText={setQuery}
+            autoFocus
+            showClearButton={hasQuery}
+            onClear={clearSearch}
+            leftIcon="back"
+            onLeftIconPress={() => navigation.goBack()}
+          />
+        </View>
+      </View>
+
+      <View style={{ marginTop: searchRowTop + 52 }}>
+        <FilterChips
+          options={FILTER_OPTIONS}
+          selectedKey={filterType}
+          onSelect={key => setFilterType(key as 'all' | 'shrine' | 'temple')}
+        />
+
+        {showEmpty ? (
+          <View style={styles.emptyContainer}>
+            <MaterialIcons name="search-off" size={48} color={colors.gray[300]} />
+            <Text style={styles.emptyText}>見つかりませんでした</Text>
+          </View>
+        ) : (
+          <FlatList
+            data={displayData}
+            keyExtractor={item => item.spot.id}
+            keyboardShouldPersistTaps="handled"
+            keyboardDismissMode="on-drag"
+            ListHeaderComponent={
+              <Text style={styles.sectionTitle}>{hasQuery ? '検索結果' : '近くのスポット'}</Text>
+            }
+            renderItem={({ item }) => (
+              <SearchResultCard
+                spot={item.spot}
+                distance={item.distance}
+                query={query}
+                onPress={() => navigation.navigate('SpotDetail', { spotId: item.spot.id })}
+              />
+            )}
+          />
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.white,
+  },
+  searchRow: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    zIndex: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    gap: spacing.sm,
+  },
+  searchBarWrapper: {
+    flex: 1,
+  },
+  sectionTitle: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  emptyContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: 100,
+    gap: spacing.md,
+  },
+  emptyText: {
+    ...typography.body,
+    color: colors.gray[400],
+  },
+});

--- a/src/screens/__tests__/MapScreen.test.tsx
+++ b/src/screens/__tests__/MapScreen.test.tsx
@@ -88,24 +88,6 @@ jest.mock('@hooks/useUserStamps', () => ({
   }),
 }));
 
-const mockSetQuery = jest.fn();
-const mockSetShowSuggestions = jest.fn();
-const mockClearSearch = jest.fn();
-
-let mockUseMapSearchReturn = {
-  query: '',
-  setQuery: mockSetQuery,
-  suggestions: [] as { spot: (typeof mockSpots)[0]; distance: number }[],
-  showSuggestions: false,
-  setShowSuggestions: mockSetShowSuggestions,
-  nearbySpots: mockSpots.map(s => ({ spot: s, distance: 1.5 })),
-  clearSearch: mockClearSearch,
-};
-
-jest.mock('@hooks/useMapSearch', () => ({
-  useMapSearch: () => mockUseMapSearchReturn,
-}));
-
 const mockParentNavigate = jest.fn();
 const mockNavigation = {
   navigate: jest.fn(),
@@ -142,15 +124,6 @@ describe('MapScreen', () => {
       signInWithGoogle: jest.fn(),
       signOut: jest.fn(),
     };
-    mockUseMapSearchReturn = {
-      query: '',
-      setQuery: mockSetQuery,
-      suggestions: [],
-      showSuggestions: false,
-      setShowSuggestions: mockSetShowSuggestions,
-      nearbySpots: mockSpots.map(s => ({ spot: s, distance: 1.5 })),
-      clearSearch: mockClearSearch,
-    };
   });
 
   it('renders without crashing', () => {
@@ -165,6 +138,14 @@ describe('MapScreen', () => {
       <MapScreen navigation={mockNavigation as never} route={mockRoute} />
     );
     expect(getByTestId('search-bar')).toBeTruthy();
+  });
+
+  it('navigates to Search screen when search bar is pressed', () => {
+    const { getByTestId } = render(
+      <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('search-bar'));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('Search');
   });
 
   it('displays MapView', () => {
@@ -214,46 +195,6 @@ describe('MapScreen', () => {
       );
 
       fireEvent.press(getByTestId('spot-marker-spot-1'));
-      expect(mockNavigation.navigate).toHaveBeenCalledWith('SpotDetail', { spotId: 'spot-1' });
-    });
-  });
-
-  describe('Search suggestions', () => {
-    it('shows suggestions list when showSuggestions is true and has nearby spots', () => {
-      mockUseMapSearchReturn = {
-        ...mockUseMapSearchReturn,
-        showSuggestions: true,
-      };
-
-      const { getByTestId } = render(
-        <MapScreen navigation={mockNavigation as never} route={mockRoute} />
-      );
-      expect(getByTestId('suggestions-list')).toBeTruthy();
-    });
-
-    it('does not show suggestions when showSuggestions is false', () => {
-      mockUseMapSearchReturn = {
-        ...mockUseMapSearchReturn,
-        showSuggestions: false,
-      };
-
-      const { queryByTestId } = render(
-        <MapScreen navigation={mockNavigation as never} route={mockRoute} />
-      );
-      expect(queryByTestId('suggestions-list')).toBeNull();
-    });
-
-    it('navigates to SpotDetail when suggestion is pressed', () => {
-      mockUseMapSearchReturn = {
-        ...mockUseMapSearchReturn,
-        showSuggestions: true,
-      };
-
-      const { getByTestId } = render(
-        <MapScreen navigation={mockNavigation as never} route={mockRoute} />
-      );
-
-      fireEvent.press(getByTestId('suggestion-spot-1'));
       expect(mockNavigation.navigate).toHaveBeenCalledWith('SpotDetail', { spotId: 'spot-1' });
     });
   });

--- a/src/screens/__tests__/SearchScreen.test.tsx
+++ b/src/screens/__tests__/SearchScreen.test.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { SearchScreen } from '@screens/SearchScreen';
+
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const React = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+      React.createElement(View, props, children),
+    useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+  };
+});
+
+const mockSpots = [
+  {
+    id: 'spot-1',
+    name: '仙台東照宮',
+    lat: 38.27,
+    lng: 140.87,
+    type: 'shrine' as const,
+    status: 'active' as const,
+    address: '仙台市青葉区東照宮1-6-1',
+    created_by_user_id: null,
+    merged_into_spot_id: null,
+    created_at: '2024-01-01',
+    updated_at: '2024-01-01',
+  },
+  {
+    id: 'spot-2',
+    name: '仙台成田山',
+    lat: 38.28,
+    lng: 140.88,
+    type: 'temple' as const,
+    status: 'active' as const,
+    address: '仙台市青葉区荒巻字青葉33-2',
+    created_by_user_id: null,
+    merged_into_spot_id: null,
+    created_at: '2024-01-01',
+    updated_at: '2024-01-01',
+  },
+  {
+    id: 'spot-3',
+    name: '大崎八幡宮',
+    lat: 38.27,
+    lng: 140.86,
+    type: 'shrine' as const,
+    status: 'active' as const,
+    address: '仙台市青葉区八幡4-6-1',
+    created_by_user_id: null,
+    merged_into_spot_id: null,
+    created_at: '2024-01-01',
+    updated_at: '2024-01-01',
+  },
+];
+
+const mockSetQuery = jest.fn();
+const mockSetFilterType = jest.fn();
+const mockClearSearch = jest.fn();
+
+let mockUseSearchScreenReturn = {
+  query: '',
+  setQuery: mockSetQuery,
+  results: [] as { spot: (typeof mockSpots)[0]; distance: number }[],
+  nearbySpots: mockSpots.map(s => ({ spot: s, distance: 1.5 })),
+  filterType: 'all' as 'all' | 'shrine' | 'temple',
+  setFilterType: mockSetFilterType,
+  clearSearch: mockClearSearch,
+};
+
+jest.mock('@hooks/useSearchScreen', () => ({
+  useSearchScreen: () => mockUseSearchScreenReturn,
+}));
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  dispatch: jest.fn(),
+  reset: jest.fn(),
+  isFocused: jest.fn(),
+  canGoBack: jest.fn(),
+  getId: jest.fn(),
+  getParent: jest.fn(),
+  getState: jest.fn(),
+  setParams: jest.fn(),
+  setOptions: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  pop: jest.fn(),
+  push: jest.fn(),
+  replace: jest.fn(),
+  popTo: jest.fn(),
+  popToTop: jest.fn(),
+};
+
+const mockRoute = { key: 'test', name: 'Search' as const, params: undefined };
+
+describe('SearchScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSearchScreenReturn = {
+      query: '',
+      setQuery: mockSetQuery,
+      results: [],
+      nearbySpots: mockSpots.map(s => ({ spot: s, distance: 1.5 })),
+      filterType: 'all',
+      setFilterType: mockSetFilterType,
+      clearSearch: mockClearSearch,
+    };
+  });
+
+  it('renders without crashing', () => {
+    const { getByTestId } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('search-screen')).toBeTruthy();
+  });
+
+  it('displays back button', () => {
+    const { getByTestId } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('search-left-icon')).toBeTruthy();
+  });
+
+  it('navigates back when back button is pressed', () => {
+    const { getByTestId } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('search-left-icon'));
+    expect(mockNavigation.goBack).toHaveBeenCalled();
+  });
+
+  it('displays search bar', () => {
+    const { getByTestId } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('search-bar')).toBeTruthy();
+  });
+
+  it('displays filter chips', () => {
+    const { getByTestId } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByTestId('filter-chip-all')).toBeTruthy();
+    expect(getByTestId('filter-chip-shrine')).toBeTruthy();
+    expect(getByTestId('filter-chip-temple')).toBeTruthy();
+  });
+
+  it('calls setFilterType when filter chip is pressed', () => {
+    const { getByTestId } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('filter-chip-shrine'));
+    expect(mockSetFilterType).toHaveBeenCalledWith('shrine');
+  });
+
+  it('displays nearby spots when query is empty', () => {
+    const { getByText } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByText('近くのスポット')).toBeTruthy();
+    expect(getByText('仙台東照宮')).toBeTruthy();
+    expect(getByText('仙台成田山')).toBeTruthy();
+    expect(getByText('大崎八幡宮')).toBeTruthy();
+  });
+
+  it('displays search results when query has results', () => {
+    mockUseSearchScreenReturn = {
+      ...mockUseSearchScreenReturn,
+      query: '仙台',
+      results: [
+        { spot: mockSpots[0], distance: 1.2 },
+        { spot: mockSpots[1], distance: 3.5 },
+      ],
+    };
+
+    const { getByText } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByText('検索結果')).toBeTruthy();
+  });
+
+  it('displays empty message when query has no results', () => {
+    mockUseSearchScreenReturn = {
+      ...mockUseSearchScreenReturn,
+      query: 'xxxxxx',
+      results: [],
+    };
+
+    const { getByText } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    expect(getByText('見つかりませんでした')).toBeTruthy();
+  });
+
+  it('navigates to SpotDetail when result card is pressed', () => {
+    mockUseSearchScreenReturn = {
+      ...mockUseSearchScreenReturn,
+      query: '仙台',
+      results: [{ spot: mockSpots[0], distance: 1.2 }],
+    };
+
+    const { getAllByTestId } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    fireEvent.press(getAllByTestId('search-result-card')[0]);
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('SpotDetail', { spotId: 'spot-1' });
+  });
+
+  it('calls setQuery when text is entered in search bar', () => {
+    const { getByTestId } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    fireEvent.changeText(getByTestId('search-input'), '仙台');
+    expect(mockSetQuery).toHaveBeenCalledWith('仙台');
+  });
+
+  it('shows clear button and calls clearSearch when pressed', () => {
+    mockUseSearchScreenReturn = {
+      ...mockUseSearchScreenReturn,
+      query: '仙台',
+      results: [{ spot: mockSpots[0], distance: 1.2 }],
+    };
+
+    const { getByTestId } = render(
+      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+    );
+    fireEvent.press(getByTestId('search-clear-button'));
+    expect(mockClearSearch).toHaveBeenCalled();
+  });
+});

--- a/src/utils/__tests__/geo.test.ts
+++ b/src/utils/__tests__/geo.test.ts
@@ -1,6 +1,7 @@
 import {
   calculateDistance,
   getBoundingBox,
+  formatDistance,
   DEFAULT_RADIUS_KM,
   RADIUS_STEPS,
   MIN_SPOTS_THRESHOLD,
@@ -52,6 +53,24 @@ describe('geo utilities', () => {
       const large = getBoundingBox(38.2682, 140.8694, 5);
       expect(large.maxLat - large.minLat).toBeGreaterThan(small.maxLat - small.minLat);
       expect(large.maxLng - large.minLng).toBeGreaterThan(small.maxLng - small.minLng);
+    });
+  });
+
+  describe('formatDistance', () => {
+    it('formats meters when less than 1km', () => {
+      expect(formatDistance(0.5)).toBe('500m');
+    });
+
+    it('formats km when 1km or more', () => {
+      expect(formatDistance(1.5)).toBe('1.5km');
+    });
+
+    it('rounds meters to nearest integer', () => {
+      expect(formatDistance(0.123)).toBe('123m');
+    });
+
+    it('formats exactly 1km as km', () => {
+      expect(formatDistance(1.0)).toBe('1.0km');
     });
   });
 

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -40,6 +40,11 @@ export function getBoundingBox(lat: number, lng: number, radiusKm: number): Boun
   };
 }
 
+export function formatDistance(km: number): string {
+  if (km < 1) return `${Math.round(km * 1000)}m`;
+  return `${km.toFixed(1)}km`;
+}
+
 export const DEFAULT_RADIUS_KM = 2;
 export const RADIUS_STEPS = [2, 3, 5, 10];
 export const MIN_SPOTS_THRESHOLD = 5;


### PR DESCRIPTION
## Summary
- マップ画面の検索バータップで専用の SearchScreen に遷移する機能を追加
- 検索バーのUI・位置がマップ画面と検索画面で一致し、パッと切り替わるUX
- フィルターチップ（すべて/神社/寺院）による検索結果の絞り込み
- スクロール・チップタップ時のキーボード自動非表示

## Test plan
- [x] テスト: 464/464 通過
- [x] Lint: 0 errors
- [x] 型チェック: OK
- [x] 検索バーのどこをタップしても検索画面に遷移する
- [x] 検索画面の ← アイコンタップでマップに戻る
- [x] テキスト入力で検索結果が表示される
- [x] フィルターチップ切替とキーボード非表示が同時に動作する
- [x] スクロール時にキーボードが自動で非表示になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)