### PR TITLE
feat(map): マーカータップ・検索フォーカス時にボトムシートでスポット詳細を表示

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -98,6 +98,7 @@ jest.mock('react-native-maps', () => {
   const MockMapView = React.forwardRef((props, ref) => {
     React.useImperativeHandle(ref, () => ({
       animateToRegion: jest.fn(),
+      animateCamera: jest.fn(),
     }));
     return React.createElement(
       View,

--- a/src/components/spot-detail/SpotBottomSheet.tsx
+++ b/src/components/spot-detail/SpotBottomSheet.tsx
@@ -1,0 +1,207 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Animated, Dimensions, PanResponder, ScrollView, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { SpotCompactCard } from './SpotCompactCard';
+import { SpotDetailContent } from './SpotDetailContent';
+import { useSpotDetail } from '@hooks/useSpotDetail';
+import { useSpotStamps } from '@hooks/useSpotStamps';
+import { useAuth } from '@hooks/useAuth';
+import { colors } from '@theme/colors';
+import { borderRadius } from '@theme/spacing';
+import { shadows } from '@theme/shadows';
+
+interface SpotBottomSheetProps {
+  spotId: string | null;
+  visitedSpotIds: Set<string>;
+  onDismiss: () => void;
+  onRecord: (spotId: string) => void;
+}
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
+const COMPACT_HEIGHT = 180;
+
+type SheetMode = 'hidden' | 'compact' | 'expanded';
+
+export function SpotBottomSheet({
+  spotId,
+  visitedSpotIds,
+  onDismiss,
+  onRecord,
+}: SpotBottomSheetProps) {
+  const insets = useSafeAreaInsets();
+  const expandedHeight = SCREEN_HEIGHT * 0.85;
+  const { spot } = useSpotDetail(spotId ?? '');
+  const { stamps, visitCount, latestVisitDate } = useSpotStamps(spotId ?? '');
+  const { isAuthenticated } = useAuth();
+
+  const [mode, setMode] = useState<SheetMode>('hidden');
+  const translateY = useRef(new Animated.Value(SCREEN_HEIGHT)).current;
+
+  const compactPosition = SCREEN_HEIGHT - COMPACT_HEIGHT - insets.bottom;
+  const expandedPosition = SCREEN_HEIGHT - expandedHeight;
+
+  // Keep mutable refs so PanResponder always reads latest values
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+  const compactPosRef = useRef(compactPosition);
+  compactPosRef.current = compactPosition;
+  const expandedPosRef = useRef(expandedPosition);
+  expandedPosRef.current = expandedPosition;
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  const animateTo = useCallback(
+    (toValue: number, callback?: () => void) => {
+      Animated.spring(translateY, {
+        toValue,
+        useNativeDriver: true,
+        tension: 65,
+        friction: 11,
+      }).start(callback);
+    },
+    [translateY]
+  );
+
+  const animateToRef = useRef(animateTo);
+  animateToRef.current = animateTo;
+
+  useEffect(() => {
+    if (spotId && spot) {
+      setMode('compact');
+      animateTo(compactPosition);
+    } else {
+      animateTo(SCREEN_HEIGHT, () => {
+        setMode('hidden');
+      });
+    }
+  }, [spotId, spot, compactPosition, animateTo]);
+
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => false,
+        onMoveShouldSetPanResponder: (_, gestureState) => {
+          // Only capture vertical drags
+          return (
+            Math.abs(gestureState.dy) > 8 && Math.abs(gestureState.dy) > Math.abs(gestureState.dx)
+          );
+        },
+        onPanResponderMove: (_, gestureState) => {
+          const currentPos =
+            modeRef.current === 'expanded' ? expandedPosRef.current : compactPosRef.current;
+          const newY = currentPos + gestureState.dy;
+          const clampedY = Math.max(expandedPosRef.current, newY);
+          translateY.setValue(clampedY);
+        },
+        onPanResponderRelease: (_, gestureState) => {
+          const { dy, vy } = gestureState;
+          const animate = animateToRef.current;
+
+          if (modeRef.current === 'compact') {
+            if (dy < -40 || vy < -0.3) {
+              setMode('expanded');
+              animate(expandedPosRef.current);
+            } else if (dy > 40 || vy > 0.3) {
+              animate(SCREEN_HEIGHT, () => {
+                setMode('hidden');
+                onDismissRef.current();
+              });
+            } else {
+              animate(compactPosRef.current);
+            }
+          } else if (modeRef.current === 'expanded') {
+            if (dy > 80 || vy > 0.5) {
+              setMode('compact');
+              animate(compactPosRef.current);
+            } else {
+              animate(expandedPosRef.current);
+            }
+          }
+        },
+      }),
+    [translateY]
+  );
+
+  const handleRecord = useCallback(() => {
+    if (spotId) {
+      onRecord(spotId);
+    }
+  }, [spotId, onRecord]);
+
+  const isVisited = spotId ? visitedSpotIds.has(spotId) : false;
+
+  if (!spotId || !spot) {
+    return null;
+  }
+
+  return (
+    <Animated.View
+      style={[
+        styles.container,
+        {
+          height: expandedHeight,
+          transform: [{ translateY }],
+        },
+      ]}
+      testID="bottom-sheet"
+      {...panResponder.panHandlers}
+    >
+      {/* Drag handle */}
+      <View style={styles.handleContainer}>
+        <View style={styles.handle} />
+      </View>
+
+      {/* Compact card (hidden when expanded) */}
+      {mode !== 'expanded' && <SpotCompactCard spot={spot} isVisited={isVisited} />}
+
+      {/* Scrollable detail content (visible when expanded) */}
+      {mode === 'expanded' && (
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator
+        >
+          <SpotDetailContent
+            spot={spot}
+            stamps={stamps}
+            visitCount={visitCount}
+            latestVisitDate={latestVisitDate}
+            isAuthenticated={isAuthenticated}
+            onRecord={handleRecord}
+            showMiniMap={false}
+          />
+        </ScrollView>
+      )}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    backgroundColor: colors.white,
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+    ...shadows.lg,
+  },
+  handleContainer: {
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.gray[300],
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+  },
+});

--- a/src/components/spot-detail/SpotCompactCard.tsx
+++ b/src/components/spot-detail/SpotCompactCard.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+
+import { Badge } from '@components/common/Badge';
+import type { Spot } from '@/types/supabase';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
+
+interface SpotCompactCardProps {
+  spot: Spot;
+  isVisited: boolean;
+}
+
+export function SpotCompactCard({ spot, isVisited }: SpotCompactCardProps) {
+  const badgeType = spot.type === 'shrine' ? 'shrine' : 'temple';
+
+  return (
+    <View style={styles.container} testID="spot-compact-card">
+      <Text style={styles.spotName} numberOfLines={1}>
+        {spot.name}
+      </Text>
+      <View style={styles.badgeRow}>
+        <Badge type={badgeType} />
+        {isVisited && <Badge type="visited" />}
+      </View>
+      {spot.address && (
+        <View style={styles.addressRow} testID="spot-compact-address">
+          <MaterialIcons name="place" size={14} color={colors.gray[400]} />
+          <Text style={styles.address} numberOfLines={1}>
+            {spot.address}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  spotName: {
+    ...typography.h3,
+    color: colors.gray[900],
+    marginBottom: spacing.xs,
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginBottom: spacing.xs,
+  },
+  addressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  address: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+    flex: 1,
+  },
+});

--- a/src/components/spot-detail/SpotDetailContent.tsx
+++ b/src/components/spot-detail/SpotDetailContent.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { Image, StyleSheet, Text, View } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+import { MaterialIcons } from '@expo/vector-icons';
+
+import { Badge } from '@components/common/Badge';
+import { Button } from '@components/common/Button';
+import { Card } from '@components/common/Card';
+import { getStampImageUrl } from '@services/stamps';
+import type { Spot, Stamp } from '@/types/supabase';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+
+interface SpotDetailContentProps {
+  spot: Spot;
+  stamps: Stamp[];
+  visitCount: number;
+  latestVisitDate: string | null;
+  isAuthenticated: boolean;
+  onRecord: () => void;
+  showMiniMap?: boolean;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}/${m}/${day}`;
+}
+
+export function SpotDetailContent({
+  spot,
+  stamps,
+  visitCount,
+  latestVisitDate,
+  isAuthenticated,
+  onRecord,
+  showMiniMap = true,
+}: SpotDetailContentProps) {
+  const badgeType = spot.type === 'shrine' ? 'shrine' : 'temple';
+  const showVisited = isAuthenticated && visitCount > 0;
+
+  return (
+    <View style={styles.content} testID="spot-detail-content">
+      <View style={styles.badgeRow}>
+        <Badge type={badgeType} />
+        {showVisited && <Badge type="visited" />}
+      </View>
+
+      <Text style={styles.spotName} testID="spot-name">
+        {spot.name}
+      </Text>
+      {spot.address && (
+        <View style={styles.addressRow}>
+          <MaterialIcons name="place" size={16} color={colors.gray[400]} />
+          <Text style={styles.address}>{spot.address}</Text>
+        </View>
+      )}
+
+      <Card style={styles.visitCard}>
+        <View style={styles.visitRow}>
+          <View style={styles.visitItem}>
+            <Text style={styles.visitLabel}>種別</Text>
+            <Text style={styles.visitValue}>{spot.type === 'shrine' ? '神社' : '寺院'}</Text>
+          </View>
+          {isAuthenticated && visitCount > 0 && (
+            <>
+              <View style={styles.visitItem}>
+                <Text style={styles.visitLabel}>訪問回数</Text>
+                <Text style={styles.visitValue}>{visitCount}</Text>
+              </View>
+              <View style={styles.visitItem}>
+                <Text style={styles.visitLabel}>最終訪問日</Text>
+                <Text style={styles.visitValue}>
+                  {latestVisitDate ? formatDate(latestVisitDate) : '-'}
+                </Text>
+              </View>
+            </>
+          )}
+        </View>
+      </Card>
+
+      <Button
+        title="ここで記録する"
+        onPress={onRecord}
+        variant="primary"
+        style={styles.recordButton}
+      />
+
+      {stamps.length > 0 && (
+        <>
+          <Text style={styles.sectionTitle}>記録済み御朱印</Text>
+          <View style={styles.stampGrid} testID="stamp-grid">
+            {stamps.map(stamp => (
+              <Image
+                key={stamp.id}
+                source={{ uri: getStampImageUrl(stamp.image_path) }}
+                style={styles.stampImage}
+                testID={`stamp-image-${stamp.id}`}
+              />
+            ))}
+          </View>
+        </>
+      )}
+
+      {showMiniMap && (
+        <>
+          <Text style={styles.sectionTitle}>アクセス</Text>
+          <View style={styles.miniMapContainer} testID="mini-map">
+            <MapView
+              style={styles.miniMapView}
+              initialRegion={{
+                latitude: spot.lat,
+                longitude: spot.lng,
+                latitudeDelta: 0.005,
+                longitudeDelta: 0.005,
+              }}
+              scrollEnabled={false}
+              zoomEnabled={false}
+              rotateEnabled={false}
+              pitchEnabled={false}
+            >
+              <Marker coordinate={{ latitude: spot.lat, longitude: spot.lng }} />
+            </MapView>
+          </View>
+          {spot.address && (
+            <View style={styles.miniMapAddress}>
+              <MaterialIcons name="place" size={16} color={colors.primary[500]} />
+              <Text style={styles.miniMapAddressText}>{spot.address}</Text>
+            </View>
+          )}
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing['3xl'],
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginBottom: spacing.md,
+  },
+  spotName: {
+    ...typography.h2,
+    color: colors.gray[900],
+    marginBottom: spacing.sm,
+  },
+  addressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginBottom: spacing.xl,
+  },
+  address: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+    flex: 1,
+  },
+  visitCard: {
+    marginBottom: spacing.lg,
+  },
+  visitRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  visitItem: {
+    flex: 1,
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  visitLabel: {
+    ...typography.caption,
+    color: colors.gray[500],
+  },
+  visitValue: {
+    ...typography.h3,
+    color: colors.gray[900],
+  },
+  recordButton: {
+    marginBottom: spacing.xl,
+  },
+  sectionTitle: {
+    ...typography.h3,
+    color: colors.gray[800],
+    marginBottom: spacing.md,
+    marginTop: spacing.lg,
+  },
+  stampGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  stampImage: {
+    width: '31.5%',
+    aspectRatio: 1,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.gray[100],
+  },
+  miniMapContainer: {
+    height: 150,
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+  },
+  miniMapView: {
+    flex: 1,
+  },
+  miniMapAddress: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginTop: spacing.md,
+  },
+  miniMapAddressText: {
+    ...typography.bodySmall,
+    color: colors.gray[600],
+    flex: 1,
+  },
+});

--- a/src/components/spot-detail/__tests__/SpotBottomSheet.test.tsx
+++ b/src/components/spot-detail/__tests__/SpotBottomSheet.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { SpotBottomSheet } from '../SpotBottomSheet';
+import type { Spot } from '@/types/supabase';
+
+jest.mock('@services/stamps', () => ({
+  fetchStampsBySpotId: jest.fn(() => Promise.resolve([])),
+  getStampImageUrl: jest.fn((path: string) => `https://example.com/${path}`),
+}));
+
+const mockSpot: Spot = {
+  id: 'spot-1',
+  name: '仙台東照宮',
+  lat: 38.28,
+  lng: 140.88,
+  type: 'shrine',
+  address: '宮城県仙台市青葉区東照宮一丁目6-1',
+  status: 'active',
+  created_by_user_id: null,
+  merged_into_spot_id: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+};
+
+jest.mock('@hooks/useSpotDetail', () => ({
+  useSpotDetail: (spotId: string | null) => ({
+    spot: spotId === 'spot-1' ? mockSpot : null,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('@hooks/useSpotStamps', () => ({
+  useSpotStamps: () => ({
+    stamps: [],
+    visitCount: 2,
+    latestVisitDate: '2024-06-15',
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: 'user-1' },
+  }),
+}));
+
+describe('SpotBottomSheet', () => {
+  const defaultProps = {
+    spotId: 'spot-1' as string | null,
+    visitedSpotIds: new Set(['spot-1']),
+    onDismiss: jest.fn(),
+    onRecord: jest.fn(),
+  };
+
+  it('renders bottom sheet when spotId is provided', () => {
+    const { getByTestId } = render(<SpotBottomSheet {...defaultProps} />);
+    expect(getByTestId('bottom-sheet')).toBeTruthy();
+  });
+
+  it('does not render when spotId is null', () => {
+    const { queryByTestId } = render(<SpotBottomSheet {...defaultProps} spotId={null} />);
+    expect(queryByTestId('bottom-sheet')).toBeNull();
+  });
+
+  it('renders spot name', () => {
+    const { getAllByText } = render(<SpotBottomSheet {...defaultProps} />);
+    expect(getAllByText('仙台東照宮').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders shrine badge', () => {
+    const { getAllByTestId } = render(<SpotBottomSheet {...defaultProps} />);
+    expect(getAllByTestId('badge-shrine').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders visited badge when spot is visited', () => {
+    const { getAllByTestId } = render(<SpotBottomSheet {...defaultProps} />);
+    const visitedBadges = getAllByTestId('badge-visited');
+    expect(visitedBadges.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/components/spot-detail/__tests__/SpotCompactCard.test.tsx
+++ b/src/components/spot-detail/__tests__/SpotCompactCard.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { SpotCompactCard } from '../SpotCompactCard';
+import type { Spot } from '@/types/supabase';
+
+const mockShrine: Spot = {
+  id: 'spot-1',
+  name: '仙台東照宮',
+  lat: 38.28,
+  lng: 140.88,
+  type: 'shrine',
+  address: '宮城県仙台市青葉区東照宮一丁目6-1',
+  status: 'active',
+  created_by_user_id: null,
+  merged_into_spot_id: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+};
+
+const mockTemple: Spot = {
+  ...mockShrine,
+  id: 'spot-2',
+  name: '瑞巌寺',
+  type: 'temple',
+  address: '宮城県宮城郡松島町松島字町内91',
+};
+
+describe('SpotCompactCard', () => {
+  const defaultProps = {
+    spot: mockShrine,
+    isVisited: false,
+  };
+
+  it('renders spot name', () => {
+    const { getByText } = render(<SpotCompactCard {...defaultProps} />);
+    expect(getByText('仙台東照宮')).toBeTruthy();
+  });
+
+  it('renders shrine badge for shrine type', () => {
+    const { getByTestId } = render(<SpotCompactCard {...defaultProps} />);
+    expect(getByTestId('badge-shrine')).toBeTruthy();
+  });
+
+  it('renders temple badge for temple type', () => {
+    const { getByTestId } = render(<SpotCompactCard {...defaultProps} spot={mockTemple} />);
+    expect(getByTestId('badge-temple')).toBeTruthy();
+  });
+
+  it('renders address', () => {
+    const { getByText } = render(<SpotCompactCard {...defaultProps} />);
+    expect(getByText('宮城県仙台市青葉区東照宮一丁目6-1')).toBeTruthy();
+  });
+
+  it('renders visited badge when isVisited is true', () => {
+    const { getByTestId } = render(<SpotCompactCard {...defaultProps} isVisited={true} />);
+    expect(getByTestId('badge-visited')).toBeTruthy();
+  });
+
+  it('does not render visited badge when isVisited is false', () => {
+    const { queryByTestId } = render(<SpotCompactCard {...defaultProps} isVisited={false} />);
+    expect(queryByTestId('badge-visited')).toBeNull();
+  });
+
+  it('handles null address gracefully', () => {
+    const spotNoAddress = { ...mockShrine, address: null };
+    const { queryByTestId } = render(<SpotCompactCard {...defaultProps} spot={spotNoAddress} />);
+    expect(queryByTestId('spot-compact-address')).toBeNull();
+  });
+});

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import MapView, { Marker, type Region } from 'react-native-maps';
+import MapView, { Marker, type MapPressEvent, type Region } from 'react-native-maps';
 import { MaterialIcons } from '@expo/vector-icons';
 
 import { FABButton } from '@components/animated/FABButton';
@@ -9,6 +9,7 @@ import { SearchBar } from '@components/common/SearchBar';
 import { LoginPromptModal } from '@components/common/LoginPromptModal';
 import { MapPin } from '@components/common/MapPin';
 import { SpotMarker } from '@components/common/SpotMarker';
+import { SpotBottomSheet } from '@components/spot-detail/SpotBottomSheet';
 import { useAuth } from '@hooks/useAuth';
 import { useLocation } from '@hooks/useLocation';
 import { useSpots } from '@hooks/useSpots';
@@ -41,6 +42,7 @@ export function MapScreen({ navigation, route }: Props) {
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [showFilter, setShowFilter] = useState(false);
   const [currentLatitudeDelta, setCurrentLatitudeDelta] = useState(LATITUDE_DELTA);
+  const [selectedSpotId, setSelectedSpotId] = useState<string | null>(null);
   const shouldShowLabels = currentLatitudeDelta <= LABEL_VISIBLE_DELTA;
   const mapRef = useRef<MapView>(null);
   const insets = useSafeAreaInsets();
@@ -63,12 +65,21 @@ export function MapScreen({ navigation, route }: Props) {
       },
       500
     );
+
+    setSelectedSpotId(focusSpotId);
   }, [route.params?.focusSpotId, spots]);
 
-  const navigateToRecord = () => {
+  // Clear selection if the selected spot is no longer in the spots list
+  useEffect(() => {
+    if (selectedSpotId && !spots.find(s => s.id === selectedSpotId)) {
+      setSelectedSpotId(null);
+    }
+  }, [selectedSpotId, spots]);
+
+  const navigateToRecord = (spotId?: string) => {
     const parent = navigation.getParent();
     if (parent) {
-      parent.navigate('Record');
+      parent.navigate('Record', spotId ? { spotId } : undefined);
     }
   };
 
@@ -91,9 +102,42 @@ export function MapScreen({ navigation, route }: Props) {
 
   const handleMarkerPress = useCallback(
     (spotId: string) => {
-      navigation.navigate('SpotDetail', { spotId });
+      setSelectedSpotId(spotId);
+
+      const spot = spots.find(s => s.id === spotId);
+      if (spot && mapRef.current) {
+        mapRef.current.animateCamera(
+          {
+            center: {
+              latitude: spot.lat,
+              longitude: spot.lng,
+            },
+          },
+          { duration: 300 }
+        );
+      }
     },
-    [navigation]
+    [spots]
+  );
+
+  const handleMapPress = useCallback((event?: MapPressEvent) => {
+    if (event?.nativeEvent?.action === 'marker-press') return;
+    setSelectedSpotId(null);
+  }, []);
+
+  const handleBottomSheetDismiss = useCallback(() => {
+    setSelectedSpotId(null);
+  }, []);
+
+  const handleBottomSheetRecord = useCallback(
+    (spotId: string) => {
+      if (isAuthenticated) {
+        navigateToRecord(spotId);
+      } else {
+        setShowLoginModal(true);
+      }
+    },
+    [isAuthenticated]
   );
 
   const handleFilterPress = () => {
@@ -185,6 +229,7 @@ export function MapScreen({ navigation, route }: Props) {
         testID="map-view"
         showsUserLocation={false}
         onRegionChangeComplete={handleRegionChangeComplete}
+        onPress={handleMapPress}
       >
         {location && (
           <Marker
@@ -216,9 +261,18 @@ export function MapScreen({ navigation, route }: Props) {
         ))}
       </MapView>
 
-      <View style={styles.fabContainer}>
-        <FABButton onPress={handleFABPress} />
-      </View>
+      {!selectedSpotId && (
+        <View style={styles.fabContainer}>
+          <FABButton onPress={handleFABPress} />
+        </View>
+      )}
+
+      <SpotBottomSheet
+        spotId={selectedSpotId}
+        visitedSpotIds={visitedSpotIds}
+        onDismiss={handleBottomSheetDismiss}
+        onRecord={handleBottomSheetRecord}
+      />
 
       <LoginPromptModal
         visible={showLoginModal}

--- a/src/screens/SpotDetailScreen.tsx
+++ b/src/screens/SpotDetailScreen.tsx
@@ -1,31 +1,19 @@
 import React from 'react';
-import { ActivityIndicator, Image, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import MapView, { Marker } from 'react-native-maps';
 import { MaterialIcons } from '@expo/vector-icons';
 
-import { Badge } from '@components/common/Badge';
-import { Button } from '@components/common/Button';
-import { Card } from '@components/common/Card';
 import { Header } from '@components/common/Header';
+import { SpotDetailContent } from '@components/spot-detail/SpotDetailContent';
 import { useSpotDetail } from '@hooks/useSpotDetail';
 import { useAuth } from '@hooks/useAuth';
 import { useSpotStamps } from '@hooks/useSpotStamps';
-import { getStampImageUrl } from '@services/stamps';
 import type { MapStackScreenProps } from '@/navigation/types';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
-import { spacing, borderRadius } from '@theme/spacing';
+import { spacing } from '@theme/spacing';
 
 type Props = MapStackScreenProps<'SpotDetail'>;
-
-function formatDate(dateStr: string): string {
-  const d = new Date(dateStr);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}/${m}/${day}`;
-}
 
 export function SpotDetailScreen({ navigation, route }: Props) {
   const { spotId } = route.params;
@@ -67,99 +55,18 @@ export function SpotDetailScreen({ navigation, route }: Props) {
     );
   }
 
-  const badgeType = spot.type === 'shrine' ? 'shrine' : 'temple';
-  const showVisited = isAuthenticated && visitCount > 0;
-
   return (
     <SafeAreaView style={styles.container} testID="spot-detail-screen">
       <Header title="スポット詳細" onBack={handleBack} />
-
       <ScrollView contentContainerStyle={styles.scrollContent}>
-        <View style={styles.badgeRow}>
-          <Badge type={badgeType} />
-          {showVisited && <Badge type="visited" />}
-        </View>
-
-        <Text style={styles.spotName} testID="spot-name">
-          {spot.name}
-        </Text>
-        {spot.address && (
-          <View style={styles.addressRow}>
-            <MaterialIcons name="place" size={16} color={colors.gray[400]} />
-            <Text style={styles.address}>{spot.address}</Text>
-          </View>
-        )}
-
-        <Card style={styles.visitCard}>
-          <View style={styles.visitRow}>
-            <View style={styles.visitItem}>
-              <Text style={styles.visitLabel}>種別</Text>
-              <Text style={styles.visitValue}>{spot.type === 'shrine' ? '神社' : '寺院'}</Text>
-            </View>
-            {isAuthenticated && visitCount > 0 && (
-              <>
-                <View style={styles.visitItem}>
-                  <Text style={styles.visitLabel}>訪問回数</Text>
-                  <Text style={styles.visitValue}>{visitCount}</Text>
-                </View>
-                <View style={styles.visitItem}>
-                  <Text style={styles.visitLabel}>最終訪問日</Text>
-                  <Text style={styles.visitValue}>
-                    {latestVisitDate ? formatDate(latestVisitDate) : '-'}
-                  </Text>
-                </View>
-              </>
-            )}
-          </View>
-        </Card>
-
-        <Button
-          title="ここで記録する"
-          onPress={handleRecord}
-          variant="primary"
-          style={styles.recordButton}
+        <SpotDetailContent
+          spot={spot}
+          stamps={stamps}
+          visitCount={visitCount}
+          latestVisitDate={latestVisitDate}
+          isAuthenticated={isAuthenticated}
+          onRecord={handleRecord}
         />
-
-        {stamps.length > 0 && (
-          <>
-            <Text style={styles.sectionTitle}>記録済み御朱印</Text>
-            <View style={styles.stampGrid} testID="stamp-grid">
-              {stamps.map(stamp => (
-                <Image
-                  key={stamp.id}
-                  source={{ uri: getStampImageUrl(stamp.image_path) }}
-                  style={styles.stampImage}
-                  testID={`stamp-image-${stamp.id}`}
-                />
-              ))}
-            </View>
-          </>
-        )}
-
-        <Text style={styles.sectionTitle}>アクセス</Text>
-        <View style={styles.miniMapContainer} testID="mini-map">
-          <MapView
-            style={styles.miniMapView}
-            initialRegion={{
-              latitude: spot.lat,
-              longitude: spot.lng,
-              latitudeDelta: 0.005,
-              longitudeDelta: 0.005,
-            }}
-            scrollEnabled={false}
-            zoomEnabled={false}
-            rotateEnabled={false}
-            pitchEnabled={false}
-          >
-            <Marker coordinate={{ latitude: spot.lat, longitude: spot.lng }} />
-          </MapView>
-        </View>
-        {spot.address && (
-          <View style={styles.miniMapAddress}>
-            <MaterialIcons name="place" size={16} color={colors.primary[500]} />
-            <Text style={styles.miniMapAddressText}>{spot.address}</Text>
-          </View>
-        )}
       </ScrollView>
     </SafeAreaView>
   );
@@ -181,87 +88,6 @@ const styles = StyleSheet.create({
     color: colors.gray[500],
   },
   scrollContent: {
-    paddingHorizontal: spacing.lg,
-    paddingBottom: spacing['3xl'],
-  },
-  badgeRow: {
-    flexDirection: 'row',
-    gap: spacing.sm,
-    marginBottom: spacing.md,
-  },
-  spotName: {
-    ...typography.h2,
-    color: colors.gray[900],
-    marginBottom: spacing.sm,
-  },
-  addressRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.xs,
-    marginBottom: spacing.xl,
-  },
-  address: {
-    ...typography.bodySmall,
-    color: colors.gray[500],
-    flex: 1,
-  },
-  visitCard: {
-    marginBottom: spacing.lg,
-  },
-  visitRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  visitItem: {
-    flex: 1,
-    alignItems: 'center',
-    gap: spacing.xs,
-  },
-  visitLabel: {
-    ...typography.caption,
-    color: colors.gray[500],
-  },
-  visitValue: {
-    ...typography.h3,
-    color: colors.gray[900],
-  },
-  recordButton: {
-    marginBottom: spacing.xl,
-  },
-  sectionTitle: {
-    ...typography.h3,
-    color: colors.gray[800],
-    marginBottom: spacing.md,
-    marginTop: spacing.lg,
-  },
-  stampGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: spacing.xs,
-  },
-  stampImage: {
-    width: '31.5%',
-    aspectRatio: 1,
-    borderRadius: borderRadius.md,
-    backgroundColor: colors.gray[100],
-  },
-  miniMapContainer: {
-    height: 150,
-    borderRadius: borderRadius.lg,
-    overflow: 'hidden',
-  },
-  miniMapView: {
-    flex: 1,
-  },
-  miniMapAddress: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.xs,
-    marginTop: spacing.md,
-  },
-  miniMapAddressText: {
-    ...typography.bodySmall,
-    color: colors.gray[600],
-    flex: 1,
+    flexGrow: 1,
   },
 });

--- a/src/screens/__tests__/MapScreen.test.tsx
+++ b/src/screens/__tests__/MapScreen.test.tsx
@@ -2,18 +2,61 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { MapScreen } from '@screens/MapScreen';
 
-jest.mock('react-native-safe-area-context', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-  const React = require('react');
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-  const { View } = require('react-native');
-  return {
-    SafeAreaView: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
-      React.createElement(View, props, children),
-    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
-    useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
-  };
-});
+jest.mock('@services/stamps', () => ({
+  fetchStampsBySpotId: jest.fn(() => Promise.resolve([])),
+  getStampImageUrl: jest.fn((path: string) => `https://example.com/${path}`),
+}));
+
+jest.mock('@hooks/useSpotDetail', () => ({
+  useSpotDetail: (spotId: string) => {
+    const spots: Record<string, unknown> = {
+      'spot-1': {
+        spot: {
+          id: 'spot-1',
+          name: 'Test Shrine',
+          lat: 38.27,
+          lng: 140.87,
+          type: 'shrine',
+          status: 'active',
+          address: '宮城県仙台市',
+          created_by_user_id: null,
+          merged_into_spot_id: null,
+          created_at: '2024-01-01',
+          updated_at: '2024-01-01',
+        },
+        isLoading: false,
+        error: null,
+      },
+      'spot-2': {
+        spot: {
+          id: 'spot-2',
+          name: 'Test Temple',
+          lat: 38.28,
+          lng: 140.88,
+          type: 'temple',
+          status: 'active',
+          address: null,
+          created_by_user_id: null,
+          merged_into_spot_id: null,
+          created_at: '2024-01-01',
+          updated_at: '2024-01-01',
+        },
+        isLoading: false,
+        error: null,
+      },
+    };
+    return spots[spotId] ?? { spot: null, isLoading: false, error: null };
+  },
+}));
+
+jest.mock('@hooks/useSpotStamps', () => ({
+  useSpotStamps: () => ({
+    stamps: [],
+    visitCount: 0,
+    latestVisitDate: null,
+    isLoading: false,
+  }),
+}));
 
 let mockUseAuthReturn = {
   user: null,
@@ -49,7 +92,7 @@ const mockSpots = [
     lng: 140.87,
     type: 'shrine',
     status: 'active',
-    address: null,
+    address: '宮城県仙台市',
     created_by_user_id: null,
     merged_into_spot_id: null,
     created_at: '2024-01-01',
@@ -163,7 +206,7 @@ describe('MapScreen', () => {
     expect(getByTestId('map-pin-current-location')).toBeTruthy();
   });
 
-  it('displays FAB button', () => {
+  it('displays FAB button when no spot is selected', () => {
     const { getByTestId } = render(
       <MapScreen navigation={mockNavigation as never} route={mockRoute} />
     );
@@ -189,13 +232,52 @@ describe('MapScreen', () => {
       expect(getAllByTestId('spot-marker-pin-tail')).toHaveLength(2);
     });
 
-    it('navigates to SpotDetail when marker is pressed', () => {
+    it('shows bottom sheet when marker is pressed', () => {
       const { getByTestId } = render(
         <MapScreen navigation={mockNavigation as never} route={mockRoute} />
       );
 
       fireEvent.press(getByTestId('spot-marker-spot-1'));
-      expect(mockNavigation.navigate).toHaveBeenCalledWith('SpotDetail', { spotId: 'spot-1' });
+      expect(getByTestId('bottom-sheet')).toBeTruthy();
+    });
+
+    it('hides FAB when marker is pressed and spot is selected', () => {
+      const { getByTestId, queryByTestId } = render(
+        <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+
+      fireEvent.press(getByTestId('spot-marker-spot-1'));
+      expect(queryByTestId('fab-button')).toBeNull();
+    });
+  });
+
+  describe('Bottom sheet', () => {
+    it('shows bottom sheet when focusSpotId is provided', () => {
+      const routeWithFocus = {
+        key: 'test',
+        name: 'Map' as const,
+        params: { focusSpotId: 'spot-1' },
+      };
+
+      const { getByTestId } = render(
+        <MapScreen navigation={mockNavigation as never} route={routeWithFocus} />
+      );
+
+      expect(getByTestId('bottom-sheet')).toBeTruthy();
+    });
+
+    it('hides bottom sheet when map is pressed', () => {
+      const { getByTestId, queryByTestId } = render(
+        <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+
+      // First show the sheet
+      fireEvent.press(getByTestId('spot-marker-spot-1'));
+      expect(getByTestId('bottom-sheet')).toBeTruthy();
+
+      // Then press the map to dismiss
+      fireEvent.press(getByTestId('map-view'));
+      expect(queryByTestId('bottom-sheet')).toBeNull();
     });
   });
 
@@ -309,23 +391,6 @@ describe('MapScreen', () => {
     });
   });
 
-  describe('Focus spot from search', () => {
-    it('calls animateToRegion when focusSpotId is provided', () => {
-      const routeWithFocus = {
-        key: 'test',
-        name: 'Map' as const,
-        params: { focusSpotId: 'spot-1' },
-      };
-
-      render(<MapScreen navigation={mockNavigation as never} route={routeWithFocus} />);
-
-      // MapView mock should have animateToRegion called
-      // Since react-native-maps is mocked, we verify the component renders without error
-      // and the spot marker is present
-      expect(true).toBe(true);
-    });
-  });
-
   describe('FAB press with authentication', () => {
     it('navigates to Record when authenticated', () => {
       mockUseAuthReturn = {
@@ -339,7 +404,7 @@ describe('MapScreen', () => {
       );
 
       fireEvent.press(getByTestId('fab-button'));
-      expect(mockParentNavigate).toHaveBeenCalledWith('Record');
+      expect(mockParentNavigate).toHaveBeenCalledWith('Record', undefined);
     });
 
     it('shows LoginPromptModal when not authenticated', () => {
@@ -362,7 +427,7 @@ describe('MapScreen', () => {
       fireEvent.press(getByTestId('modal-google-login-button'));
 
       await waitFor(() => {
-        expect(mockParentNavigate).toHaveBeenCalledWith('Record');
+        expect(mockParentNavigate).toHaveBeenCalledWith('Record', undefined);
       });
     });
 


### PR DESCRIPTION
## Summary
- マップ画面でスポットのピンタップや検索結果フォーカス時に、画面下部からGoogle Maps風のボトムシートでスポット情報を表示
- 上スワイプで詳細表示に拡大、下スワイプで閉じる操作感を実装
- SpotDetailScreenの詳細コンテンツを共通コンポーネント（SpotDetailContent）に抽出

## Changes
- **SpotBottomSheet**: Animated API + PanResponderによる2段階ボトムシート（compact → expanded）
- **SpotCompactCard**: コンパクト表示（スポット名・種別バッジ・住所）
- **SpotDetailContent**: SpotDetailScreenから共通化した詳細表示コンポーネント
- **MapScreen**: ボトムシート統合、マーカータップ時にanimateCameraでズーム維持しつつ中央移動
- **SpotDetailScreen**: SpotDetailContentを使うようリファクタ

## Test plan
- [x] 全494テスト通過
- [x] lint エラー0件
- [x] 型チェック通過
- [x] 実機（Expo Go）で動作確認済み
  - マーカータップでボトムシート表示
  - 検索結果フォーカスでボトムシート表示
  - 上スワイプで詳細表示に拡大
  - 下スワイプで閉じる
  - 地図空白タップで閉じる
  - ズームレベル維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)