### PR TITLE
feat(search): 検索画面に検索履歴・検索バー背景色改善を追加

### DIFF
--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -85,7 +85,7 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: colors.white,
+    backgroundColor: colors.gray[100],
     borderRadius: borderRadius.xl,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,

--- a/src/components/search/SearchHistoryList.tsx
+++ b/src/components/search/SearchHistoryList.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { View, Text, FlatList, Pressable, TouchableOpacity, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import type { SearchHistoryItem } from '@hooks/useSearchHistory';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
+
+interface SearchHistoryListProps {
+  history: SearchHistoryItem[];
+  onSelect: (item: SearchHistoryItem) => void;
+  onClear: () => void;
+}
+
+export function SearchHistoryList({ history, onSelect, onClear }: SearchHistoryListProps) {
+  const renderHeader = () => {
+    if (history.length === 0) {
+      return null;
+    }
+
+    return (
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>最近の検索</Text>
+        <TouchableOpacity testID="clear-history-button" onPress={onClear}>
+          <Text style={styles.clearButton}>クリア</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  };
+
+  const renderEmpty = () => (
+    <View style={styles.emptyContainer}>
+      <Text style={styles.emptyText}>検索履歴はありません</Text>
+    </View>
+  );
+
+  const renderItem = ({ item }: { item: SearchHistoryItem }) => (
+    <Pressable testID="history-item" style={styles.item} onPress={() => onSelect(item)}>
+      <MaterialIcons name="history" size={20} color={colors.gray[400]} />
+      <Text style={styles.itemText}>{item.spotName}</Text>
+    </Pressable>
+  );
+
+  return (
+    <FlatList
+      data={history}
+      keyExtractor={item => item.spotId}
+      renderItem={renderItem}
+      ListHeaderComponent={renderHeader}
+      ListEmptyComponent={renderEmpty}
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  headerTitle: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  clearButton: {
+    ...typography.bodySmall,
+    color: colors.primary[500],
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  itemText: {
+    ...typography.body,
+    color: colors.gray[800],
+  },
+  emptyContainer: {
+    alignItems: 'center',
+    paddingTop: 100,
+  },
+  emptyText: {
+    ...typography.body,
+    color: colors.gray[400],
+  },
+});

--- a/src/components/search/__tests__/SearchHistoryList.test.tsx
+++ b/src/components/search/__tests__/SearchHistoryList.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { SearchHistoryList } from '../SearchHistoryList';
+import type { SearchHistoryItem } from '@hooks/useSearchHistory';
+
+describe('SearchHistoryList', () => {
+  const mockHistory: SearchHistoryItem[] = [
+    { spotId: 'spot-1', spotName: '青葉神社' },
+    { spotId: 'spot-2', spotName: '仙台東照宮' },
+    { spotId: 'spot-3', spotName: '大崎八幡宮' },
+  ];
+  const mockOnSelect = jest.fn();
+  const mockOnClear = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('履歴がある場合に「最近の検索」ヘッダーが表示される', () => {
+    const { getByText } = render(
+      <SearchHistoryList history={mockHistory} onSelect={mockOnSelect} onClear={mockOnClear} />
+    );
+    expect(getByText('最近の検索')).toBeTruthy();
+  });
+
+  it('履歴項目のスポット名が正しく表示される', () => {
+    const { getByText } = render(
+      <SearchHistoryList history={mockHistory} onSelect={mockOnSelect} onClear={mockOnClear} />
+    );
+    expect(getByText('青葉神社')).toBeTruthy();
+    expect(getByText('仙台東照宮')).toBeTruthy();
+    expect(getByText('大崎八幡宮')).toBeTruthy();
+  });
+
+  it('履歴項目タップで onSelect がアイテムごと呼ばれる', () => {
+    const { getAllByTestId } = render(
+      <SearchHistoryList history={mockHistory} onSelect={mockOnSelect} onClear={mockOnClear} />
+    );
+    fireEvent.press(getAllByTestId('history-item')[0]);
+    expect(mockOnSelect).toHaveBeenCalledWith({ spotId: 'spot-1', spotName: '青葉神社' });
+  });
+
+  it('クリアボタンタップで onClear が呼ばれる', () => {
+    const { getByTestId } = render(
+      <SearchHistoryList history={mockHistory} onSelect={mockOnSelect} onClear={mockOnClear} />
+    );
+    fireEvent.press(getByTestId('clear-history-button'));
+    expect(mockOnClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('履歴が空の場合に「検索履歴はありません」が表示される', () => {
+    const { getByText } = render(
+      <SearchHistoryList history={[]} onSelect={mockOnSelect} onClear={mockOnClear} />
+    );
+    expect(getByText('検索履歴はありません')).toBeTruthy();
+  });
+
+  it('履歴が空の場合にクリアボタンが表示されない', () => {
+    const { queryByTestId } = render(
+      <SearchHistoryList history={[]} onSelect={mockOnSelect} onClear={mockOnClear} />
+    );
+    expect(queryByTestId('clear-history-button')).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useSearchHistory.test.ts
+++ b/src/hooks/__tests__/useSearchHistory.test.ts
@@ -1,0 +1,105 @@
+import { renderHook, act } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useSearchHistory } from '@hooks/useSearchHistory';
+
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
+const mockSetItem = AsyncStorage.setItem as jest.Mock;
+const mockRemoveItem = AsyncStorage.removeItem as jest.Mock;
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(() => Promise.resolve(null)),
+  setItem: jest.fn(() => Promise.resolve()),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useSearchHistory', () => {
+  it('初期状態で history が空配列、isLoading が false になる', async () => {
+    const { result } = renderHook(() => useSearchHistory());
+    await act(async () => {});
+    expect(result.current.history).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('addHistory でスポットが履歴に追加される', async () => {
+    const { result } = renderHook(() => useSearchHistory());
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.addHistory({ spotId: 'spot-1', spotName: '青葉神社' });
+    });
+
+    expect(result.current.history).toEqual([{ spotId: 'spot-1', spotName: '青葉神社' }]);
+    expect(mockSetItem).toHaveBeenCalledWith(
+      'search_history',
+      JSON.stringify([{ spotId: 'spot-1', spotName: '青葉神社' }])
+    );
+  });
+
+  it('重複するスポットは先頭に移動される', async () => {
+    mockGetItem.mockResolvedValueOnce(
+      JSON.stringify([
+        { spotId: 'spot-1', spotName: '青葉神社' },
+        { spotId: 'spot-2', spotName: '仙台東照宮' },
+      ])
+    );
+    const { result } = renderHook(() => useSearchHistory());
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.addHistory({ spotId: 'spot-2', spotName: '仙台東照宮' });
+    });
+
+    expect(result.current.history[0]).toEqual({ spotId: 'spot-2', spotName: '仙台東照宮' });
+    expect(result.current.history[1]).toEqual({ spotId: 'spot-1', spotName: '青葉神社' });
+    expect(result.current.history).toHaveLength(2);
+  });
+
+  it('最大10件を超えると古い履歴が削除される', async () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({
+      spotId: `spot-${i}`,
+      spotName: `Spot ${i}`,
+    }));
+    mockGetItem.mockResolvedValueOnce(JSON.stringify(items));
+    const { result } = renderHook(() => useSearchHistory());
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.addHistory({ spotId: 'spot-new', spotName: 'New Spot' });
+    });
+
+    expect(result.current.history).toHaveLength(10);
+    expect(result.current.history[0]).toEqual({ spotId: 'spot-new', spotName: 'New Spot' });
+    expect(result.current.history.find(h => h.spotId === 'spot-9')).toBeUndefined();
+  });
+
+  it('空の spotId は追加されない', async () => {
+    const { result } = renderHook(() => useSearchHistory());
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.addHistory({ spotId: '', spotName: '' });
+    });
+
+    expect(result.current.history).toEqual([]);
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+
+  it('clearHistory で全履歴が削除される', async () => {
+    mockGetItem.mockResolvedValueOnce(JSON.stringify([{ spotId: 'spot-1', spotName: '青葉神社' }]));
+    const { result } = renderHook(() => useSearchHistory());
+    await act(async () => {});
+
+    expect(result.current.history).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.clearHistory();
+    });
+
+    expect(result.current.history).toEqual([]);
+    expect(mockRemoveItem).toHaveBeenCalledWith('search_history');
+  });
+});

--- a/src/hooks/__tests__/useSearchScreen.test.ts
+++ b/src/hooks/__tests__/useSearchScreen.test.ts
@@ -55,11 +55,10 @@ beforeEach(() => {
 });
 
 describe('useSearchScreen', () => {
-  it('初期状態で query が空、results が空、nearbySpots が返る', () => {
+  it('初期状態で query が空、results が空', () => {
     const { result } = renderHook(() => useSearchScreen());
     expect(result.current.query).toBe('');
     expect(result.current.results).toEqual([]);
-    expect(result.current.nearbySpots).toHaveLength(3);
     expect(result.current.filterType).toBe('all');
   });
 
@@ -127,15 +126,20 @@ describe('useSearchScreen', () => {
     jest.useRealTimers();
   });
 
-  it('nearbySpots は filterType を適用しない（常に最寄り3件）', () => {
+  it('filterType 変更後も results はフィルタに従う', () => {
+    jest.useFakeTimers();
     const { result } = renderHook(() => useSearchScreen());
 
     act(() => {
-      result.current.setFilterType('shrine');
+      result.current.setQuery('e');
+      result.current.setFilterType('temple');
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
     });
 
-    // filterType が shrine でも nearbySpots は全種別の最寄り3件
-    expect(result.current.nearbySpots).toHaveLength(3);
+    expect(result.current.results.every(r => r.spot.type === 'temple')).toBe(true);
+    jest.useRealTimers();
   });
 
   it('results は距離順にソートされる', () => {

--- a/src/hooks/useSearchHistory.ts
+++ b/src/hooks/useSearchHistory.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect, useCallback } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = 'search_history';
+const MAX_HISTORY = 10;
+
+export interface SearchHistoryItem {
+  spotId: string;
+  spotName: string;
+}
+
+interface UseSearchHistoryReturn {
+  history: SearchHistoryItem[];
+  isLoading: boolean;
+  addHistory: (item: SearchHistoryItem) => Promise<void>;
+  clearHistory: () => Promise<void>;
+}
+
+export function useSearchHistory(): UseSearchHistoryReturn {
+  const [history, setHistory] = useState<SearchHistoryItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY).then(value => {
+      if (value) {
+        try {
+          const parsed = JSON.parse(value);
+          setHistory(Array.isArray(parsed) ? parsed : []);
+        } catch {
+          setHistory([]);
+        }
+      }
+      setIsLoading(false);
+    });
+  }, []);
+
+  const addHistory = useCallback(async (item: SearchHistoryItem) => {
+    if (!item.spotId || !item.spotName) return;
+
+    setHistory(prev => {
+      const filtered = prev.filter(h => h.spotId !== item.spotId);
+      const next = [item, ...filtered].slice(0, MAX_HISTORY);
+      AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
+  const clearHistory = useCallback(async () => {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+    setHistory([]);
+  }, []);
+
+  return { history, isLoading, addHistory, clearHistory };
+}

--- a/src/hooks/useSearchScreen.ts
+++ b/src/hooks/useSearchScreen.ts
@@ -13,14 +13,12 @@ export interface UseSearchScreenReturn {
   query: string;
   setQuery: (text: string) => void;
   results: SpotWithDistance[];
-  nearbySpots: SpotWithDistance[];
   filterType: 'all' | 'shrine' | 'temple';
   setFilterType: (type: 'all' | 'shrine' | 'temple') => void;
   clearSearch: () => void;
 }
 
 const DEBOUNCE_MS = 300;
-const MAX_NEARBY = 3;
 
 export function useSearchScreen(): UseSearchScreenReturn {
   const { location } = useLocation();
@@ -50,8 +48,6 @@ export function useSearchScreen(): UseSearchScreenReturn {
       .sort((a, b) => a.distance - b.distance);
   }, [allSpots, location]);
 
-  const nearbySpots = useMemo(() => spotsWithDistance.slice(0, MAX_NEARBY), [spotsWithDistance]);
-
   const results = useMemo(() => {
     if (!debouncedQuery) return [];
     const lower = debouncedQuery.toLowerCase();
@@ -70,7 +66,6 @@ export function useSearchScreen(): UseSearchScreenReturn {
     query,
     setQuery,
     results,
-    nearbySpots,
     filterType,
     setFilterType,
     clearSearch,

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -6,7 +6,10 @@ import { MaterialIcons } from '@expo/vector-icons';
 import { SearchBar } from '@components/common/SearchBar';
 import { FilterChips } from '@components/common/FilterChips';
 import { SearchResultCard } from '@components/search/SearchResultCard';
+import { SearchHistoryList } from '@components/search/SearchHistoryList';
 import { useSearchScreen } from '@hooks/useSearchScreen';
+import { useSearchHistory } from '@hooks/useSearchHistory';
+import type { SearchHistoryItem } from '@hooks/useSearchHistory';
 import type { MapStackScreenProps } from '@/navigation/types';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
@@ -21,14 +24,22 @@ const FILTER_OPTIONS = [
 ];
 
 export function SearchScreen({ navigation }: Props) {
-  const { query, setQuery, results, nearbySpots, filterType, setFilterType, clearSearch } =
-    useSearchScreen();
+  const { query, setQuery, results, filterType, setFilterType, clearSearch } = useSearchScreen();
+  const { history, addHistory, clearHistory } = useSearchHistory();
   const insets = useSafeAreaInsets();
 
   const searchRowTop = insets.top + spacing.xs;
   const hasQuery = query.length > 0;
-  const displayData = hasQuery ? results : nearbySpots;
   const showEmpty = hasQuery && results.length === 0;
+
+  const handleResultPress = (spotId: string, spotName: string) => {
+    addHistory({ spotId, spotName });
+    navigation.navigate('SpotDetail', { spotId });
+  };
+
+  const handleHistorySelect = (item: SearchHistoryItem) => {
+    navigation.navigate('SpotDetail', { spotId: item.spotId });
+  };
 
   return (
     <View style={styles.container} testID="search-screen">
@@ -47,50 +58,58 @@ export function SearchScreen({ navigation }: Props) {
       </View>
 
       <View style={{ marginTop: searchRowTop + 52, flex: 1 }}>
-        {showEmpty ? (
-          <FlatList
-            data={[]}
-            renderItem={() => null}
-            keyboardShouldPersistTaps="handled"
-            keyboardDismissMode="on-drag"
-            ListHeaderComponent={
-              <>
-                <FilterChips
-                  options={FILTER_OPTIONS}
-                  selectedKey={filterType}
-                  onSelect={key => setFilterType(key as 'all' | 'shrine' | 'temple')}
+        {hasQuery ? (
+          showEmpty ? (
+            <FlatList
+              data={[]}
+              renderItem={() => null}
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag"
+              ListHeaderComponent={
+                <>
+                  <FilterChips
+                    options={FILTER_OPTIONS}
+                    selectedKey={filterType}
+                    onSelect={key => setFilterType(key as 'all' | 'shrine' | 'temple')}
+                  />
+                  <View style={styles.emptyContainer}>
+                    <MaterialIcons name="search-off" size={48} color={colors.gray[300]} />
+                    <Text style={styles.emptyText}>見つかりませんでした</Text>
+                  </View>
+                </>
+              }
+            />
+          ) : (
+            <FlatList
+              data={results}
+              keyExtractor={item => item.spot.id}
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag"
+              ListHeaderComponent={
+                <>
+                  <FilterChips
+                    options={FILTER_OPTIONS}
+                    selectedKey={filterType}
+                    onSelect={key => setFilterType(key as 'all' | 'shrine' | 'temple')}
+                  />
+                  <Text style={styles.sectionTitle}>検索結果</Text>
+                </>
+              }
+              renderItem={({ item }) => (
+                <SearchResultCard
+                  spot={item.spot}
+                  distance={item.distance}
+                  query={query}
+                  onPress={() => handleResultPress(item.spot.id, item.spot.name)}
                 />
-                <View style={styles.emptyContainer}>
-                  <MaterialIcons name="search-off" size={48} color={colors.gray[300]} />
-                  <Text style={styles.emptyText}>見つかりませんでした</Text>
-                </View>
-              </>
-            }
-          />
+              )}
+            />
+          )
         ) : (
-          <FlatList
-            data={displayData}
-            keyExtractor={item => item.spot.id}
-            keyboardShouldPersistTaps="handled"
-            keyboardDismissMode="on-drag"
-            ListHeaderComponent={
-              <>
-                <FilterChips
-                  options={FILTER_OPTIONS}
-                  selectedKey={filterType}
-                  onSelect={key => setFilterType(key as 'all' | 'shrine' | 'temple')}
-                />
-                <Text style={styles.sectionTitle}>{hasQuery ? '検索結果' : '近くのスポット'}</Text>
-              </>
-            }
-            renderItem={({ item }) => (
-              <SearchResultCard
-                spot={item.spot}
-                distance={item.distance}
-                query={query}
-                onPress={() => navigation.navigate('SpotDetail', { spotId: item.spot.id })}
-              />
-            )}
+          <SearchHistoryList
+            history={history}
+            onSelect={handleHistorySelect}
+            onClear={clearHistory}
           />
         )}
       </View>

--- a/src/screens/__tests__/SearchScreen.test.tsx
+++ b/src/screens/__tests__/SearchScreen.test.tsx
@@ -41,19 +41,6 @@ const mockSpots = [
     created_at: '2024-01-01',
     updated_at: '2024-01-01',
   },
-  {
-    id: 'spot-3',
-    name: '大崎八幡宮',
-    lat: 38.27,
-    lng: 140.86,
-    type: 'shrine' as const,
-    status: 'active' as const,
-    address: '仙台市青葉区八幡4-6-1',
-    created_by_user_id: null,
-    merged_into_spot_id: null,
-    created_at: '2024-01-01',
-    updated_at: '2024-01-01',
-  },
 ];
 
 const mockSetQuery = jest.fn();
@@ -64,7 +51,6 @@ let mockUseSearchScreenReturn = {
   query: '',
   setQuery: mockSetQuery,
   results: [] as { spot: (typeof mockSpots)[0]; distance: number }[],
-  nearbySpots: mockSpots.map(s => ({ spot: s, distance: 1.5 })),
   filterType: 'all' as 'all' | 'shrine' | 'temple',
   setFilterType: mockSetFilterType,
   clearSearch: mockClearSearch,
@@ -72,6 +58,23 @@ let mockUseSearchScreenReturn = {
 
 jest.mock('@hooks/useSearchScreen', () => ({
   useSearchScreen: () => mockUseSearchScreenReturn,
+}));
+
+const mockAddHistory = jest.fn();
+const mockClearHistory = jest.fn();
+
+let mockUseSearchHistoryReturn = {
+  history: [
+    { spotId: 'spot-1', spotName: '仙台東照宮' },
+    { spotId: 'spot-2', spotName: '仙台成田山' },
+  ],
+  isLoading: false,
+  addHistory: mockAddHistory,
+  clearHistory: mockClearHistory,
+};
+
+jest.mock('@hooks/useSearchHistory', () => ({
+  useSearchHistory: () => mockUseSearchHistoryReturn,
 }));
 
 const mockNavigation = {
@@ -104,10 +107,18 @@ describe('SearchScreen', () => {
       query: '',
       setQuery: mockSetQuery,
       results: [],
-      nearbySpots: mockSpots.map(s => ({ spot: s, distance: 1.5 })),
       filterType: 'all',
       setFilterType: mockSetFilterType,
       clearSearch: mockClearSearch,
+    };
+    mockUseSearchHistoryReturn = {
+      history: [
+        { spotId: 'spot-1', spotName: '仙台東照宮' },
+        { spotId: 'spot-2', spotName: '仙台成田山' },
+      ],
+      isLoading: false,
+      addHistory: mockAddHistory,
+      clearHistory: mockClearHistory,
     };
   });
 
@@ -140,74 +151,121 @@ describe('SearchScreen', () => {
     expect(getByTestId('search-bar')).toBeTruthy();
   });
 
-  it('displays filter chips', () => {
-    const { getByTestId } = render(
-      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
-    );
-    expect(getByTestId('filter-chip-all')).toBeTruthy();
-    expect(getByTestId('filter-chip-shrine')).toBeTruthy();
-    expect(getByTestId('filter-chip-temple')).toBeTruthy();
+  describe('Search history (query empty)', () => {
+    it('displays search history when query is empty', () => {
+      const { getByText } = render(
+        <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+      expect(getByText('最近の検索')).toBeTruthy();
+      expect(getByText('仙台東照宮')).toBeTruthy();
+      expect(getByText('仙台成田山')).toBeTruthy();
+    });
+
+    it('displays empty history message when no history', () => {
+      mockUseSearchHistoryReturn = {
+        ...mockUseSearchHistoryReturn,
+        history: [],
+      };
+
+      const { getByText } = render(
+        <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+      expect(getByText('検索履歴はありません')).toBeTruthy();
+    });
+
+    it('navigates to SpotDetail when history item is tapped', () => {
+      const { getAllByTestId } = render(
+        <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+      fireEvent.press(getAllByTestId('history-item')[0]);
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('SpotDetail', { spotId: 'spot-1' });
+    });
+
+    it('clears history when clear button is pressed', () => {
+      const { getByTestId } = render(
+        <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+      fireEvent.press(getByTestId('clear-history-button'));
+      expect(mockClearHistory).toHaveBeenCalled();
+    });
   });
 
-  it('calls setFilterType when filter chip is pressed', () => {
-    const { getByTestId } = render(
-      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
-    );
-    fireEvent.press(getByTestId('filter-chip-shrine'));
-    expect(mockSetFilterType).toHaveBeenCalledWith('shrine');
-  });
+  describe('Search results (query present)', () => {
+    it('displays filter chips when query is present', () => {
+      mockUseSearchScreenReturn = {
+        ...mockUseSearchScreenReturn,
+        query: '仙台',
+        results: [{ spot: mockSpots[0], distance: 1.2 }],
+      };
 
-  it('displays nearby spots when query is empty', () => {
-    const { getByText } = render(
-      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
-    );
-    expect(getByText('近くのスポット')).toBeTruthy();
-    expect(getByText('仙台東照宮')).toBeTruthy();
-    expect(getByText('仙台成田山')).toBeTruthy();
-    expect(getByText('大崎八幡宮')).toBeTruthy();
-  });
+      const { getByTestId } = render(
+        <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+      expect(getByTestId('filter-chip-all')).toBeTruthy();
+      expect(getByTestId('filter-chip-shrine')).toBeTruthy();
+      expect(getByTestId('filter-chip-temple')).toBeTruthy();
+    });
 
-  it('displays search results when query has results', () => {
-    mockUseSearchScreenReturn = {
-      ...mockUseSearchScreenReturn,
-      query: '仙台',
-      results: [
-        { spot: mockSpots[0], distance: 1.2 },
-        { spot: mockSpots[1], distance: 3.5 },
-      ],
-    };
+    it('calls setFilterType when filter chip is pressed', () => {
+      mockUseSearchScreenReturn = {
+        ...mockUseSearchScreenReturn,
+        query: '仙台',
+        results: [{ spot: mockSpots[0], distance: 1.2 }],
+      };
 
-    const { getByText } = render(
-      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
-    );
-    expect(getByText('検索結果')).toBeTruthy();
-  });
+      const { getByTestId } = render(
+        <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+      fireEvent.press(getByTestId('filter-chip-shrine'));
+      expect(mockSetFilterType).toHaveBeenCalledWith('shrine');
+    });
 
-  it('displays empty message when query has no results', () => {
-    mockUseSearchScreenReturn = {
-      ...mockUseSearchScreenReturn,
-      query: 'xxxxxx',
-      results: [],
-    };
+    it('displays search results', () => {
+      mockUseSearchScreenReturn = {
+        ...mockUseSearchScreenReturn,
+        query: '仙台',
+        results: [
+          { spot: mockSpots[0], distance: 1.2 },
+          { spot: mockSpots[1], distance: 3.5 },
+        ],
+      };
 
-    const { getByText } = render(
-      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
-    );
-    expect(getByText('見つかりませんでした')).toBeTruthy();
-  });
+      const { getByText } = render(
+        <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+      expect(getByText('検索結果')).toBeTruthy();
+    });
 
-  it('navigates to SpotDetail when result card is pressed', () => {
-    mockUseSearchScreenReturn = {
-      ...mockUseSearchScreenReturn,
-      query: '仙台',
-      results: [{ spot: mockSpots[0], distance: 1.2 }],
-    };
+    it('displays empty message when query has no results', () => {
+      mockUseSearchScreenReturn = {
+        ...mockUseSearchScreenReturn,
+        query: 'xxxxxx',
+        results: [],
+      };
 
-    const { getAllByTestId } = render(
-      <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
-    );
-    fireEvent.press(getAllByTestId('search-result-card')[0]);
-    expect(mockNavigation.navigate).toHaveBeenCalledWith('SpotDetail', { spotId: 'spot-1' });
+      const { getByText } = render(
+        <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+      expect(getByText('見つかりませんでした')).toBeTruthy();
+    });
+
+    it('adds spot to history and navigates when result card is pressed', () => {
+      mockUseSearchScreenReturn = {
+        ...mockUseSearchScreenReturn,
+        query: '仙台',
+        results: [{ spot: mockSpots[0], distance: 1.2 }],
+      };
+
+      const { getAllByTestId } = render(
+        <SearchScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+      fireEvent.press(getAllByTestId('search-result-card')[0]);
+      expect(mockAddHistory).toHaveBeenCalledWith({
+        spotId: 'spot-1',
+        spotName: '仙台東照宮',
+      });
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('SpotDetail', { spotId: 'spot-1' });
+    });
   });
 
   it('calls setQuery when text is entered in search bar', () => {


### PR DESCRIPTION
## Summary
- 検索結果からスポット詳細に遷移した際にスポット名を検索履歴に保存
- 履歴タップで直接スポット詳細画面に遷移（1タップで到達）
- AsyncStorage で最大10件の履歴を永続化、全履歴クリア機能
- 検索バーの背景色を white → gray[100] に変更し視認性向上

## Test plan
- [x] テスト: 479/479 通過
- [x] Lint: 0 errors
- [x] 型チェック: OK
- [x] 検索結果タップ → スポット詳細遷移 + 履歴にスポット名が保存される
- [x] 履歴タップ → 直接スポット詳細画面に遷移する
- [x] 履歴クリアで全履歴が消える
- [x] 検索バーの背景色が両画面で視認しやすい

🤖 Generated with [Claude Code](https://claude.com/claude-code)