### PR TITLE
feat(wishlist): 行きたいリスト（お気に入り）機能を追加

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -98,6 +98,7 @@ jest.mock('react-native-maps', () => {
   const MockMapView = React.forwardRef((props, ref) => {
     React.useImperativeHandle(ref, () => ({
       animateToRegion: jest.fn(),
+      animateCamera: jest.fn(),
     }));
     return React.createElement(
       View,

--- a/src/components/__tests__/WishlistButton.test.tsx
+++ b/src/components/__tests__/WishlistButton.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { WishlistButton } from '@components/animated/WishlistButton';
+
+describe('WishlistButton', () => {
+  it('未追加状態でfavorite-borderアイコンを表示する', () => {
+    const { getByTestId } = render(<WishlistButton isWishlisted={false} onPress={() => {}} />);
+    const button = getByTestId('wishlist-button');
+    expect(button).toBeTruthy();
+  });
+
+  it('追加済み状態でfavoriteアイコンを表示する', () => {
+    const { getByTestId } = render(<WishlistButton isWishlisted={true} onPress={() => {}} />);
+    const button = getByTestId('wishlist-button');
+    expect(button).toBeTruthy();
+  });
+
+  it('タップ時にonPressコールバックが呼ばれる', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(<WishlistButton isWishlisted={false} onPress={onPress} />);
+    fireEvent.press(getByTestId('wishlist-button'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('カスタムサイズが適用される', () => {
+    const { getByTestId } = render(
+      <WishlistButton isWishlisted={false} onPress={() => {}} size={32} />
+    );
+    expect(getByTestId('wishlist-button')).toBeTruthy();
+  });
+
+  it('デフォルトサイズは24', () => {
+    const { getByTestId } = render(<WishlistButton isWishlisted={false} onPress={() => {}} />);
+    expect(getByTestId('wishlist-button')).toBeTruthy();
+  });
+
+  it('isWishlisted が true のときに wishlist-button-active testID が存在する', () => {
+    const { getByTestId } = render(<WishlistButton isWishlisted={true} onPress={() => {}} />);
+    expect(getByTestId('wishlist-button-active')).toBeTruthy();
+  });
+
+  it('isWishlisted が false のときに wishlist-button-inactive testID が存在する', () => {
+    const { getByTestId } = render(<WishlistButton isWishlisted={false} onPress={() => {}} />);
+    expect(getByTestId('wishlist-button-inactive')).toBeTruthy();
+  });
+});

--- a/src/components/animated/WishlistButton.tsx
+++ b/src/components/animated/WishlistButton.tsx
@@ -1,0 +1,76 @@
+import React, { useRef } from 'react';
+import { TouchableOpacity, Animated, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { colors } from '@theme/colors';
+
+interface WishlistButtonProps {
+  isWishlisted: boolean;
+  onPress: () => void;
+  size?: number;
+}
+
+export const WishlistButton: React.FC<WishlistButtonProps> = ({
+  isWishlisted,
+  onPress,
+  size = 24,
+}) => {
+  const scale = useRef(new Animated.Value(1)).current;
+
+  const handlePress = () => {
+    // 追加時はXいいね風の弾むアニメーション、解除時はアニメーションなし
+    if (!isWishlisted) {
+      Animated.sequence([
+        Animated.timing(scale, {
+          toValue: 0.8,
+          duration: 80,
+          useNativeDriver: true,
+        }),
+        Animated.timing(scale, {
+          toValue: 1.3,
+          duration: 150,
+          useNativeDriver: true,
+        }),
+        Animated.timing(scale, {
+          toValue: 1.0,
+          duration: 100,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    }
+    onPress();
+  };
+
+  return (
+    <TouchableOpacity
+      onPress={handlePress}
+      activeOpacity={0.7}
+      testID="wishlist-button"
+      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+    >
+      <Animated.View style={[styles.container, { transform: [{ scale }] }]}>
+        {isWishlisted ? (
+          <MaterialIcons
+            name="flag"
+            size={size}
+            color={colors.primary[500]}
+            testID="wishlist-button-active"
+          />
+        ) : (
+          <MaterialIcons
+            name="outlined-flag"
+            size={size}
+            color={colors.gray[400]}
+            testID="wishlist-button-inactive"
+          />
+        )}
+      </Animated.View>
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/components/spot-detail/SpotBottomSheet.tsx
+++ b/src/components/spot-detail/SpotBottomSheet.tsx
@@ -16,6 +16,8 @@ interface SpotBottomSheetProps {
   visitedSpotIds: Set<string>;
   onDismiss: () => void;
   onRecord: (spotId: string) => void;
+  wishlistSpotIds?: Set<string>;
+  onWishlistToggle?: (spotId: string) => void;
 }
 
 const SCREEN_HEIGHT = Dimensions.get('window').height;
@@ -28,6 +30,8 @@ export function SpotBottomSheet({
   visitedSpotIds,
   onDismiss,
   onRecord,
+  wishlistSpotIds,
+  onWishlistToggle,
 }: SpotBottomSheetProps) {
   const insets = useSafeAreaInsets();
   const expandedHeight = SCREEN_HEIGHT * 0.85;
@@ -130,6 +134,13 @@ export function SpotBottomSheet({
   }, [spotId, onRecord]);
 
   const isVisited = spotId ? visitedSpotIds.has(spotId) : false;
+  const isWishlisted = spotId && wishlistSpotIds ? wishlistSpotIds.has(spotId) : false;
+
+  const handleWishlistPress = useCallback(() => {
+    if (spotId && onWishlistToggle) {
+      onWishlistToggle(spotId);
+    }
+  }, [spotId, onWishlistToggle]);
 
   if (!spotId || !spot) {
     return null;
@@ -153,7 +164,14 @@ export function SpotBottomSheet({
       </View>
 
       {/* Compact card (hidden when expanded) */}
-      {mode !== 'expanded' && <SpotCompactCard spot={spot} isVisited={isVisited} />}
+      {mode !== 'expanded' && (
+        <SpotCompactCard
+          spot={spot}
+          isVisited={isVisited}
+          isWishlisted={isWishlisted}
+          onWishlistPress={onWishlistToggle ? handleWishlistPress : undefined}
+        />
+      )}
 
       {/* Scrollable detail content (visible when expanded) */}
       {mode === 'expanded' && (
@@ -170,6 +188,8 @@ export function SpotBottomSheet({
             isAuthenticated={isAuthenticated}
             onRecord={handleRecord}
             showMiniMap={false}
+            isWishlisted={isWishlisted}
+            onWishlistPress={onWishlistToggle ? handleWishlistPress : undefined}
           />
         </ScrollView>
       )}

--- a/src/components/spot-detail/SpotBottomSheet.tsx
+++ b/src/components/spot-detail/SpotBottomSheet.tsx
@@ -1,0 +1,207 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Animated, Dimensions, PanResponder, ScrollView, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { SpotCompactCard } from './SpotCompactCard';
+import { SpotDetailContent } from './SpotDetailContent';
+import { useSpotDetail } from '@hooks/useSpotDetail';
+import { useSpotStamps } from '@hooks/useSpotStamps';
+import { useAuth } from '@hooks/useAuth';
+import { colors } from '@theme/colors';
+import { borderRadius } from '@theme/spacing';
+import { shadows } from '@theme/shadows';
+
+interface SpotBottomSheetProps {
+  spotId: string | null;
+  visitedSpotIds: Set<string>;
+  onDismiss: () => void;
+  onRecord: (spotId: string) => void;
+}
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
+const COMPACT_HEIGHT = 180;
+
+type SheetMode = 'hidden' | 'compact' | 'expanded';
+
+export function SpotBottomSheet({
+  spotId,
+  visitedSpotIds,
+  onDismiss,
+  onRecord,
+}: SpotBottomSheetProps) {
+  const insets = useSafeAreaInsets();
+  const expandedHeight = SCREEN_HEIGHT * 0.85;
+  const { spot } = useSpotDetail(spotId ?? '');
+  const { stamps, visitCount, latestVisitDate } = useSpotStamps(spotId ?? '');
+  const { isAuthenticated } = useAuth();
+
+  const [mode, setMode] = useState<SheetMode>('hidden');
+  const translateY = useRef(new Animated.Value(SCREEN_HEIGHT)).current;
+
+  const compactPosition = SCREEN_HEIGHT - COMPACT_HEIGHT - insets.bottom;
+  const expandedPosition = SCREEN_HEIGHT - expandedHeight;
+
+  // Keep mutable refs so PanResponder always reads latest values
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+  const compactPosRef = useRef(compactPosition);
+  compactPosRef.current = compactPosition;
+  const expandedPosRef = useRef(expandedPosition);
+  expandedPosRef.current = expandedPosition;
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  const animateTo = useCallback(
+    (toValue: number, callback?: () => void) => {
+      Animated.spring(translateY, {
+        toValue,
+        useNativeDriver: true,
+        tension: 65,
+        friction: 11,
+      }).start(callback);
+    },
+    [translateY]
+  );
+
+  const animateToRef = useRef(animateTo);
+  animateToRef.current = animateTo;
+
+  useEffect(() => {
+    if (spotId && spot) {
+      setMode('compact');
+      animateTo(compactPosition);
+    } else {
+      animateTo(SCREEN_HEIGHT, () => {
+        setMode('hidden');
+      });
+    }
+  }, [spotId, spot, compactPosition, animateTo]);
+
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => false,
+        onMoveShouldSetPanResponder: (_, gestureState) => {
+          // Only capture vertical drags
+          return (
+            Math.abs(gestureState.dy) > 8 && Math.abs(gestureState.dy) > Math.abs(gestureState.dx)
+          );
+        },
+        onPanResponderMove: (_, gestureState) => {
+          const currentPos =
+            modeRef.current === 'expanded' ? expandedPosRef.current : compactPosRef.current;
+          const newY = currentPos + gestureState.dy;
+          const clampedY = Math.max(expandedPosRef.current, newY);
+          translateY.setValue(clampedY);
+        },
+        onPanResponderRelease: (_, gestureState) => {
+          const { dy, vy } = gestureState;
+          const animate = animateToRef.current;
+
+          if (modeRef.current === 'compact') {
+            if (dy < -40 || vy < -0.3) {
+              setMode('expanded');
+              animate(expandedPosRef.current);
+            } else if (dy > 40 || vy > 0.3) {
+              animate(SCREEN_HEIGHT, () => {
+                setMode('hidden');
+                onDismissRef.current();
+              });
+            } else {
+              animate(compactPosRef.current);
+            }
+          } else if (modeRef.current === 'expanded') {
+            if (dy > 80 || vy > 0.5) {
+              setMode('compact');
+              animate(compactPosRef.current);
+            } else {
+              animate(expandedPosRef.current);
+            }
+          }
+        },
+      }),
+    [translateY]
+  );
+
+  const handleRecord = useCallback(() => {
+    if (spotId) {
+      onRecord(spotId);
+    }
+  }, [spotId, onRecord]);
+
+  const isVisited = spotId ? visitedSpotIds.has(spotId) : false;
+
+  if (!spotId || !spot) {
+    return null;
+  }
+
+  return (
+    <Animated.View
+      style={[
+        styles.container,
+        {
+          height: expandedHeight,
+          transform: [{ translateY }],
+        },
+      ]}
+      testID="bottom-sheet"
+      {...panResponder.panHandlers}
+    >
+      {/* Drag handle */}
+      <View style={styles.handleContainer}>
+        <View style={styles.handle} />
+      </View>
+
+      {/* Compact card (hidden when expanded) */}
+      {mode !== 'expanded' && <SpotCompactCard spot={spot} isVisited={isVisited} />}
+
+      {/* Scrollable detail content (visible when expanded) */}
+      {mode === 'expanded' && (
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator
+        >
+          <SpotDetailContent
+            spot={spot}
+            stamps={stamps}
+            visitCount={visitCount}
+            latestVisitDate={latestVisitDate}
+            isAuthenticated={isAuthenticated}
+            onRecord={handleRecord}
+            showMiniMap={false}
+          />
+        </ScrollView>
+      )}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    backgroundColor: colors.white,
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+    ...shadows.lg,
+  },
+  handleContainer: {
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.gray[300],
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+  },
+});

--- a/src/components/spot-detail/SpotCompactCard.tsx
+++ b/src/components/spot-detail/SpotCompactCard.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 
 import { Badge } from '@components/common/Badge';
+import { WishlistButton } from '@components/animated/WishlistButton';
 import type { Spot } from '@/types/supabase';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
@@ -11,28 +12,42 @@ import { spacing } from '@theme/spacing';
 interface SpotCompactCardProps {
   spot: Spot;
   isVisited: boolean;
+  isWishlisted?: boolean;
+  onWishlistPress?: () => void;
 }
 
-export function SpotCompactCard({ spot, isVisited }: SpotCompactCardProps) {
+export function SpotCompactCard({
+  spot,
+  isVisited,
+  isWishlisted,
+  onWishlistPress,
+}: SpotCompactCardProps) {
   const badgeType = spot.type === 'shrine' ? 'shrine' : 'temple';
 
   return (
     <View style={styles.container} testID="spot-compact-card">
-      <Text style={styles.spotName} numberOfLines={1}>
-        {spot.name}
-      </Text>
-      <View style={styles.badgeRow}>
-        <Badge type={badgeType} />
-        {isVisited && <Badge type="visited" />}
-      </View>
-      {spot.address && (
-        <View style={styles.addressRow} testID="spot-compact-address">
-          <MaterialIcons name="place" size={14} color={colors.gray[400]} />
-          <Text style={styles.address} numberOfLines={1}>
-            {spot.address}
+      <View style={styles.row}>
+        <View style={styles.textContent}>
+          <Text style={styles.spotName} numberOfLines={1}>
+            {spot.name}
           </Text>
+          <View style={styles.badgeRow}>
+            <Badge type={badgeType} />
+            {isVisited && <Badge type="visited" />}
+          </View>
+          {spot.address && (
+            <View style={styles.addressRow} testID="spot-compact-address">
+              <MaterialIcons name="place" size={14} color={colors.gray[400]} />
+              <Text style={styles.address} numberOfLines={1}>
+                {spot.address}
+              </Text>
+            </View>
+          )}
         </View>
-      )}
+        {onWishlistPress && isWishlisted !== undefined && (
+          <WishlistButton isWishlisted={isWishlisted} onPress={onWishlistPress} />
+        )}
+      </View>
     </View>
   );
 }
@@ -41,6 +56,13 @@ const styles = StyleSheet.create({
   container: {
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  textContent: {
+    flex: 1,
   },
   spotName: {
     ...typography.h3,

--- a/src/components/spot-detail/SpotCompactCard.tsx
+++ b/src/components/spot-detail/SpotCompactCard.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+
+import { Badge } from '@components/common/Badge';
+import type { Spot } from '@/types/supabase';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
+
+interface SpotCompactCardProps {
+  spot: Spot;
+  isVisited: boolean;
+}
+
+export function SpotCompactCard({ spot, isVisited }: SpotCompactCardProps) {
+  const badgeType = spot.type === 'shrine' ? 'shrine' : 'temple';
+
+  return (
+    <View style={styles.container} testID="spot-compact-card">
+      <Text style={styles.spotName} numberOfLines={1}>
+        {spot.name}
+      </Text>
+      <View style={styles.badgeRow}>
+        <Badge type={badgeType} />
+        {isVisited && <Badge type="visited" />}
+      </View>
+      {spot.address && (
+        <View style={styles.addressRow} testID="spot-compact-address">
+          <MaterialIcons name="place" size={14} color={colors.gray[400]} />
+          <Text style={styles.address} numberOfLines={1}>
+            {spot.address}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  spotName: {
+    ...typography.h3,
+    color: colors.gray[900],
+    marginBottom: spacing.xs,
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginBottom: spacing.xs,
+  },
+  addressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  address: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+    flex: 1,
+  },
+});

--- a/src/components/spot-detail/SpotDetailContent.tsx
+++ b/src/components/spot-detail/SpotDetailContent.tsx
@@ -6,6 +6,7 @@ import { MaterialIcons } from '@expo/vector-icons';
 import { Badge } from '@components/common/Badge';
 import { Button } from '@components/common/Button';
 import { Card } from '@components/common/Card';
+import { WishlistButton } from '@components/animated/WishlistButton';
 import { getStampImageUrl } from '@services/stamps';
 import type { Spot, Stamp } from '@/types/supabase';
 import { colors } from '@theme/colors';
@@ -20,6 +21,8 @@ interface SpotDetailContentProps {
   isAuthenticated: boolean;
   onRecord: () => void;
   showMiniMap?: boolean;
+  isWishlisted?: boolean;
+  onWishlistPress?: () => void;
 }
 
 function formatDate(dateStr: string): string {
@@ -38,6 +41,8 @@ export function SpotDetailContent({
   isAuthenticated,
   onRecord,
   showMiniMap = true,
+  isWishlisted,
+  onWishlistPress,
 }: SpotDetailContentProps) {
   const badgeType = spot.type === 'shrine' ? 'shrine' : 'temple';
   const showVisited = isAuthenticated && visitCount > 0;
@@ -49,9 +54,14 @@ export function SpotDetailContent({
         {showVisited && <Badge type="visited" />}
       </View>
 
-      <Text style={styles.spotName} testID="spot-name">
-        {spot.name}
-      </Text>
+      <View style={styles.nameRow}>
+        <Text style={[styles.spotName, styles.spotNameFlex]} testID="spot-name">
+          {spot.name}
+        </Text>
+        {onWishlistPress && isWishlisted !== undefined && (
+          <WishlistButton isWishlisted={isWishlisted} onPress={onWishlistPress} />
+        )}
+      </View>
       {spot.address && (
         <View style={styles.addressRow}>
           <MaterialIcons name="place" size={16} color={colors.gray[400]} />
@@ -147,10 +157,17 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
     marginBottom: spacing.md,
   },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
   spotName: {
     ...typography.h2,
     color: colors.gray[900],
-    marginBottom: spacing.sm,
+  },
+  spotNameFlex: {
+    flex: 1,
   },
   addressRow: {
     flexDirection: 'row',

--- a/src/components/spot-detail/SpotDetailContent.tsx
+++ b/src/components/spot-detail/SpotDetailContent.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { Image, StyleSheet, Text, View } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+import { MaterialIcons } from '@expo/vector-icons';
+
+import { Badge } from '@components/common/Badge';
+import { Button } from '@components/common/Button';
+import { Card } from '@components/common/Card';
+import { getStampImageUrl } from '@services/stamps';
+import type { Spot, Stamp } from '@/types/supabase';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing, borderRadius } from '@theme/spacing';
+
+interface SpotDetailContentProps {
+  spot: Spot;
+  stamps: Stamp[];
+  visitCount: number;
+  latestVisitDate: string | null;
+  isAuthenticated: boolean;
+  onRecord: () => void;
+  showMiniMap?: boolean;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}/${m}/${day}`;
+}
+
+export function SpotDetailContent({
+  spot,
+  stamps,
+  visitCount,
+  latestVisitDate,
+  isAuthenticated,
+  onRecord,
+  showMiniMap = true,
+}: SpotDetailContentProps) {
+  const badgeType = spot.type === 'shrine' ? 'shrine' : 'temple';
+  const showVisited = isAuthenticated && visitCount > 0;
+
+  return (
+    <View style={styles.content} testID="spot-detail-content">
+      <View style={styles.badgeRow}>
+        <Badge type={badgeType} />
+        {showVisited && <Badge type="visited" />}
+      </View>
+
+      <Text style={styles.spotName} testID="spot-name">
+        {spot.name}
+      </Text>
+      {spot.address && (
+        <View style={styles.addressRow}>
+          <MaterialIcons name="place" size={16} color={colors.gray[400]} />
+          <Text style={styles.address}>{spot.address}</Text>
+        </View>
+      )}
+
+      <Card style={styles.visitCard}>
+        <View style={styles.visitRow}>
+          <View style={styles.visitItem}>
+            <Text style={styles.visitLabel}>種別</Text>
+            <Text style={styles.visitValue}>{spot.type === 'shrine' ? '神社' : '寺院'}</Text>
+          </View>
+          {isAuthenticated && visitCount > 0 && (
+            <>
+              <View style={styles.visitItem}>
+                <Text style={styles.visitLabel}>訪問回数</Text>
+                <Text style={styles.visitValue}>{visitCount}</Text>
+              </View>
+              <View style={styles.visitItem}>
+                <Text style={styles.visitLabel}>最終訪問日</Text>
+                <Text style={styles.visitValue}>
+                  {latestVisitDate ? formatDate(latestVisitDate) : '-'}
+                </Text>
+              </View>
+            </>
+          )}
+        </View>
+      </Card>
+
+      <Button
+        title="ここで記録する"
+        onPress={onRecord}
+        variant="primary"
+        style={styles.recordButton}
+      />
+
+      {stamps.length > 0 && (
+        <>
+          <Text style={styles.sectionTitle}>記録済み御朱印</Text>
+          <View style={styles.stampGrid} testID="stamp-grid">
+            {stamps.map(stamp => (
+              <Image
+                key={stamp.id}
+                source={{ uri: getStampImageUrl(stamp.image_path) }}
+                style={styles.stampImage}
+                testID={`stamp-image-${stamp.id}`}
+              />
+            ))}
+          </View>
+        </>
+      )}
+
+      {showMiniMap && (
+        <>
+          <Text style={styles.sectionTitle}>アクセス</Text>
+          <View style={styles.miniMapContainer} testID="mini-map">
+            <MapView
+              style={styles.miniMapView}
+              initialRegion={{
+                latitude: spot.lat,
+                longitude: spot.lng,
+                latitudeDelta: 0.005,
+                longitudeDelta: 0.005,
+              }}
+              scrollEnabled={false}
+              zoomEnabled={false}
+              rotateEnabled={false}
+              pitchEnabled={false}
+            >
+              <Marker coordinate={{ latitude: spot.lat, longitude: spot.lng }} />
+            </MapView>
+          </View>
+          {spot.address && (
+            <View style={styles.miniMapAddress}>
+              <MaterialIcons name="place" size={16} color={colors.primary[500]} />
+              <Text style={styles.miniMapAddressText}>{spot.address}</Text>
+            </View>
+          )}
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing['3xl'],
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginBottom: spacing.md,
+  },
+  spotName: {
+    ...typography.h2,
+    color: colors.gray[900],
+    marginBottom: spacing.sm,
+  },
+  addressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginBottom: spacing.xl,
+  },
+  address: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+    flex: 1,
+  },
+  visitCard: {
+    marginBottom: spacing.lg,
+  },
+  visitRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  visitItem: {
+    flex: 1,
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  visitLabel: {
+    ...typography.caption,
+    color: colors.gray[500],
+  },
+  visitValue: {
+    ...typography.h3,
+    color: colors.gray[900],
+  },
+  recordButton: {
+    marginBottom: spacing.xl,
+  },
+  sectionTitle: {
+    ...typography.h3,
+    color: colors.gray[800],
+    marginBottom: spacing.md,
+    marginTop: spacing.lg,
+  },
+  stampGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  stampImage: {
+    width: '31.5%',
+    aspectRatio: 1,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.gray[100],
+  },
+  miniMapContainer: {
+    height: 150,
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+  },
+  miniMapView: {
+    flex: 1,
+  },
+  miniMapAddress: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginTop: spacing.md,
+  },
+  miniMapAddressText: {
+    ...typography.bodySmall,
+    color: colors.gray[600],
+    flex: 1,
+  },
+});

--- a/src/components/spot-detail/__tests__/SpotBottomSheet.test.tsx
+++ b/src/components/spot-detail/__tests__/SpotBottomSheet.test.tsx
@@ -52,6 +52,8 @@ describe('SpotBottomSheet', () => {
     visitedSpotIds: new Set(['spot-1']),
     onDismiss: jest.fn(),
     onRecord: jest.fn(),
+    wishlistSpotIds: new Set<string>(),
+    onWishlistToggle: jest.fn(),
   };
 
   it('renders bottom sheet when spotId is provided', () => {

--- a/src/components/spot-detail/__tests__/SpotBottomSheet.test.tsx
+++ b/src/components/spot-detail/__tests__/SpotBottomSheet.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { SpotBottomSheet } from '../SpotBottomSheet';
+import type { Spot } from '@/types/supabase';
+
+jest.mock('@services/stamps', () => ({
+  fetchStampsBySpotId: jest.fn(() => Promise.resolve([])),
+  getStampImageUrl: jest.fn((path: string) => `https://example.com/${path}`),
+}));
+
+const mockSpot: Spot = {
+  id: 'spot-1',
+  name: '仙台東照宮',
+  lat: 38.28,
+  lng: 140.88,
+  type: 'shrine',
+  address: '宮城県仙台市青葉区東照宮一丁目6-1',
+  status: 'active',
+  created_by_user_id: null,
+  merged_into_spot_id: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+};
+
+jest.mock('@hooks/useSpotDetail', () => ({
+  useSpotDetail: (spotId: string | null) => ({
+    spot: spotId === 'spot-1' ? mockSpot : null,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('@hooks/useSpotStamps', () => ({
+  useSpotStamps: () => ({
+    stamps: [],
+    visitCount: 2,
+    latestVisitDate: '2024-06-15',
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: 'user-1' },
+  }),
+}));
+
+describe('SpotBottomSheet', () => {
+  const defaultProps = {
+    spotId: 'spot-1' as string | null,
+    visitedSpotIds: new Set(['spot-1']),
+    onDismiss: jest.fn(),
+    onRecord: jest.fn(),
+  };
+
+  it('renders bottom sheet when spotId is provided', () => {
+    const { getByTestId } = render(<SpotBottomSheet {...defaultProps} />);
+    expect(getByTestId('bottom-sheet')).toBeTruthy();
+  });
+
+  it('does not render when spotId is null', () => {
+    const { queryByTestId } = render(<SpotBottomSheet {...defaultProps} spotId={null} />);
+    expect(queryByTestId('bottom-sheet')).toBeNull();
+  });
+
+  it('renders spot name', () => {
+    const { getAllByText } = render(<SpotBottomSheet {...defaultProps} />);
+    expect(getAllByText('仙台東照宮').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders shrine badge', () => {
+    const { getAllByTestId } = render(<SpotBottomSheet {...defaultProps} />);
+    expect(getAllByTestId('badge-shrine').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders visited badge when spot is visited', () => {
+    const { getAllByTestId } = render(<SpotBottomSheet {...defaultProps} />);
+    const visitedBadges = getAllByTestId('badge-visited');
+    expect(visitedBadges.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/components/spot-detail/__tests__/SpotCompactCard.test.tsx
+++ b/src/components/spot-detail/__tests__/SpotCompactCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import { SpotCompactCard } from '../SpotCompactCard';
 import type { Spot } from '@/types/supabase';
 
@@ -65,5 +65,27 @@ describe('SpotCompactCard', () => {
     const spotNoAddress = { ...mockShrine, address: null };
     const { queryByTestId } = render(<SpotCompactCard {...defaultProps} spot={spotNoAddress} />);
     expect(queryByTestId('spot-compact-address')).toBeNull();
+  });
+
+  it('renders wishlist button when props are provided', () => {
+    const onWishlistPress = jest.fn();
+    const { getByTestId } = render(
+      <SpotCompactCard {...defaultProps} isWishlisted={false} onWishlistPress={onWishlistPress} />
+    );
+    expect(getByTestId('wishlist-button')).toBeTruthy();
+  });
+
+  it('does not render wishlist button when props are not provided', () => {
+    const { queryByTestId } = render(<SpotCompactCard {...defaultProps} />);
+    expect(queryByTestId('wishlist-button')).toBeNull();
+  });
+
+  it('calls onWishlistPress when wishlist button is tapped', () => {
+    const onWishlistPress = jest.fn();
+    const { getByTestId } = render(
+      <SpotCompactCard {...defaultProps} isWishlisted={false} onWishlistPress={onWishlistPress} />
+    );
+    fireEvent.press(getByTestId('wishlist-button'));
+    expect(onWishlistPress).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/spot-detail/__tests__/SpotCompactCard.test.tsx
+++ b/src/components/spot-detail/__tests__/SpotCompactCard.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { SpotCompactCard } from '../SpotCompactCard';
+import type { Spot } from '@/types/supabase';
+
+const mockShrine: Spot = {
+  id: 'spot-1',
+  name: '仙台東照宮',
+  lat: 38.28,
+  lng: 140.88,
+  type: 'shrine',
+  address: '宮城県仙台市青葉区東照宮一丁目6-1',
+  status: 'active',
+  created_by_user_id: null,
+  merged_into_spot_id: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+};
+
+const mockTemple: Spot = {
+  ...mockShrine,
+  id: 'spot-2',
+  name: '瑞巌寺',
+  type: 'temple',
+  address: '宮城県宮城郡松島町松島字町内91',
+};
+
+describe('SpotCompactCard', () => {
+  const defaultProps = {
+    spot: mockShrine,
+    isVisited: false,
+  };
+
+  it('renders spot name', () => {
+    const { getByText } = render(<SpotCompactCard {...defaultProps} />);
+    expect(getByText('仙台東照宮')).toBeTruthy();
+  });
+
+  it('renders shrine badge for shrine type', () => {
+    const { getByTestId } = render(<SpotCompactCard {...defaultProps} />);
+    expect(getByTestId('badge-shrine')).toBeTruthy();
+  });
+
+  it('renders temple badge for temple type', () => {
+    const { getByTestId } = render(<SpotCompactCard {...defaultProps} spot={mockTemple} />);
+    expect(getByTestId('badge-temple')).toBeTruthy();
+  });
+
+  it('renders address', () => {
+    const { getByText } = render(<SpotCompactCard {...defaultProps} />);
+    expect(getByText('宮城県仙台市青葉区東照宮一丁目6-1')).toBeTruthy();
+  });
+
+  it('renders visited badge when isVisited is true', () => {
+    const { getByTestId } = render(<SpotCompactCard {...defaultProps} isVisited={true} />);
+    expect(getByTestId('badge-visited')).toBeTruthy();
+  });
+
+  it('does not render visited badge when isVisited is false', () => {
+    const { queryByTestId } = render(<SpotCompactCard {...defaultProps} isVisited={false} />);
+    expect(queryByTestId('badge-visited')).toBeNull();
+  });
+
+  it('handles null address gracefully', () => {
+    const spotNoAddress = { ...mockShrine, address: null };
+    const { queryByTestId } = render(<SpotCompactCard {...defaultProps} spot={spotNoAddress} />);
+    expect(queryByTestId('spot-compact-address')).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useWishlist.test.ts
+++ b/src/hooks/__tests__/useWishlist.test.ts
@@ -1,0 +1,164 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useWishlist } from '@hooks/useWishlist';
+
+const mockFetchWishlistSpotIds = jest.fn();
+const mockAddToWishlist = jest.fn();
+const mockRemoveFromWishlist = jest.fn();
+
+jest.mock('@services/wishlist', () => ({
+  fetchWishlistSpotIds: (...args: unknown[]) => mockFetchWishlistSpotIds(...args),
+  addToWishlist: (...args: unknown[]) => mockAddToWishlist(...args),
+  removeFromWishlist: (...args: unknown[]) => mockRemoveFromWishlist(...args),
+}));
+
+let mockUser: { id: string } | null = null;
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: mockUser,
+    isAuthenticated: mockUser !== null,
+  }),
+}));
+
+describe('useWishlist', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = null;
+  });
+
+  it('未ログイン時は空のSetを返す', async () => {
+    mockUser = null;
+    const { result } = renderHook(() => useWishlist());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.wishlistSpotIds.size).toBe(0);
+    expect(mockFetchWishlistSpotIds).not.toHaveBeenCalled();
+  });
+
+  it('ログイン時にwishlist spot IDsを取得する', async () => {
+    mockUser = { id: 'user-1' };
+    mockFetchWishlistSpotIds.mockResolvedValue(new Set(['spot-1', 'spot-2']));
+
+    const { result } = renderHook(() => useWishlist());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.wishlistSpotIds.size).toBe(2);
+    expect(result.current.wishlistSpotIds.has('spot-1')).toBe(true);
+    expect(mockFetchWishlistSpotIds).toHaveBeenCalledWith('user-1');
+  });
+
+  it('フェッチエラー時は空のSetを返す', async () => {
+    mockUser = { id: 'user-1' };
+    mockFetchWishlistSpotIds.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useWishlist());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.wishlistSpotIds.size).toBe(0);
+  });
+
+  it('toggleWishlist: 未登録スポットを追加する（楽観的更新）', async () => {
+    mockUser = { id: 'user-1' };
+    mockFetchWishlistSpotIds.mockResolvedValue(new Set(['spot-1']));
+    mockAddToWishlist.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useWishlist());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.toggleWishlist('spot-2');
+    });
+
+    expect(result.current.wishlistSpotIds.has('spot-2')).toBe(true);
+    expect(mockAddToWishlist).toHaveBeenCalledWith('user-1', 'spot-2');
+  });
+
+  it('toggleWishlist: 登録済みスポットを削除する（楽観的更新）', async () => {
+    mockUser = { id: 'user-1' };
+    mockFetchWishlistSpotIds.mockResolvedValue(new Set(['spot-1', 'spot-2']));
+    mockRemoveFromWishlist.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useWishlist());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.toggleWishlist('spot-1');
+    });
+
+    expect(result.current.wishlistSpotIds.has('spot-1')).toBe(false);
+    expect(mockRemoveFromWishlist).toHaveBeenCalledWith('user-1', 'spot-1');
+  });
+
+  it('toggleWishlist: API失敗時にロールバックする', async () => {
+    mockUser = { id: 'user-1' };
+    mockFetchWishlistSpotIds.mockResolvedValue(new Set(['spot-1']));
+    mockAddToWishlist.mockRejectedValue(new Error('API error'));
+
+    const { result } = renderHook(() => useWishlist());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.toggleWishlist('spot-2');
+    });
+
+    // ロールバックされて spot-2 が含まれていないこと
+    expect(result.current.wishlistSpotIds.has('spot-2')).toBe(false);
+  });
+
+  it('toggleWishlist: 未ログイン時は何もしない', async () => {
+    mockUser = null;
+    const { result } = renderHook(() => useWishlist());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.toggleWishlist('spot-1');
+    });
+
+    expect(mockAddToWishlist).not.toHaveBeenCalled();
+    expect(mockRemoveFromWishlist).not.toHaveBeenCalled();
+  });
+
+  it('isToggling: toggle中はtrueになる', async () => {
+    mockUser = { id: 'user-1' };
+    mockFetchWishlistSpotIds.mockResolvedValue(new Set());
+    // addToWishlist を遅延させる
+    mockAddToWishlist.mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100)));
+
+    const { result } = renderHook(() => useWishlist());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    act(() => {
+      result.current.toggleWishlist('spot-1');
+    });
+
+    expect(result.current.isToggling).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isToggling).toBe(false);
+    });
+  });
+});

--- a/src/hooks/__tests__/useWishlistSpots.test.ts
+++ b/src/hooks/__tests__/useWishlistSpots.test.ts
@@ -1,0 +1,115 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useWishlistSpots } from '@hooks/useWishlistSpots';
+import type { WishlistWithSpot } from '@/types/supabase';
+
+const mockFetchWishlistSpots = jest.fn();
+
+jest.mock('@services/wishlist', () => ({
+  fetchWishlistSpots: (...args: unknown[]) => mockFetchWishlistSpots(...args),
+}));
+
+// useFocusEffect をuseEffectとして動作させるモック
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (cb: () => void) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const { useEffect } = require('react');
+    useEffect(cb, [cb]);
+  },
+}));
+
+let mockUser: { id: string } | null = null;
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+const makeWishlistSpot = (spotId: string, name: string): WishlistWithSpot => ({
+  id: `wl-${spotId}`,
+  user_id: 'user-1',
+  spot_id: spotId,
+  created_at: '2026-01-01T00:00:00Z',
+  spots: {
+    name,
+    type: 'shrine',
+    address: `${name}の住所`,
+  },
+});
+
+describe('useWishlistSpots', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = null;
+  });
+
+  it('未認証時はspots=[], isLoading=falseを返す', async () => {
+    mockUser = null;
+    const { result } = renderHook(() => useWishlistSpots());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.spots).toEqual([]);
+    expect(mockFetchWishlistSpots).not.toHaveBeenCalled();
+  });
+
+  it('認証済み: fetchWishlistSpotsがuserIdで呼ばれる', async () => {
+    mockUser = { id: 'user-1' };
+    mockFetchWishlistSpots.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useWishlistSpots());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockFetchWishlistSpots).toHaveBeenCalledWith('user-1');
+  });
+
+  it('データ取得成功: wishlistスポット一覧を返す', async () => {
+    mockUser = { id: 'user-1' };
+    const mockSpots = [
+      makeWishlistSpot('spot-1', '伊勢神宮'),
+      makeWishlistSpot('spot-2', '浅草寺'),
+    ];
+    mockFetchWishlistSpots.mockResolvedValue(mockSpots);
+
+    const { result } = renderHook(() => useWishlistSpots());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.spots).toHaveLength(2);
+    expect(result.current.spots[0].spots.name).toBe('伊勢神宮');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('エラー時: error がセットされ、spots は空のまま', async () => {
+    mockUser = { id: 'user-1' };
+    mockFetchWishlistSpots.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useWishlistSpots());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.spots).toEqual([]);
+    expect(result.current.error).toBe('Network error');
+  });
+
+  it('フォーカス時にリフェッチされる', async () => {
+    mockUser = { id: 'user-1' };
+    mockFetchWishlistSpots.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useWishlistSpots());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // useFocusEffect がuseEffectとして動くため、マウント時に1回呼ばれる
+    expect(mockFetchWishlistSpots).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useWishlist.ts
+++ b/src/hooks/useWishlist.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '@hooks/useAuth';
+import { fetchWishlistSpotIds, addToWishlist, removeFromWishlist } from '@services/wishlist';
+
+interface UseWishlistReturn {
+  wishlistSpotIds: Set<string>;
+  toggleWishlist: (spotId: string) => Promise<void>;
+  isLoading: boolean;
+  isToggling: boolean;
+}
+
+export function useWishlist(): UseWishlistReturn {
+  const { user, isAuthenticated } = useAuth();
+  const [wishlistSpotIds, setWishlistSpotIds] = useState<Set<string>>(new Set());
+  const [isLoading, setIsLoading] = useState(true);
+  const [isToggling, setIsToggling] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated || !user) {
+      setWishlistSpotIds(new Set());
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const ids = await fetchWishlistSpotIds(user.id);
+        if (!cancelled) setWishlistSpotIds(ids);
+      } catch {
+        if (!cancelled) setWishlistSpotIds(new Set());
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, user]);
+
+  const toggleWishlist = useCallback(
+    async (spotId: string) => {
+      // 未ログイン時は何もしない（UI側でログインモーダルを制御）
+      if (!user) return;
+
+      const isWishlisted = wishlistSpotIds.has(spotId);
+
+      // 楽観的更新：UIを即座に反映
+      const updatedIds = new Set(wishlistSpotIds);
+      if (isWishlisted) {
+        updatedIds.delete(spotId);
+      } else {
+        updatedIds.add(spotId);
+      }
+      setWishlistSpotIds(updatedIds);
+      setIsToggling(true);
+
+      try {
+        if (isWishlisted) {
+          await removeFromWishlist(user.id, spotId);
+        } else {
+          await addToWishlist(user.id, spotId);
+        }
+      } catch {
+        // API失敗時はロールバック
+        setWishlistSpotIds(wishlistSpotIds);
+      } finally {
+        setIsToggling(false);
+      }
+    },
+    [user, wishlistSpotIds]
+  );
+
+  return { wishlistSpotIds, toggleWishlist, isLoading, isToggling };
+}

--- a/src/hooks/useWishlistSpots.ts
+++ b/src/hooks/useWishlistSpots.ts
@@ -1,0 +1,63 @@
+import { useState, useCallback } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import { useAuth } from '@hooks/useAuth';
+import { fetchWishlistSpots } from '@services/wishlist';
+import type { WishlistWithSpot } from '@/types/supabase';
+
+interface UseWishlistSpotsReturn {
+  spots: WishlistWithSpot[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+/**
+ * CollectionScreen用。フォーカス時にwishlistスポット一覧をリフェッチする
+ */
+export function useWishlistSpots(): UseWishlistSpotsReturn {
+  const { user } = useAuth();
+  const [spots, setSpots] = useState<WishlistWithSpot[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const refetch = useCallback(() => {
+    setRefreshKey(prev => prev + 1);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!user) {
+        setSpots([]);
+        setIsLoading(false);
+        return;
+      }
+
+      let cancelled = false;
+
+      (async () => {
+        try {
+          setIsLoading(true);
+          const data = await fetchWishlistSpots(user.id);
+          if (!cancelled) {
+            setSpots(data);
+            setError(null);
+          }
+        } catch (e) {
+          if (!cancelled) {
+            setSpots([]);
+            setError(e instanceof Error ? e.message : '取得に失敗しました');
+          }
+        } finally {
+          if (!cancelled) setIsLoading(false);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+    }, [user, refreshKey])
+  );
+
+  return { spots, isLoading, error, refetch };
+}

--- a/src/navigation/__tests__/RootNavigator.test.tsx
+++ b/src/navigation/__tests__/RootNavigator.test.tsx
@@ -60,6 +60,28 @@ jest.mock('@hooks/useUserStamps', () => ({
   }),
 }));
 
+jest.mock('@hooks/useWishlist', () => ({
+  useWishlist: () => ({
+    wishlistSpotIds: new Set(),
+    toggleWishlist: jest.fn(),
+    isLoading: false,
+    isToggling: false,
+  }),
+}));
+
+jest.mock('@hooks/useWishlistSpots', () => ({
+  useWishlistSpots: () => ({
+    spots: [],
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock('@services/wishlist', () => ({
+  removeFromWishlist: jest.fn(),
+}));
+
 jest.mock('@hooks/useMapSearch', () => ({
   useMapSearch: () => ({
     query: '',

--- a/src/navigation/__tests__/TabNavigator.test.tsx
+++ b/src/navigation/__tests__/TabNavigator.test.tsx
@@ -53,6 +53,28 @@ jest.mock('@hooks/useUserStamps', () => ({
   }),
 }));
 
+jest.mock('@hooks/useWishlist', () => ({
+  useWishlist: () => ({
+    wishlistSpotIds: new Set(),
+    toggleWishlist: jest.fn(),
+    isLoading: false,
+    isToggling: false,
+  }),
+}));
+
+jest.mock('@hooks/useWishlistSpots', () => ({
+  useWishlistSpots: () => ({
+    spots: [],
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock('@services/wishlist', () => ({
+  removeFromWishlist: jest.fn(),
+}));
+
 jest.mock('@hooks/useMapSearch', () => ({
   useMapSearch: () => ({
     query: '',

--- a/src/screens/CollectionScreen.tsx
+++ b/src/screens/CollectionScreen.tsx
@@ -2,7 +2,12 @@ import { MaterialIcons } from '@expo/vector-icons';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { Badge } from '@components/common/Badge';
 import { Card } from '@components/common/Card';
+import { WishlistButton } from '@components/animated/WishlistButton';
+import { useAuth } from '@hooks/useAuth';
+import { useWishlistSpots } from '@hooks/useWishlistSpots';
+import { removeFromWishlist } from '@services/wishlist';
 import { colors } from '@theme/colors';
 import { borderRadius, spacing } from '@theme/spacing';
 import { typography } from '@theme/typography';
@@ -31,6 +36,15 @@ const BADGE_DATA = [
 ];
 
 export function CollectionScreen(_props: Props) {
+  const { user } = useAuth();
+  const { spots: wishlistSpots, refetch: refetchWishlist } = useWishlistSpots();
+
+  const handleRemoveFromWishlist = async (spotId: string) => {
+    if (!user) return;
+    await removeFromWishlist(user.id, spotId);
+    refetchWishlist();
+  };
+
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <ScrollView
@@ -74,6 +88,44 @@ export function CollectionScreen(_props: Props) {
             </View>
           ))}
         </Card>
+
+        {/* Wishlist Section */}
+        <Text style={styles.sectionTitle}>行きたいリスト</Text>
+        {wishlistSpots.length === 0 ? (
+          <Card style={styles.wishlistEmptyCard}>
+            <MaterialIcons name="outlined-flag" size={40} color={colors.gray[300]} />
+            <Text style={styles.wishlistEmptyText}>行きたいスポットをマップで保存しましょう</Text>
+          </Card>
+        ) : (
+          wishlistSpots.map(item => (
+            <View key={item.id} testID={`wishlist-item-${item.spot_id}`}>
+              <Card style={styles.wishlistCard}>
+                <View style={styles.wishlistRow}>
+                  <View style={styles.wishlistInfo}>
+                    <Text style={styles.wishlistSpotName} numberOfLines={1}>
+                      {item.spots.name}
+                    </Text>
+                    <View style={styles.wishlistBadgeRow}>
+                      <Badge type={item.spots.type === 'shrine' ? 'shrine' : 'temple'} />
+                    </View>
+                    {item.spots.address && (
+                      <View style={styles.wishlistAddressRow}>
+                        <MaterialIcons name="place" size={14} color={colors.gray[400]} />
+                        <Text style={styles.wishlistAddress} numberOfLines={1}>
+                          {item.spots.address}
+                        </Text>
+                      </View>
+                    )}
+                  </View>
+                  <WishlistButton
+                    isWishlisted={true}
+                    onPress={() => handleRemoveFromWishlist(item.spot_id)}
+                  />
+                </View>
+              </Card>
+            </View>
+          ))
+        )}
 
         {/* Challenge Section */}
         <Text style={styles.sectionTitle}>巡礼チャレンジ</Text>
@@ -195,6 +247,47 @@ const styles = StyleSheet.create({
     color: colors.gray[700],
     width: 28,
     textAlign: 'right',
+  },
+  wishlistEmptyCard: {
+    alignItems: 'center',
+    paddingVertical: spacing.xl,
+    marginBottom: spacing.xl,
+    gap: spacing.sm,
+  },
+  wishlistEmptyText: {
+    ...typography.bodySmall,
+    color: colors.gray[400],
+    textAlign: 'center',
+  },
+  wishlistCard: {
+    marginBottom: spacing.md,
+  },
+  wishlistRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  wishlistInfo: {
+    flex: 1,
+  },
+  wishlistSpotName: {
+    ...typography.body,
+    color: colors.gray[800],
+    marginBottom: spacing.xs,
+  },
+  wishlistBadgeRow: {
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginBottom: spacing.xs,
+  },
+  wishlistAddressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  wishlistAddress: {
+    ...typography.bodySmall,
+    color: colors.gray[500],
+    flex: 1,
   },
   challengeCard: {
     marginBottom: spacing.md,

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -14,6 +14,7 @@ import { useAuth } from '@hooks/useAuth';
 import { useLocation } from '@hooks/useLocation';
 import { useSpots } from '@hooks/useSpots';
 import { useUserStamps } from '@hooks/useUserStamps';
+import { useWishlist } from '@hooks/useWishlist';
 import type { MapStackScreenProps } from '@/navigation/types';
 import type { Spot } from '@/types/supabase';
 import { colors } from '@theme/colors';
@@ -28,15 +29,23 @@ const LATITUDE_DELTA = 0.02;
 const LONGITUDE_DELTA = 0.02;
 const LABEL_VISIBLE_DELTA = 0.08;
 
-function getPinColor(spot: Spot, visitedSpotIds: Set<string>): string {
-  if (!visitedSpotIds.has(spot.id)) return colors.pin.unvisited;
-  return spot.type === 'shrine' ? colors.pin.shrineVisited : colors.pin.templeVisited;
+function getPinColor(
+  spot: Spot,
+  visitedSpotIds: Set<string>,
+  wishlistSpotIds?: Set<string>
+): string {
+  if (visitedSpotIds.has(spot.id)) {
+    return spot.type === 'shrine' ? colors.pin.shrineVisited : colors.pin.templeVisited;
+  }
+  if (wishlistSpotIds?.has(spot.id)) return colors.pin.wishlisted;
+  return colors.pin.unvisited;
 }
 
 export function MapScreen({ navigation, route }: Props) {
   const { isAuthenticated } = useAuth();
   const { location } = useLocation();
   const { visitedSpotIds } = useUserStamps();
+  const { wishlistSpotIds, toggleWishlist } = useWishlist();
   const [filterMode, setFilterMode] = useState<FilterMode>('all');
   const { spots } = useSpots(location, filterMode, visitedSpotIds);
   const [showLoginModal, setShowLoginModal] = useState(false);
@@ -138,6 +147,17 @@ export function MapScreen({ navigation, route }: Props) {
       }
     },
     [isAuthenticated]
+  );
+
+  const handleWishlistToggle = useCallback(
+    (spotId: string) => {
+      if (!isAuthenticated) {
+        setShowLoginModal(true);
+        return;
+      }
+      toggleWishlist(spotId);
+    },
+    [isAuthenticated, toggleWishlist]
   );
 
   const handleFilterPress = () => {
@@ -253,7 +273,7 @@ export function MapScreen({ navigation, route }: Props) {
             tracksViewChanges={false}
           >
             <SpotMarker
-              color={getPinColor(spot, visitedSpotIds)}
+              color={getPinColor(spot, visitedSpotIds, wishlistSpotIds)}
               name={spot.name}
               showLabel={shouldShowLabels}
             />
@@ -272,6 +292,8 @@ export function MapScreen({ navigation, route }: Props) {
         visitedSpotIds={visitedSpotIds}
         onDismiss={handleBottomSheetDismiss}
         onRecord={handleBottomSheetRecord}
+        wishlistSpotIds={wishlistSpotIds}
+        onWishlistToggle={handleWishlistToggle}
       />
 
       <LoginPromptModal

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import MapView, { Marker, type Region } from 'react-native-maps';
+import MapView, { Marker, type MapPressEvent, type Region } from 'react-native-maps';
 import { MaterialIcons } from '@expo/vector-icons';
 
 import { FABButton } from '@components/animated/FABButton';
@@ -9,6 +9,7 @@ import { SearchBar } from '@components/common/SearchBar';
 import { LoginPromptModal } from '@components/common/LoginPromptModal';
 import { MapPin } from '@components/common/MapPin';
 import { SpotMarker } from '@components/common/SpotMarker';
+import { SpotBottomSheet } from '@components/spot-detail/SpotBottomSheet';
 import { useAuth } from '@hooks/useAuth';
 import { useLocation } from '@hooks/useLocation';
 import { useSpots } from '@hooks/useSpots';
@@ -41,6 +42,7 @@ export function MapScreen({ navigation, route }: Props) {
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [showFilter, setShowFilter] = useState(false);
   const [currentLatitudeDelta, setCurrentLatitudeDelta] = useState(LATITUDE_DELTA);
+  const [selectedSpotId, setSelectedSpotId] = useState<string | null>(null);
   const shouldShowLabels = currentLatitudeDelta <= LABEL_VISIBLE_DELTA;
   const mapRef = useRef<MapView>(null);
   const insets = useSafeAreaInsets();
@@ -63,12 +65,21 @@ export function MapScreen({ navigation, route }: Props) {
       },
       500
     );
+
+    setSelectedSpotId(focusSpotId);
   }, [route.params?.focusSpotId, spots]);
 
-  const navigateToRecord = () => {
+  // Clear selection if the selected spot is no longer in the spots list
+  useEffect(() => {
+    if (selectedSpotId && !spots.find(s => s.id === selectedSpotId)) {
+      setSelectedSpotId(null);
+    }
+  }, [selectedSpotId, spots]);
+
+  const navigateToRecord = (spotId?: string) => {
     const parent = navigation.getParent();
     if (parent) {
-      parent.navigate('Record');
+      parent.navigate('Record', spotId ? { spotId } : undefined);
     }
   };
 
@@ -91,9 +102,42 @@ export function MapScreen({ navigation, route }: Props) {
 
   const handleMarkerPress = useCallback(
     (spotId: string) => {
-      navigation.navigate('SpotDetail', { spotId });
+      setSelectedSpotId(spotId);
+
+      const spot = spots.find(s => s.id === spotId);
+      if (spot && mapRef.current) {
+        mapRef.current.animateCamera(
+          {
+            center: {
+              latitude: spot.lat,
+              longitude: spot.lng,
+            },
+          },
+          { duration: 300 }
+        );
+      }
     },
-    [navigation]
+    [spots]
+  );
+
+  const handleMapPress = useCallback((event?: MapPressEvent) => {
+    if (event?.nativeEvent?.action === 'marker-press') return;
+    setSelectedSpotId(null);
+  }, []);
+
+  const handleBottomSheetDismiss = useCallback(() => {
+    setSelectedSpotId(null);
+  }, []);
+
+  const handleBottomSheetRecord = useCallback(
+    (spotId: string) => {
+      if (isAuthenticated) {
+        navigateToRecord(spotId);
+      } else {
+        setShowLoginModal(true);
+      }
+    },
+    [isAuthenticated]
   );
 
   const handleFilterPress = () => {
@@ -185,6 +229,7 @@ export function MapScreen({ navigation, route }: Props) {
         testID="map-view"
         showsUserLocation={false}
         onRegionChangeComplete={handleRegionChangeComplete}
+        onPress={handleMapPress}
       >
         {location && (
           <Marker
@@ -216,9 +261,18 @@ export function MapScreen({ navigation, route }: Props) {
         ))}
       </MapView>
 
-      <View style={styles.fabContainer}>
-        <FABButton onPress={handleFABPress} />
-      </View>
+      {!selectedSpotId && (
+        <View style={styles.fabContainer}>
+          <FABButton onPress={handleFABPress} />
+        </View>
+      )}
+
+      <SpotBottomSheet
+        spotId={selectedSpotId}
+        visitedSpotIds={visitedSpotIds}
+        onDismiss={handleBottomSheetDismiss}
+        onRecord={handleBottomSheetRecord}
+      />
 
       <LoginPromptModal
         visible={showLoginModal}

--- a/src/screens/SpotDetailScreen.tsx
+++ b/src/screens/SpotDetailScreen.tsx
@@ -1,31 +1,19 @@
 import React from 'react';
-import { ActivityIndicator, Image, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import MapView, { Marker } from 'react-native-maps';
 import { MaterialIcons } from '@expo/vector-icons';
 
-import { Badge } from '@components/common/Badge';
-import { Button } from '@components/common/Button';
-import { Card } from '@components/common/Card';
 import { Header } from '@components/common/Header';
+import { SpotDetailContent } from '@components/spot-detail/SpotDetailContent';
 import { useSpotDetail } from '@hooks/useSpotDetail';
 import { useAuth } from '@hooks/useAuth';
 import { useSpotStamps } from '@hooks/useSpotStamps';
-import { getStampImageUrl } from '@services/stamps';
 import type { MapStackScreenProps } from '@/navigation/types';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
-import { spacing, borderRadius } from '@theme/spacing';
+import { spacing } from '@theme/spacing';
 
 type Props = MapStackScreenProps<'SpotDetail'>;
-
-function formatDate(dateStr: string): string {
-  const d = new Date(dateStr);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}/${m}/${day}`;
-}
 
 export function SpotDetailScreen({ navigation, route }: Props) {
   const { spotId } = route.params;
@@ -67,99 +55,18 @@ export function SpotDetailScreen({ navigation, route }: Props) {
     );
   }
 
-  const badgeType = spot.type === 'shrine' ? 'shrine' : 'temple';
-  const showVisited = isAuthenticated && visitCount > 0;
-
   return (
     <SafeAreaView style={styles.container} testID="spot-detail-screen">
       <Header title="スポット詳細" onBack={handleBack} />
-
       <ScrollView contentContainerStyle={styles.scrollContent}>
-        <View style={styles.badgeRow}>
-          <Badge type={badgeType} />
-          {showVisited && <Badge type="visited" />}
-        </View>
-
-        <Text style={styles.spotName} testID="spot-name">
-          {spot.name}
-        </Text>
-        {spot.address && (
-          <View style={styles.addressRow}>
-            <MaterialIcons name="place" size={16} color={colors.gray[400]} />
-            <Text style={styles.address}>{spot.address}</Text>
-          </View>
-        )}
-
-        <Card style={styles.visitCard}>
-          <View style={styles.visitRow}>
-            <View style={styles.visitItem}>
-              <Text style={styles.visitLabel}>種別</Text>
-              <Text style={styles.visitValue}>{spot.type === 'shrine' ? '神社' : '寺院'}</Text>
-            </View>
-            {isAuthenticated && visitCount > 0 && (
-              <>
-                <View style={styles.visitItem}>
-                  <Text style={styles.visitLabel}>訪問回数</Text>
-                  <Text style={styles.visitValue}>{visitCount}</Text>
-                </View>
-                <View style={styles.visitItem}>
-                  <Text style={styles.visitLabel}>最終訪問日</Text>
-                  <Text style={styles.visitValue}>
-                    {latestVisitDate ? formatDate(latestVisitDate) : '-'}
-                  </Text>
-                </View>
-              </>
-            )}
-          </View>
-        </Card>
-
-        <Button
-          title="ここで記録する"
-          onPress={handleRecord}
-          variant="primary"
-          style={styles.recordButton}
+        <SpotDetailContent
+          spot={spot}
+          stamps={stamps}
+          visitCount={visitCount}
+          latestVisitDate={latestVisitDate}
+          isAuthenticated={isAuthenticated}
+          onRecord={handleRecord}
         />
-
-        {stamps.length > 0 && (
-          <>
-            <Text style={styles.sectionTitle}>記録済み御朱印</Text>
-            <View style={styles.stampGrid} testID="stamp-grid">
-              {stamps.map(stamp => (
-                <Image
-                  key={stamp.id}
-                  source={{ uri: getStampImageUrl(stamp.image_path) }}
-                  style={styles.stampImage}
-                  testID={`stamp-image-${stamp.id}`}
-                />
-              ))}
-            </View>
-          </>
-        )}
-
-        <Text style={styles.sectionTitle}>アクセス</Text>
-        <View style={styles.miniMapContainer} testID="mini-map">
-          <MapView
-            style={styles.miniMapView}
-            initialRegion={{
-              latitude: spot.lat,
-              longitude: spot.lng,
-              latitudeDelta: 0.005,
-              longitudeDelta: 0.005,
-            }}
-            scrollEnabled={false}
-            zoomEnabled={false}
-            rotateEnabled={false}
-            pitchEnabled={false}
-          >
-            <Marker coordinate={{ latitude: spot.lat, longitude: spot.lng }} />
-          </MapView>
-        </View>
-        {spot.address && (
-          <View style={styles.miniMapAddress}>
-            <MaterialIcons name="place" size={16} color={colors.primary[500]} />
-            <Text style={styles.miniMapAddressText}>{spot.address}</Text>
-          </View>
-        )}
       </ScrollView>
     </SafeAreaView>
   );
@@ -181,87 +88,6 @@ const styles = StyleSheet.create({
     color: colors.gray[500],
   },
   scrollContent: {
-    paddingHorizontal: spacing.lg,
-    paddingBottom: spacing['3xl'],
-  },
-  badgeRow: {
-    flexDirection: 'row',
-    gap: spacing.sm,
-    marginBottom: spacing.md,
-  },
-  spotName: {
-    ...typography.h2,
-    color: colors.gray[900],
-    marginBottom: spacing.sm,
-  },
-  addressRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.xs,
-    marginBottom: spacing.xl,
-  },
-  address: {
-    ...typography.bodySmall,
-    color: colors.gray[500],
-    flex: 1,
-  },
-  visitCard: {
-    marginBottom: spacing.lg,
-  },
-  visitRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  visitItem: {
-    flex: 1,
-    alignItems: 'center',
-    gap: spacing.xs,
-  },
-  visitLabel: {
-    ...typography.caption,
-    color: colors.gray[500],
-  },
-  visitValue: {
-    ...typography.h3,
-    color: colors.gray[900],
-  },
-  recordButton: {
-    marginBottom: spacing.xl,
-  },
-  sectionTitle: {
-    ...typography.h3,
-    color: colors.gray[800],
-    marginBottom: spacing.md,
-    marginTop: spacing.lg,
-  },
-  stampGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: spacing.xs,
-  },
-  stampImage: {
-    width: '31.5%',
-    aspectRatio: 1,
-    borderRadius: borderRadius.md,
-    backgroundColor: colors.gray[100],
-  },
-  miniMapContainer: {
-    height: 150,
-    borderRadius: borderRadius.lg,
-    overflow: 'hidden',
-  },
-  miniMapView: {
-    flex: 1,
-  },
-  miniMapAddress: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.xs,
-    marginTop: spacing.md,
-  },
-  miniMapAddressText: {
-    ...typography.bodySmall,
-    color: colors.gray[600],
-    flex: 1,
+    flexGrow: 1,
   },
 });

--- a/src/screens/__tests__/CollectionScreen.test.tsx
+++ b/src/screens/__tests__/CollectionScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 
 import { CollectionScreen } from '../CollectionScreen';
 import type { MainTabScreenProps } from '@/navigation/types';
@@ -14,6 +14,31 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 'user-1' },
+    isAuthenticated: true,
+  }),
+}));
+
+const mockRefetch = jest.fn();
+let mockWishlistSpots: unknown[] = [];
+
+jest.mock('@hooks/useWishlistSpots', () => ({
+  useWishlistSpots: () => ({
+    spots: mockWishlistSpots,
+    isLoading: false,
+    error: null,
+    refetch: mockRefetch,
+  }),
+}));
+
+const mockRemoveFromWishlist = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@services/wishlist', () => ({
+  removeFromWishlist: (...args: unknown[]) => mockRemoveFromWishlist(...args),
+}));
+
 const mockNavigation = {
   navigate: jest.fn(),
   goBack: jest.fn(),
@@ -27,6 +52,11 @@ const mockRoute = {
 } as unknown as MainTabScreenProps<'Collection'>['route'];
 
 describe('CollectionScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWishlistSpots = [];
+  });
+
   it('renders the header', () => {
     const { getByText } = render(
       <CollectionScreen navigation={mockNavigation} route={mockRoute} />
@@ -74,5 +104,62 @@ describe('CollectionScreen', () => {
     expect(getByText('10箇所達成')).toBeTruthy();
     expect(getByText('巡礼者')).toBeTruthy();
     expect(getByText('全国制覇')).toBeTruthy();
+  });
+
+  describe('Wishlist section', () => {
+    it('renders wishlist section title', () => {
+      const { getByText } = render(
+        <CollectionScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      expect(getByText('行きたいリスト')).toBeTruthy();
+    });
+
+    it('renders empty state when no wishlist spots', () => {
+      mockWishlistSpots = [];
+      const { getByText } = render(
+        <CollectionScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      expect(getByText('行きたいスポットをマップで保存しましょう')).toBeTruthy();
+    });
+
+    it('renders wishlist items', () => {
+      mockWishlistSpots = [
+        {
+          id: 'wl-1',
+          user_id: 'user-1',
+          spot_id: 'spot-1',
+          created_at: '2026-01-01T00:00:00Z',
+          spots: { name: '伊勢神宮', type: 'shrine', address: '三重県伊勢市宇治館町1' },
+        },
+      ];
+      const { getByText, getByTestId } = render(
+        <CollectionScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      expect(getByText('伊勢神宮')).toBeTruthy();
+      expect(getByTestId('wishlist-item-spot-1')).toBeTruthy();
+    });
+
+    it('calls removeFromWishlist and refetch when wishlist button is pressed', async () => {
+      mockWishlistSpots = [
+        {
+          id: 'wl-1',
+          user_id: 'user-1',
+          spot_id: 'spot-1',
+          created_at: '2026-01-01T00:00:00Z',
+          spots: { name: '伊勢神宮', type: 'shrine', address: '三重県伊勢市宇治館町1' },
+        },
+      ];
+      const { getByTestId } = render(
+        <CollectionScreen navigation={mockNavigation} route={mockRoute} />
+      );
+
+      fireEvent.press(getByTestId('wishlist-button'));
+
+      // Wait for async operation
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(mockRemoveFromWishlist).toHaveBeenCalledWith('user-1', 'spot-1');
+      expect(mockRefetch).toHaveBeenCalled();
+    });
   });
 });

--- a/src/screens/__tests__/MapScreen.test.tsx
+++ b/src/screens/__tests__/MapScreen.test.tsx
@@ -2,18 +2,61 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { MapScreen } from '@screens/MapScreen';
 
-jest.mock('react-native-safe-area-context', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-  const React = require('react');
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-  const { View } = require('react-native');
-  return {
-    SafeAreaView: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
-      React.createElement(View, props, children),
-    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
-    useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
-  };
-});
+jest.mock('@services/stamps', () => ({
+  fetchStampsBySpotId: jest.fn(() => Promise.resolve([])),
+  getStampImageUrl: jest.fn((path: string) => `https://example.com/${path}`),
+}));
+
+jest.mock('@hooks/useSpotDetail', () => ({
+  useSpotDetail: (spotId: string) => {
+    const spots: Record<string, unknown> = {
+      'spot-1': {
+        spot: {
+          id: 'spot-1',
+          name: 'Test Shrine',
+          lat: 38.27,
+          lng: 140.87,
+          type: 'shrine',
+          status: 'active',
+          address: '宮城県仙台市',
+          created_by_user_id: null,
+          merged_into_spot_id: null,
+          created_at: '2024-01-01',
+          updated_at: '2024-01-01',
+        },
+        isLoading: false,
+        error: null,
+      },
+      'spot-2': {
+        spot: {
+          id: 'spot-2',
+          name: 'Test Temple',
+          lat: 38.28,
+          lng: 140.88,
+          type: 'temple',
+          status: 'active',
+          address: null,
+          created_by_user_id: null,
+          merged_into_spot_id: null,
+          created_at: '2024-01-01',
+          updated_at: '2024-01-01',
+        },
+        isLoading: false,
+        error: null,
+      },
+    };
+    return spots[spotId] ?? { spot: null, isLoading: false, error: null };
+  },
+}));
+
+jest.mock('@hooks/useSpotStamps', () => ({
+  useSpotStamps: () => ({
+    stamps: [],
+    visitCount: 0,
+    latestVisitDate: null,
+    isLoading: false,
+  }),
+}));
 
 let mockUseAuthReturn = {
   user: null,
@@ -49,7 +92,7 @@ const mockSpots = [
     lng: 140.87,
     type: 'shrine',
     status: 'active',
-    address: null,
+    address: '宮城県仙台市',
     created_by_user_id: null,
     merged_into_spot_id: null,
     created_at: '2024-01-01',
@@ -163,7 +206,7 @@ describe('MapScreen', () => {
     expect(getByTestId('map-pin-current-location')).toBeTruthy();
   });
 
-  it('displays FAB button', () => {
+  it('displays FAB button when no spot is selected', () => {
     const { getByTestId } = render(
       <MapScreen navigation={mockNavigation as never} route={mockRoute} />
     );
@@ -189,13 +232,52 @@ describe('MapScreen', () => {
       expect(getAllByTestId('spot-marker-pin-tail')).toHaveLength(2);
     });
 
-    it('navigates to SpotDetail when marker is pressed', () => {
+    it('shows bottom sheet when marker is pressed', () => {
       const { getByTestId } = render(
         <MapScreen navigation={mockNavigation as never} route={mockRoute} />
       );
 
       fireEvent.press(getByTestId('spot-marker-spot-1'));
-      expect(mockNavigation.navigate).toHaveBeenCalledWith('SpotDetail', { spotId: 'spot-1' });
+      expect(getByTestId('bottom-sheet')).toBeTruthy();
+    });
+
+    it('hides FAB when marker is pressed and spot is selected', () => {
+      const { getByTestId, queryByTestId } = render(
+        <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+
+      fireEvent.press(getByTestId('spot-marker-spot-1'));
+      expect(queryByTestId('fab-button')).toBeNull();
+    });
+  });
+
+  describe('Bottom sheet', () => {
+    it('shows bottom sheet when focusSpotId is provided', () => {
+      const routeWithFocus = {
+        key: 'test',
+        name: 'Map' as const,
+        params: { focusSpotId: 'spot-1' },
+      };
+
+      const { getByTestId } = render(
+        <MapScreen navigation={mockNavigation as never} route={routeWithFocus} />
+      );
+
+      expect(getByTestId('bottom-sheet')).toBeTruthy();
+    });
+
+    it('hides bottom sheet when map is pressed', () => {
+      const { getByTestId, queryByTestId } = render(
+        <MapScreen navigation={mockNavigation as never} route={mockRoute} />
+      );
+
+      // First show the sheet
+      fireEvent.press(getByTestId('spot-marker-spot-1'));
+      expect(getByTestId('bottom-sheet')).toBeTruthy();
+
+      // Then press the map to dismiss
+      fireEvent.press(getByTestId('map-view'));
+      expect(queryByTestId('bottom-sheet')).toBeNull();
     });
   });
 
@@ -309,23 +391,6 @@ describe('MapScreen', () => {
     });
   });
 
-  describe('Focus spot from search', () => {
-    it('calls animateToRegion when focusSpotId is provided', () => {
-      const routeWithFocus = {
-        key: 'test',
-        name: 'Map' as const,
-        params: { focusSpotId: 'spot-1' },
-      };
-
-      render(<MapScreen navigation={mockNavigation as never} route={routeWithFocus} />);
-
-      // MapView mock should have animateToRegion called
-      // Since react-native-maps is mocked, we verify the component renders without error
-      // and the spot marker is present
-      expect(true).toBe(true);
-    });
-  });
-
   describe('FAB press with authentication', () => {
     it('navigates to Record when authenticated', () => {
       mockUseAuthReturn = {
@@ -339,7 +404,7 @@ describe('MapScreen', () => {
       );
 
       fireEvent.press(getByTestId('fab-button'));
-      expect(mockParentNavigate).toHaveBeenCalledWith('Record');
+      expect(mockParentNavigate).toHaveBeenCalledWith('Record', undefined);
     });
 
     it('shows LoginPromptModal when not authenticated', () => {
@@ -362,7 +427,7 @@ describe('MapScreen', () => {
       fireEvent.press(getByTestId('modal-google-login-button'));
 
       await waitFor(() => {
-        expect(mockParentNavigate).toHaveBeenCalledWith('Record');
+        expect(mockParentNavigate).toHaveBeenCalledWith('Record', undefined);
       });
     });
 

--- a/src/screens/__tests__/MapScreen.test.tsx
+++ b/src/screens/__tests__/MapScreen.test.tsx
@@ -131,6 +131,15 @@ jest.mock('@hooks/useUserStamps', () => ({
   }),
 }));
 
+jest.mock('@hooks/useWishlist', () => ({
+  useWishlist: () => ({
+    wishlistSpotIds: new Set(),
+    toggleWishlist: jest.fn(),
+    isLoading: false,
+    isToggling: false,
+  }),
+}));
+
 const mockParentNavigate = jest.fn();
 const mockNavigation = {
   navigate: jest.fn(),

--- a/src/services/__tests__/wishlist.test.ts
+++ b/src/services/__tests__/wishlist.test.ts
@@ -1,0 +1,189 @@
+import {
+  fetchWishlistSpotIds,
+  addToWishlist,
+  removeFromWishlist,
+  fetchWishlistSpots,
+} from '@services/wishlist';
+
+const mockSelect = jest.fn();
+const mockEq = jest.fn();
+const mockDelete = jest.fn();
+const mockFrom = jest.fn();
+const mockUpsert = jest.fn();
+
+jest.mock('@services/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+describe('fetchWishlistSpotIds', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ユーザーのwishlist spot IDをSet<string>で返す', async () => {
+    const mockData = [{ spot_id: 'spot-1' }, { spot_id: 'spot-2' }];
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ data: mockData, error: null });
+
+    const result = await fetchWishlistSpotIds('user-1');
+
+    expect(mockFrom).toHaveBeenCalledWith('wishlists');
+    expect(mockSelect).toHaveBeenCalledWith('spot_id');
+    expect(mockEq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(result).toEqual(new Set(['spot-1', 'spot-2']));
+  });
+
+  it('エラー時は空のSetを返す', async () => {
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ data: null, error: { message: 'error' } });
+
+    const result = await fetchWishlistSpotIds('user-1');
+
+    expect(result).toEqual(new Set());
+  });
+
+  it('データが空の場合は空のSetを返す', async () => {
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ data: [], error: null });
+
+    const result = await fetchWishlistSpotIds('user-1');
+
+    expect(result).toEqual(new Set());
+  });
+});
+
+describe('addToWishlist', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('wishlistにupsertで追加する', async () => {
+    mockFrom.mockReturnValue({ upsert: mockUpsert });
+    mockUpsert.mockReturnValue({ error: null });
+
+    await addToWishlist('user-1', 'spot-1');
+
+    expect(mockFrom).toHaveBeenCalledWith('wishlists');
+    expect(mockUpsert).toHaveBeenCalledWith(
+      { user_id: 'user-1', spot_id: 'spot-1' },
+      { onConflict: 'user_id,spot_id' }
+    );
+  });
+
+  it('エラー時はconsole.warnを呼ぶ', async () => {
+    mockFrom.mockReturnValue({ upsert: mockUpsert });
+    mockUpsert.mockReturnValue({ error: { message: 'insert error' } });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await addToWishlist('user-1', 'spot-1');
+
+    expect(warnSpy).toHaveBeenCalledWith('addToWishlist error:', 'insert error');
+    warnSpy.mockRestore();
+  });
+});
+
+describe('removeFromWishlist', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('wishlistから削除する', async () => {
+    const mockEqSpot = jest.fn();
+    mockFrom.mockReturnValue({ delete: mockDelete });
+    mockDelete.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ eq: mockEqSpot });
+    mockEqSpot.mockReturnValue({ error: null });
+
+    await removeFromWishlist('user-1', 'spot-1');
+
+    expect(mockFrom).toHaveBeenCalledWith('wishlists');
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockEq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(mockEqSpot).toHaveBeenCalledWith('spot_id', 'spot-1');
+  });
+
+  it('エラー時はconsole.warnを呼ぶ', async () => {
+    const mockEqSpot = jest.fn();
+    mockFrom.mockReturnValue({ delete: mockDelete });
+    mockDelete.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ eq: mockEqSpot });
+    mockEqSpot.mockReturnValue({ error: { message: 'delete error' } });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await removeFromWishlist('user-1', 'spot-1');
+
+    expect(warnSpy).toHaveBeenCalledWith('removeFromWishlist error:', 'delete error');
+    warnSpy.mockRestore();
+  });
+});
+
+describe('fetchWishlistSpots', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('スポット情報込みのwishlistを返す', async () => {
+    const mockData = [
+      {
+        id: 'wl-1',
+        user_id: 'user-1',
+        spot_id: 'spot-1',
+        created_at: '2026-01-01T00:00:00Z',
+        spots: { name: '伊勢神宮', type: 'shrine', address: '三重県伊勢市宇治館町1' },
+      },
+      {
+        id: 'wl-2',
+        user_id: 'user-1',
+        spot_id: 'spot-2',
+        created_at: '2026-01-02T00:00:00Z',
+        spots: { name: '浅草寺', type: 'temple', address: '東京都台東区浅草2-3-1' },
+      },
+    ];
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ data: mockData, error: null });
+
+    const result = await fetchWishlistSpots('user-1');
+
+    expect(mockFrom).toHaveBeenCalledWith('wishlists');
+    expect(mockSelect).toHaveBeenCalledWith('*, spots!inner(name, type, address)');
+    expect(mockEq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(result).toEqual(mockData);
+    expect(result[0].spots.name).toBe('伊勢神宮');
+  });
+
+  it('エラー時は空配列を返す', async () => {
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ data: null, error: { message: 'error' } });
+
+    const result = await fetchWishlistSpots('user-1');
+
+    expect(result).toEqual([]);
+  });
+
+  it('住所がnullのスポットも含む', async () => {
+    const mockData = [
+      {
+        id: 'wl-1',
+        user_id: 'user-1',
+        spot_id: 'spot-1',
+        created_at: '2026-01-01T00:00:00Z',
+        spots: { name: '不明神社', type: 'shrine', address: null },
+      },
+    ];
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ data: mockData, error: null });
+
+    const result = await fetchWishlistSpots('user-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].spots.address).toBeNull();
+  });
+});

--- a/src/services/wishlist.ts
+++ b/src/services/wishlist.ts
@@ -1,0 +1,61 @@
+import { supabase } from '@services/supabase';
+import type { WishlistWithSpot } from '@/types/supabase';
+
+/**
+ * ユーザーのwishlistに登録されたspot IDをSet<string>で取得（MapScreen用）
+ */
+export async function fetchWishlistSpotIds(userId: string): Promise<Set<string>> {
+  const { data, error } = await supabase.from('wishlists').select('spot_id').eq('user_id', userId);
+
+  if (error) {
+    console.warn('fetchWishlistSpotIds error:', error.message);
+    return new Set();
+  }
+
+  return new Set((data as { spot_id: string }[]).map(row => row.spot_id));
+}
+
+/**
+ * wishlistにスポットを追加する（upsertで冪等）
+ */
+export async function addToWishlist(userId: string, spotId: string): Promise<void> {
+  const { error } = await supabase
+    .from('wishlists')
+    .upsert({ user_id: userId, spot_id: spotId }, { onConflict: 'user_id,spot_id' });
+
+  if (error) {
+    console.warn('addToWishlist error:', error.message);
+  }
+}
+
+/**
+ * wishlistからスポットを削除する
+ */
+export async function removeFromWishlist(userId: string, spotId: string): Promise<void> {
+  const { error } = await supabase
+    .from('wishlists')
+    .delete()
+    .eq('user_id', userId)
+    .eq('spot_id', spotId);
+
+  if (error) {
+    console.warn('removeFromWishlist error:', error.message);
+  }
+}
+
+/**
+ * wishlistのスポット一覧をspot情報込みで取得（CollectionScreen用）
+ */
+export async function fetchWishlistSpots(userId: string): Promise<WishlistWithSpot[]> {
+  const { data, error } = await supabase
+    .from('wishlists')
+    .select('*, spots!inner(name, type, address)')
+    .eq('user_id', userId);
+
+  if (error) {
+    console.warn('fetchWishlistSpots error:', error.message);
+    return [];
+  }
+
+  return data as WishlistWithSpot[];
+}

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -46,6 +46,7 @@ export const colors = {
   pin: {
     shrineVisited: '#EF4444',
     templeVisited: '#A855F7',
+    wishlisted: '#F59E0B',
     unvisited: '#9CA3AF',
     currentLocation: '#3B82F6',
   },

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -46,6 +46,21 @@ export interface StampWithSpot extends Stamp {
   };
 }
 
+export interface Wishlist {
+  id: string;
+  user_id: string;
+  spot_id: string;
+  created_at: string;
+}
+
+export interface WishlistWithSpot extends Wishlist {
+  spots: {
+    name: string;
+    type: SpotType;
+    address: string | null;
+  };
+}
+
 export interface Goshuincho {
   id: string;
   user_id: string;

--- a/supabase/migrations/20260331000000_create_wishlists.sql
+++ b/supabase/migrations/20260331000000_create_wishlists.sql
@@ -1,0 +1,28 @@
+
+-- wishlists テーブル（行きたいリスト）
+CREATE TABLE public.wishlists (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  spot_id UUID NOT NULL REFERENCES public.spots(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, spot_id)
+);
+
+-- インデックス
+CREATE INDEX idx_wishlists_user_id ON public.wishlists (user_id);
+CREATE INDEX idx_wishlists_spot_id ON public.wishlists (spot_id);
+
+-- RLS（SELECT/INSERT/DELETE のみ。UPDATE不要、toggle は DELETE + INSERT で実現）
+ALTER TABLE public.wishlists ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own wishlists"
+  ON public.wishlists FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own wishlists"
+  ON public.wishlists FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own wishlists"
+  ON public.wishlists FOR DELETE
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- スポット詳細カード（ボトムシート）にフラッグアイコンを追加し、「行きたい」スポットとして保存できる機能を実装
- 地図上で「行きたい」スポットをamber色（#F59E0B）で表示
- コレクション画面に「行きたいリスト」セクションを追加し、保存したスポットを一覧表示

## 変更内容
- **DB**: `wishlists` テーブル追加（Supabase RLS有効）
- **サービス層**: `src/services/wishlist.ts` - CRUD操作
- **Hooks**: `useWishlist`（楽観的更新）、`useWishlistSpots`（Collection用）
- **UI**: `WishlistButton` - flag/outlined-flagアイコン＋弾むアニメーション
- **MapScreen**: ピン色にwishlist状態追加、未ログイン時ログインモーダル表示
- **CollectionScreen**: 地域別〜巡礼チャレンジ間に行きたいリストセクション追加

## Test plan
- [x] テスト: 501件全パス
- [x] Lint: エラー0
- [x] 型チェック: OK
- [ ] UI目視確認: ボトムシートのフラッグアイコン表示・アニメーション
- [ ] UI目視確認: 地図ピンの色分け（amber）
- [ ] UI目視確認: コレクション画面の行きたいリストセクション

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)