### PR TITLE
feat(public-stamps): 御朱印記録の公開機能を追加 (#45)

### DIFF
--- a/src/components/common/ImagePreviewModal.tsx
+++ b/src/components/common/ImagePreviewModal.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { Modal, StyleSheet, Text, View, Image, TouchableOpacity, ScrollView } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { colors } from '@theme/colors';
+import { typography } from '@theme/typography';
+import { spacing } from '@theme/spacing';
+
+interface ImagePreviewModalProps {
+  visible: boolean;
+  onClose: () => void;
+  imageUrl: string;
+  userName?: string | null;
+  memo?: string | null;
+  visitedAt?: string | null;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}/${m}/${day}`;
+}
+
+export function ImagePreviewModal({
+  visible,
+  onClose,
+  imageUrl,
+  userName,
+  memo,
+  visitedAt,
+}: ImagePreviewModalProps) {
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <TouchableOpacity style={styles.closeButton} onPress={onClose} testID="close-button">
+          <MaterialIcons name="close" size={28} color={colors.white} />
+        </TouchableOpacity>
+
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
+          maximumZoomScale={3}
+          minimumZoomScale={1}
+        >
+          <Image
+            source={{ uri: imageUrl }}
+            style={styles.image}
+            resizeMode="contain"
+            testID="preview-image"
+          />
+        </ScrollView>
+
+        <View style={styles.infoContainer}>
+          {userName && (
+            <Text style={styles.userName} testID="preview-username">
+              {userName}
+            </Text>
+          )}
+          {memo && (
+            <Text style={styles.memo} testID="preview-memo">
+              {memo}
+            </Text>
+          )}
+          {visitedAt && (
+            <Text style={styles.visitedAt} testID="preview-visited-at">
+              {formatDate(visitedAt)}
+            </Text>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.9)',
+    justifyContent: 'center',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: spacing['4xl'],
+    right: spacing.lg,
+    zIndex: 10,
+    padding: spacing.sm,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  image: {
+    width: '100%',
+    height: '80%',
+  },
+  infoContainer: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing['3xl'],
+    gap: spacing.xs,
+  },
+  userName: {
+    ...typography.body,
+    color: colors.white,
+    fontWeight: '600',
+  },
+  memo: {
+    ...typography.bodySmall,
+    color: 'rgba(255, 255, 255, 0.8)',
+  },
+  visitedAt: {
+    ...typography.caption,
+    color: 'rgba(255, 255, 255, 0.6)',
+  },
+});

--- a/src/components/common/__tests__/ImagePreviewModal.test.tsx
+++ b/src/components/common/__tests__/ImagePreviewModal.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ImagePreviewModal } from '../ImagePreviewModal';
+
+describe('ImagePreviewModal', () => {
+  const defaultProps = {
+    visible: true,
+    onClose: jest.fn(),
+    imageUrl: 'https://example.com/stamp.jpg',
+    userName: 'テストユーザー',
+    memo: '素敵な御朱印でした',
+    visitedAt: '2024-06-15',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('visible=true で画像が表示されること', () => {
+    const { getByTestId } = render(<ImagePreviewModal {...defaultProps} />);
+    expect(getByTestId('preview-image')).toBeTruthy();
+  });
+
+  it('visible=false で何も表示されないこと', () => {
+    const { queryByTestId } = render(<ImagePreviewModal {...defaultProps} visible={false} />);
+    expect(queryByTestId('preview-image')).toBeNull();
+  });
+
+  it('ユーザー名が表示されること', () => {
+    const { getByText } = render(<ImagePreviewModal {...defaultProps} />);
+    expect(getByText('テストユーザー')).toBeTruthy();
+  });
+
+  it('メモが表示されること', () => {
+    const { getByText } = render(<ImagePreviewModal {...defaultProps} />);
+    expect(getByText('素敵な御朱印でした')).toBeTruthy();
+  });
+
+  it('訪問日が表示されること', () => {
+    const { getByText } = render(<ImagePreviewModal {...defaultProps} />);
+    expect(getByText('2024/06/15')).toBeTruthy();
+  });
+
+  it('閉じるボタンのタップで onClose が呼ばれること', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(<ImagePreviewModal {...defaultProps} onClose={onClose} />);
+    fireEvent.press(getByTestId('close-button'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('ユーザー名が null の場合は表示されないこと', () => {
+    const { queryByTestId } = render(<ImagePreviewModal {...defaultProps} userName={null} />);
+    expect(queryByTestId('preview-username')).toBeNull();
+  });
+
+  it('メモが null の場合は表示されないこと', () => {
+    const { queryByTestId } = render(<ImagePreviewModal {...defaultProps} memo={null} />);
+    expect(queryByTestId('preview-memo')).toBeNull();
+  });
+});

--- a/src/components/spot-detail/SpotBottomSheet.tsx
+++ b/src/components/spot-detail/SpotBottomSheet.tsx
@@ -36,7 +36,7 @@ export function SpotBottomSheet({
   const insets = useSafeAreaInsets();
   const expandedHeight = SCREEN_HEIGHT * 0.85;
   const { spot } = useSpotDetail(spotId ?? '');
-  const { stamps, visitCount, latestVisitDate } = useSpotStamps(spotId ?? '');
+  const { stamps, visitCount, latestVisitDate, publicStamps } = useSpotStamps(spotId ?? '');
   const { isAuthenticated } = useAuth();
 
   const [mode, setMode] = useState<SheetMode>('hidden');
@@ -190,6 +190,7 @@ export function SpotBottomSheet({
             showMiniMap={false}
             isWishlisted={isWishlisted}
             onWishlistPress={onWishlistToggle ? handleWishlistPress : undefined}
+            publicStamps={publicStamps}
           />
         </ScrollView>
       )}

--- a/src/components/spot-detail/SpotDetailContent.tsx
+++ b/src/components/spot-detail/SpotDetailContent.tsx
@@ -1,17 +1,22 @@
-import React from 'react';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import React, { useState } from 'react';
+import { Dimensions, Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import { MaterialIcons } from '@expo/vector-icons';
 
 import { Badge } from '@components/common/Badge';
 import { Button } from '@components/common/Button';
 import { Card } from '@components/common/Card';
+import { ImagePreviewModal } from '@components/common/ImagePreviewModal';
 import { WishlistButton } from '@components/animated/WishlistButton';
 import { getStampImageUrl } from '@services/stamps';
-import type { Spot, Stamp } from '@/types/supabase';
+import type { Spot, Stamp, PublicStampWithUser } from '@/types/supabase';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing, borderRadius } from '@theme/spacing';
+
+const GRID_GAP = spacing.xs;
+const CONTENT_PADDING = spacing.lg;
+const STAMP_IMAGE_SIZE = (Dimensions.get('window').width - CONTENT_PADDING * 2 - GRID_GAP * 2) / 3;
 
 interface SpotDetailContentProps {
   spot: Spot;
@@ -23,6 +28,7 @@ interface SpotDetailContentProps {
   showMiniMap?: boolean;
   isWishlisted?: boolean;
   onWishlistPress?: () => void;
+  publicStamps?: PublicStampWithUser[];
 }
 
 function formatDate(dateStr: string): string {
@@ -43,9 +49,11 @@ export function SpotDetailContent({
   showMiniMap = true,
   isWishlisted,
   onWishlistPress,
+  publicStamps = [],
 }: SpotDetailContentProps) {
   const badgeType = spot.type === 'shrine' ? 'shrine' : 'temple';
   const showVisited = isAuthenticated && visitCount > 0;
+  const [selectedPublicStamp, setSelectedPublicStamp] = useState<PublicStampWithUser | null>(null);
 
   return (
     <View style={styles.content} testID="spot-detail-content">
@@ -113,6 +121,43 @@ export function SpotDetailContent({
             ))}
           </View>
         </>
+      )}
+
+      {publicStamps.length > 0 && (
+        <>
+          <Text style={styles.sectionTitle}>みんなの御朱印</Text>
+          <View style={styles.stampGrid} testID="public-stamp-grid">
+            {publicStamps.map(ps => (
+              <TouchableOpacity
+                key={ps.id}
+                onPress={() => setSelectedPublicStamp(ps)}
+                testID={`public-stamp-image-${ps.id}`}
+                style={styles.publicStampContainer}
+              >
+                <Image
+                  source={{ uri: getStampImageUrl(ps.image_path) }}
+                  style={styles.publicStampImage}
+                />
+                <View style={styles.publicStampOverlay}>
+                  <Text style={styles.publicStampUserName} numberOfLines={1}>
+                    {ps.profiles.display_name ?? '匿名'}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </>
+      )}
+
+      {selectedPublicStamp && (
+        <ImagePreviewModal
+          visible={!!selectedPublicStamp}
+          onClose={() => setSelectedPublicStamp(null)}
+          imageUrl={getStampImageUrl(selectedPublicStamp.image_path)}
+          userName={selectedPublicStamp.profiles.display_name}
+          memo={selectedPublicStamp.memo}
+          visitedAt={selectedPublicStamp.visited_at}
+        />
       )}
 
       {showMiniMap && (
@@ -215,10 +260,36 @@ const styles = StyleSheet.create({
     gap: spacing.xs,
   },
   stampImage: {
-    width: '31.5%',
-    aspectRatio: 1,
+    width: STAMP_IMAGE_SIZE,
+    height: STAMP_IMAGE_SIZE,
     borderRadius: borderRadius.md,
     backgroundColor: colors.gray[100],
+  },
+  publicStampContainer: {
+    width: STAMP_IMAGE_SIZE,
+    position: 'relative',
+  },
+  publicStampImage: {
+    width: STAMP_IMAGE_SIZE,
+    height: STAMP_IMAGE_SIZE,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.gray[100],
+  },
+  publicStampOverlay: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 2,
+    borderBottomLeftRadius: borderRadius.md,
+    borderBottomRightRadius: borderRadius.md,
+  },
+  publicStampUserName: {
+    ...typography.caption,
+    color: colors.white,
+    textAlign: 'center',
   },
   miniMapContainer: {
     height: 150,

--- a/src/components/spot-detail/__tests__/SpotBottomSheet.test.tsx
+++ b/src/components/spot-detail/__tests__/SpotBottomSheet.test.tsx
@@ -33,6 +33,7 @@ jest.mock('@hooks/useSpotDetail', () => ({
 jest.mock('@hooks/useSpotStamps', () => ({
   useSpotStamps: () => ({
     stamps: [],
+    publicStamps: [],
     visitCount: 2,
     latestVisitDate: '2024-06-15',
     isLoading: false,

--- a/src/components/spot-detail/__tests__/SpotDetailContent.test.tsx
+++ b/src/components/spot-detail/__tests__/SpotDetailContent.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { SpotDetailContent } from '../SpotDetailContent';
+import type { Spot, PublicStampWithUser } from '@/types/supabase';
+
+jest.mock('react-native-maps', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: View,
+    Marker: View,
+  };
+});
+
+jest.mock('@services/stamps', () => ({
+  getStampImageUrl: (path: string) => `https://example.com/${path}`,
+}));
+
+const mockSpot: Spot = {
+  id: 'spot-1',
+  name: '大崎八幡宮',
+  lat: 38.2744,
+  lng: 140.8577,
+  type: 'shrine',
+  address: '宮城県仙台市青葉区八幡4-6-1',
+  status: 'active',
+  created_by_user_id: null,
+  merged_into_spot_id: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+};
+
+const mockPublicStamps: PublicStampWithUser[] = [
+  {
+    id: 'ps-1',
+    user_id: 'other-user-1',
+    spot_id: 'spot-1',
+    goshuincho_id: null,
+    visited_at: '2024-05-01',
+    image_path: 'other-user-1/stamp1.jpg',
+    memo: '天気がよかった',
+    is_public: true,
+    created_at: '2024-05-01T00:00:00Z',
+    updated_at: '2024-05-01T00:00:00Z',
+    profiles: {
+      display_name: 'ユーザーA',
+      avatar_url: null,
+    },
+  },
+  {
+    id: 'ps-2',
+    user_id: 'other-user-2',
+    spot_id: 'spot-1',
+    goshuincho_id: null,
+    visited_at: '2024-06-01',
+    image_path: 'other-user-2/stamp2.jpg',
+    memo: null,
+    is_public: true,
+    created_at: '2024-06-01T00:00:00Z',
+    updated_at: '2024-06-01T00:00:00Z',
+    profiles: {
+      display_name: 'ユーザーB',
+      avatar_url: null,
+    },
+  },
+];
+
+const defaultProps = {
+  spot: mockSpot,
+  stamps: [],
+  visitCount: 0,
+  latestVisitDate: null,
+  isAuthenticated: true,
+  onRecord: jest.fn(),
+  showMiniMap: false,
+};
+
+describe('SpotDetailContent - みんなの御朱印', () => {
+  it('publicStamps がある場合「みんなの御朱印」セクションが表示されること', () => {
+    const { getByText } = render(
+      <SpotDetailContent {...defaultProps} publicStamps={mockPublicStamps} />
+    );
+    expect(getByText('みんなの御朱印')).toBeTruthy();
+  });
+
+  it('publicStamps が空の場合セクションが非表示であること', () => {
+    const { queryByText } = render(<SpotDetailContent {...defaultProps} publicStamps={[]} />);
+    expect(queryByText('みんなの御朱印')).toBeNull();
+  });
+
+  it('publicStamps が未指定の場合セクションが非表示であること', () => {
+    const { queryByText } = render(<SpotDetailContent {...defaultProps} />);
+    expect(queryByText('みんなの御朱印')).toBeNull();
+  });
+
+  it('公開御朱印の画像が表示されること', () => {
+    const { getByTestId } = render(
+      <SpotDetailContent {...defaultProps} publicStamps={mockPublicStamps} />
+    );
+    expect(getByTestId('public-stamp-image-ps-1')).toBeTruthy();
+    expect(getByTestId('public-stamp-image-ps-2')).toBeTruthy();
+  });
+
+  it('投稿者名がオーバーレイ表示されること', () => {
+    const { getByText } = render(
+      <SpotDetailContent {...defaultProps} publicStamps={mockPublicStamps} />
+    );
+    expect(getByText('ユーザーA')).toBeTruthy();
+    expect(getByText('ユーザーB')).toBeTruthy();
+  });
+
+  it('画像タップでモーダルが開くこと', () => {
+    const { getByTestId } = render(
+      <SpotDetailContent {...defaultProps} publicStamps={mockPublicStamps} />
+    );
+    fireEvent.press(getByTestId('public-stamp-image-ps-1'));
+    expect(getByTestId('preview-image')).toBeTruthy();
+  });
+});

--- a/src/hooks/__tests__/useDefaultPublicSetting.test.ts
+++ b/src/hooks/__tests__/useDefaultPublicSetting.test.ts
@@ -1,0 +1,103 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useDefaultPublicSetting } from '@hooks/useDefaultPublicSetting';
+
+const mockFetchProfile = jest.fn();
+const mockUpdateDefaultPublicSetting = jest.fn();
+const mockUseAuth = jest.fn();
+
+jest.mock('@services/profiles', () => ({
+  fetchProfile: (...args: unknown[]) => mockFetchProfile(...args),
+  updateDefaultPublicSetting: (...args: unknown[]) => mockUpdateDefaultPublicSetting(...args),
+}));
+
+jest.mock('@hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+describe('useDefaultPublicSetting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ user: null });
+    mockUpdateDefaultPublicSetting.mockResolvedValue(undefined);
+  });
+
+  it('fetches default_stamp_public from profile when logged in', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'user-1' } });
+    mockFetchProfile.mockResolvedValue({ default_stamp_public: true });
+
+    const { result } = renderHook(() => useDefaultPublicSetting());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.defaultPublic).toBe(true);
+    expect(mockFetchProfile).toHaveBeenCalledWith('user-1');
+  });
+
+  it('returns defaultPublic false when not logged in', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+
+    const { result } = renderHook(() => useDefaultPublicSetting());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.defaultPublic).toBe(false);
+    expect(mockFetchProfile).not.toHaveBeenCalled();
+  });
+
+  it('updateDefaultPublic calls updateDefaultPublicSetting and updates local state', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'user-1' } });
+    mockFetchProfile.mockResolvedValue({ default_stamp_public: false });
+
+    const { result } = renderHook(() => useDefaultPublicSetting());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.defaultPublic).toBe(false);
+
+    await act(async () => {
+      await result.current.updateDefaultPublic(true);
+    });
+
+    expect(mockUpdateDefaultPublicSetting).toHaveBeenCalledWith('user-1', true);
+    expect(result.current.defaultPublic).toBe(true);
+  });
+
+  it('does not throw on error from fetchProfile', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'user-1' } });
+    mockFetchProfile.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useDefaultPublicSetting());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.defaultPublic).toBe(false);
+  });
+
+  it('does not throw on error from updateDefaultPublicSetting', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'user-1' } });
+    mockFetchProfile.mockResolvedValue({ default_stamp_public: false });
+    mockUpdateDefaultPublicSetting.mockRejectedValue(new Error('Update failed'));
+
+    const { result } = renderHook(() => useDefaultPublicSetting());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Should not throw
+    await act(async () => {
+      await result.current.updateDefaultPublic(true);
+    });
+
+    // State should not change on error
+    expect(result.current.defaultPublic).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useGalleryStamps.test.ts
+++ b/src/hooks/__tests__/useGalleryStamps.test.ts
@@ -32,6 +32,7 @@ const makeStampWithSpot = (overrides: Partial<StampWithSpot> = {}): StampWithSpo
   visited_at: '2024-06-01',
   image_path: 'img/1.jpg',
   memo: null,
+  is_public: false,
   created_at: '2024-06-01',
   updated_at: '2024-06-01',
   spots: { name: '伊勢神宮', type: 'shrine' },

--- a/src/hooks/__tests__/useRecordForm.test.ts
+++ b/src/hooks/__tests__/useRecordForm.test.ts
@@ -6,6 +6,7 @@ const mockFetchSpotById = jest.fn();
 const mockUploadStampImage = jest.fn();
 const mockCreateStamp = jest.fn();
 const mockUseAuth = jest.fn();
+const mockFetchProfile = jest.fn();
 
 jest.mock('@services/spots', () => ({
   fetchSpotById: (...args: unknown[]) => mockFetchSpotById(...args),
@@ -18,6 +19,10 @@ jest.mock('@services/stamps', () => ({
 
 jest.mock('@hooks/useAuth', () => ({
   useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('@services/profiles', () => ({
+  fetchProfile: (...args: unknown[]) => mockFetchProfile(...args),
 }));
 
 const fakeSpot: Spot = {
@@ -42,6 +47,7 @@ const fakeStamp: Stamp = {
   visited_at: '2024-06-01T00:00:00.000Z',
   image_path: 'user-1/12345.jpg',
   memo: '',
+  is_public: false,
   created_at: '2024-06-01T00:00:00Z',
   updated_at: '2024-06-01T00:00:00Z',
 };
@@ -50,6 +56,7 @@ describe('useRecordForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseAuth.mockReturnValue({ user: { id: 'user-1' } });
+    mockFetchProfile.mockResolvedValue({ default_stamp_public: false });
   });
 
   it('has correct initial state', () => {
@@ -172,6 +179,7 @@ describe('useRecordForm', () => {
       imagePath: 'user-1/12345.jpg',
       visitedAt: expect.any(String),
       memo: '',
+      isPublic: false,
     });
     expect(result.current.isSubmitting).toBe(false);
   });
@@ -230,5 +238,80 @@ describe('useRecordForm', () => {
     expect(result.current.spotError).toBeNull();
     expect(result.current.imageError).toBeNull();
     expect(result.current.submitError).toBeNull();
+  });
+
+  it('isPublic defaults to false', () => {
+    const { result } = renderHook(() => useRecordForm());
+
+    expect(result.current.isPublic).toBe(false);
+  });
+
+  it('setIsPublic changes isPublic value', () => {
+    const { result } = renderHook(() => useRecordForm());
+
+    act(() => {
+      result.current.setIsPublic(true);
+    });
+
+    expect(result.current.isPublic).toBe(true);
+  });
+
+  it('submit passes isPublic to createStamp', async () => {
+    mockUploadStampImage.mockResolvedValue('user-1/12345.jpg');
+    mockCreateStamp.mockResolvedValue(fakeStamp);
+
+    const { result } = renderHook(() => useRecordForm());
+
+    act(() => {
+      result.current.selectSpot(fakeSpot);
+      result.current.setImageUri('file:///photo.jpg');
+      result.current.setIsPublic(true);
+    });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(mockCreateStamp).toHaveBeenCalledWith({
+      userId: 'user-1',
+      spotId: 'spot-1',
+      imagePath: 'user-1/12345.jpg',
+      visitedAt: expect.any(String),
+      memo: '',
+      isPublic: true,
+    });
+  });
+
+  it('isPublic initializes to true when profile default_stamp_public is true', async () => {
+    mockFetchProfile.mockResolvedValue({ default_stamp_public: true });
+
+    const { result } = renderHook(() => useRecordForm());
+
+    await waitFor(() => {
+      expect(result.current.isPublic).toBe(true);
+    });
+
+    expect(mockFetchProfile).toHaveBeenCalledWith('user-1');
+  });
+
+  it('reset restores isPublic to default value', async () => {
+    mockFetchProfile.mockResolvedValue({ default_stamp_public: true });
+
+    const { result } = renderHook(() => useRecordForm());
+
+    await waitFor(() => {
+      expect(result.current.isPublic).toBe(true);
+    });
+
+    act(() => {
+      result.current.setIsPublic(false);
+    });
+    expect(result.current.isPublic).toBe(false);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.isPublic).toBe(true);
   });
 });

--- a/src/hooks/__tests__/useSpotStamps.test.ts
+++ b/src/hooks/__tests__/useSpotStamps.test.ts
@@ -1,11 +1,13 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { useSpotStamps } from '@hooks/useSpotStamps';
-import type { Stamp } from '@/types/supabase';
+import type { Stamp, PublicStampWithUser } from '@/types/supabase';
 
 const mockFetchStampsBySpotId = jest.fn();
+const mockFetchPublicStampsBySpotId = jest.fn();
 
 jest.mock('@services/stamps', () => ({
   fetchStampsBySpotId: (...args: unknown[]) => mockFetchStampsBySpotId(...args),
+  fetchPublicStampsBySpotId: (...args: unknown[]) => mockFetchPublicStampsBySpotId(...args),
 }));
 
 let mockIsAuthenticated = false;
@@ -24,15 +26,32 @@ const makeStamp = (overrides: Partial<Stamp> = {}): Stamp => ({
   visited_at: '2024-06-01',
   image_path: 'img/1.jpg',
   memo: null,
+  is_public: false,
   created_at: '2024-06-01',
   updated_at: '2024-06-01',
   ...overrides,
 });
 
 describe('useSpotStamps', () => {
+  const makePublicStamp = (overrides: Partial<PublicStampWithUser> = {}): PublicStampWithUser => ({
+    id: 'public-stamp-1',
+    user_id: 'other-user',
+    spot_id: 'spot-1',
+    goshuincho_id: null,
+    visited_at: '2024-07-01',
+    image_path: 'img/public.jpg',
+    memo: null,
+    is_public: true,
+    created_at: '2024-07-01',
+    updated_at: '2024-07-01',
+    profiles: { display_name: 'Other User', avatar_url: null },
+    ...overrides,
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsAuthenticated = false;
+    mockFetchPublicStampsBySpotId.mockResolvedValue([]);
   });
 
   it('returns empty result when not authenticated', async () => {
@@ -97,5 +116,51 @@ describe('useSpotStamps', () => {
     expect(result.current.stamps).toEqual([]);
     expect(result.current.visitCount).toBe(0);
     expect(result.current.latestVisitDate).toBeNull();
+  });
+
+  it('returns publicStamps when authenticated', async () => {
+    mockIsAuthenticated = true;
+    mockFetchStampsBySpotId.mockResolvedValue([]);
+    const publicStamps = [makePublicStamp()];
+    mockFetchPublicStampsBySpotId.mockResolvedValue(publicStamps);
+
+    const { result } = renderHook(() => useSpotStamps('spot-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.publicStamps).toEqual(publicStamps);
+    expect(mockFetchPublicStampsBySpotId).toHaveBeenCalledWith('spot-1');
+  });
+
+  it('returns publicStamps even when not authenticated', async () => {
+    mockIsAuthenticated = false;
+    const publicStamps = [makePublicStamp()];
+    mockFetchPublicStampsBySpotId.mockResolvedValue(publicStamps);
+
+    const { result } = renderHook(() => useSpotStamps('spot-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.stamps).toEqual([]);
+    expect(result.current.publicStamps).toEqual(publicStamps);
+    expect(mockFetchPublicStampsBySpotId).toHaveBeenCalledWith('spot-1');
+  });
+
+  it('returns empty publicStamps on fetch error', async () => {
+    mockIsAuthenticated = true;
+    mockFetchStampsBySpotId.mockResolvedValue([]);
+    mockFetchPublicStampsBySpotId.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useSpotStamps('spot-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.publicStamps).toEqual([]);
   });
 });

--- a/src/hooks/__tests__/useStampDetail.test.ts
+++ b/src/hooks/__tests__/useStampDetail.test.ts
@@ -20,6 +20,7 @@ const fakeStamp: StampWithSpot = {
   visited_at: '2024-06-01',
   image_path: 'img/1.jpg',
   memo: 'テストメモ',
+  is_public: false,
   created_at: '2024-06-01T00:00:00Z',
   updated_at: '2024-06-01T00:00:00Z',
   spots: { name: '伊勢神宮', type: 'shrine' },

--- a/src/hooks/useDefaultPublicSetting.ts
+++ b/src/hooks/useDefaultPublicSetting.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '@hooks/useAuth';
+import { fetchProfile, updateDefaultPublicSetting } from '@services/profiles';
+
+interface UseDefaultPublicSettingReturn {
+  defaultPublic: boolean;
+  isLoading: boolean;
+  updateDefaultPublic: (value: boolean) => Promise<void>;
+}
+
+export function useDefaultPublicSetting(): UseDefaultPublicSettingReturn {
+  const { user } = useAuth();
+  const [defaultPublic, setDefaultPublic] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user) {
+      setDefaultPublic(false);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const profile = await fetchProfile(user.id);
+        if (!cancelled && profile) {
+          setDefaultPublic(profile.default_stamp_public);
+        }
+      } catch {
+        // エラー時はデフォルト値(false)のまま
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const updateDefaultPublic = useCallback(
+    async (value: boolean): Promise<void> => {
+      if (!user) return;
+
+      try {
+        await updateDefaultPublicSetting(user.id, value);
+        setDefaultPublic(value);
+      } catch {
+        // エラー時は状態を変更しない
+      }
+    },
+    [user]
+  );
+
+  return {
+    defaultPublic,
+    isLoading,
+    updateDefaultPublic,
+  };
+}

--- a/src/hooks/useRecordForm.ts
+++ b/src/hooks/useRecordForm.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import type { Spot, Stamp } from '@/types/supabase';
 import { fetchSpotById } from '@services/spots';
 import { uploadStampImage, createStamp } from '@services/stamps';
+import { fetchProfile } from '@services/profiles';
 import { useAuth } from '@hooks/useAuth';
 
 interface UseRecordFormParams {
@@ -13,6 +14,7 @@ interface UseRecordFormReturn {
   imageUri: string | null;
   visitedAt: Date;
   memo: string;
+  isPublic: boolean;
   spotError: string | null;
   imageError: string | null;
   isSubmitting: boolean;
@@ -21,6 +23,7 @@ interface UseRecordFormReturn {
   setImageUri: (uri: string) => void;
   setVisitedAt: (date: Date) => void;
   setMemo: (text: string) => void;
+  setIsPublic: (value: boolean) => void;
   validate: () => boolean;
   submit: () => Promise<{ success: boolean; stamp?: Stamp }>;
   reset: () => void;
@@ -35,6 +38,8 @@ export function useRecordForm(params?: UseRecordFormParams): UseRecordFormReturn
   const [memo, setMemo] = useState('');
   const [spotError, setSpotError] = useState<string | null>(null);
   const [imageError, setImageError] = useState<string | null>(null);
+  const [isPublic, setIsPublic] = useState(false);
+  const [defaultPublic, setDefaultPublic] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
@@ -47,6 +52,17 @@ export function useRecordForm(params?: UseRecordFormParams): UseRecordFormReturn
       });
     }
   }, [params?.initialSpotId]);
+
+  useEffect(() => {
+    if (user) {
+      fetchProfile(user.id).then(profile => {
+        if (profile) {
+          setIsPublic(profile.default_stamp_public);
+          setDefaultPublic(profile.default_stamp_public);
+        }
+      });
+    }
+  }, [user]);
 
   const selectSpot = useCallback((spot: Spot) => {
     setSelectedSpot(spot);
@@ -95,6 +111,7 @@ export function useRecordForm(params?: UseRecordFormParams): UseRecordFormReturn
         imagePath,
         visitedAt: visitedAt.toISOString(),
         memo,
+        isPublic: isPublic,
       });
 
       return { success: true, stamp };
@@ -105,24 +122,26 @@ export function useRecordForm(params?: UseRecordFormParams): UseRecordFormReturn
     } finally {
       setIsSubmitting(false);
     }
-  }, [validate, user, imageUri, selectedSpot, visitedAt, memo]);
+  }, [validate, user, imageUri, selectedSpot, visitedAt, memo, isPublic]);
 
   const reset = useCallback(() => {
     setSelectedSpot(null);
     setImageUriState(null);
     setVisitedAt(new Date());
     setMemo('');
+    setIsPublic(defaultPublic);
     setSpotError(null);
     setImageError(null);
     setSubmitError(null);
     setIsSubmitting(false);
-  }, []);
+  }, [defaultPublic]);
 
   return {
     selectedSpot,
     imageUri,
     visitedAt,
     memo,
+    isPublic,
     spotError,
     imageError,
     isSubmitting,
@@ -131,6 +150,7 @@ export function useRecordForm(params?: UseRecordFormParams): UseRecordFormReturn
     setImageUri,
     setVisitedAt,
     setMemo,
+    setIsPublic,
     validate,
     submit,
     reset,

--- a/src/hooks/useSpotStamps.ts
+++ b/src/hooks/useSpotStamps.ts
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@hooks/useAuth';
-import { fetchStampsBySpotId } from '@services/stamps';
-import type { Stamp } from '@/types/supabase';
+import { fetchStampsBySpotId, fetchPublicStampsBySpotId } from '@services/stamps';
+import type { Stamp, PublicStampWithUser } from '@/types/supabase';
 
 interface UseSpotStampsReturn {
   stamps: Stamp[];
+  publicStamps: PublicStampWithUser[];
   visitCount: number;
   latestVisitDate: string | null;
   isLoading: boolean;
@@ -13,11 +14,13 @@ interface UseSpotStampsReturn {
 export function useSpotStamps(spotId: string): UseSpotStampsReturn {
   const { isAuthenticated } = useAuth();
   const [stamps, setStamps] = useState<Stamp[]>([]);
+  const [publicStamps, setPublicStamps] = useState<PublicStampWithUser[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (!spotId) {
       setStamps([]);
+      setPublicStamps([]);
       setIsLoading(false);
       return;
     }
@@ -25,14 +28,36 @@ export function useSpotStamps(spotId: string): UseSpotStampsReturn {
     let cancelled = false;
 
     (async () => {
-      try {
-        const data = await fetchStampsBySpotId(spotId);
-        if (!cancelled) setStamps(data);
-      } catch {
-        if (!cancelled) setStamps([]);
-      } finally {
-        if (!cancelled) setIsLoading(false);
+      const promises: Promise<void>[] = [];
+
+      // 自分のスタンプ取得（ログイン時のみ）
+      if (isAuthenticated) {
+        promises.push(
+          fetchStampsBySpotId(spotId)
+            .then(data => {
+              if (!cancelled) setStamps(data);
+            })
+            .catch(() => {
+              if (!cancelled) setStamps([]);
+            })
+        );
+      } else {
+        setStamps([]);
       }
+
+      // 公開スタンプ取得（ログイン状態に関わらず）
+      promises.push(
+        fetchPublicStampsBySpotId(spotId)
+          .then(data => {
+            if (!cancelled) setPublicStamps(data);
+          })
+          .catch(() => {
+            if (!cancelled) setPublicStamps([]);
+          })
+      );
+
+      await Promise.all(promises);
+      if (!cancelled) setIsLoading(false);
     })();
 
     return () => {
@@ -42,6 +67,7 @@ export function useSpotStamps(spotId: string): UseSpotStampsReturn {
 
   return {
     stamps,
+    publicStamps,
     visitCount: stamps.length,
     latestVisitDate: stamps[0]?.visited_at ?? null,
     isLoading,

--- a/src/navigation/__tests__/RootNavigator.test.tsx
+++ b/src/navigation/__tests__/RootNavigator.test.tsx
@@ -105,9 +105,18 @@ jest.mock('@hooks/useSpotDetail', () => ({
 jest.mock('@hooks/useSpotStamps', () => ({
   useSpotStamps: () => ({
     stamps: [],
+    publicStamps: [],
     visitCount: 0,
     latestVisitDate: null,
     isLoading: false,
+  }),
+}));
+
+jest.mock('@hooks/useDefaultPublicSetting', () => ({
+  useDefaultPublicSetting: () => ({
+    defaultPublic: false,
+    isLoading: false,
+    updateDefaultPublic: jest.fn(),
   }),
 }));
 

--- a/src/navigation/__tests__/TabNavigator.test.tsx
+++ b/src/navigation/__tests__/TabNavigator.test.tsx
@@ -98,9 +98,18 @@ jest.mock('@hooks/useSpotDetail', () => ({
 jest.mock('@hooks/useSpotStamps', () => ({
   useSpotStamps: () => ({
     stamps: [],
+    publicStamps: [],
     visitCount: 0,
     latestVisitDate: null,
     isLoading: false,
+  }),
+}));
+
+jest.mock('@hooks/useDefaultPublicSetting', () => ({
+  useDefaultPublicSetting: () => ({
+    defaultPublic: false,
+    isLoading: false,
+    updateDefaultPublic: jest.fn(),
   }),
 }));
 

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react';
 import {
   StyleSheet,
+  Switch,
   Text,
   View,
   ScrollView,
@@ -172,6 +173,24 @@ export function RecordScreen({ navigation, route }: Props) {
             />
           </View>
 
+          <View style={styles.publicToggleSection}>
+            <View style={styles.publicToggleRow}>
+              <MaterialIcons
+                name={form.isPublic ? 'public' : 'lock'}
+                size={20}
+                color={form.isPublic ? colors.primary[500] : colors.gray[500]}
+              />
+              <Text style={styles.publicToggleLabel}>この御朱印を公開する</Text>
+              <Switch
+                value={form.isPublic}
+                onValueChange={form.setIsPublic}
+                trackColor={{ false: colors.gray[300], true: colors.primary[200] }}
+                thumbColor={form.isPublic ? colors.primary[500] : colors.gray[100]}
+                testID="public-toggle"
+              />
+            </View>
+          </View>
+
           {form.submitError && (
             <Text style={styles.submitError} testID="submit-error">
               {form.submitError}
@@ -268,6 +287,24 @@ const styles = StyleSheet.create({
     backgroundColor: colors.white,
     textAlignVertical: 'top',
     color: colors.gray[800],
+  },
+  publicToggleSection: {
+    marginTop: spacing.lg,
+  },
+  publicToggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    padding: spacing.lg,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.white,
+  },
+  publicToggleLabel: {
+    ...typography.body,
+    color: colors.gray[800],
+    flex: 1,
   },
   submitError: {
     ...typography.bodySmall,

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,9 +1,10 @@
 import { MaterialIcons } from '@expo/vector-icons';
-import { Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Card } from '@components/common/Card';
 import { useAuth } from '@hooks/useAuth';
+import { useDefaultPublicSetting } from '@hooks/useDefaultPublicSetting';
 import { colors } from '@theme/colors';
 import { borderRadius, spacing } from '@theme/spacing';
 import { typography } from '@theme/typography';
@@ -13,6 +14,7 @@ type Props = MainTabScreenProps<'Settings'>;
 
 export function SettingsScreen({ navigation }: Props) {
   const { user, isAuthenticated, signOut } = useAuth();
+  const { defaultPublic, updateDefaultPublic } = useDefaultPublicSetting();
 
   const displayName = isAuthenticated
     ? (user?.user_metadata?.full_name as string) || 'ユーザー'
@@ -67,6 +69,30 @@ export function SettingsScreen({ navigation }: Props) {
             </TouchableOpacity>
           )}
         </Card>
+
+        {/* Public Settings Section - only for authenticated users */}
+        {isAuthenticated && (
+          <>
+            <Text style={styles.sectionTitle}>公開設定</Text>
+            <Card style={styles.sectionCard}>
+              <View style={styles.publicRow}>
+                <View style={styles.publicLabelContainer}>
+                  <Text style={styles.rowLabel}>御朱印のデフォルト公開設定</Text>
+                  <Text style={styles.publicDescription}>
+                    新しく記録する御朱印を自動的に公開します
+                  </Text>
+                </View>
+                <Switch
+                  value={defaultPublic}
+                  onValueChange={updateDefaultPublic}
+                  trackColor={{ false: colors.gray[300], true: colors.primary[200] }}
+                  thumbColor={defaultPublic ? colors.primary[500] : colors.gray[100]}
+                  testID="default-public-toggle"
+                />
+              </View>
+            </Card>
+          </>
+        )}
 
         {/* Plan Section */}
         <Text style={styles.sectionTitle}>プラン</Text>
@@ -159,6 +185,20 @@ const styles = StyleSheet.create({
     ...typography.body,
     color: colors.primary[500],
     flex: 1,
+  },
+  publicRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    gap: spacing.md,
+  },
+  publicLabelContainer: {
+    flex: 1,
+  },
+  publicDescription: {
+    ...typography.caption,
+    color: colors.gray[500],
+    marginTop: spacing.xs,
   },
   planRow: {
     paddingVertical: spacing.md,

--- a/src/screens/__tests__/GalleryScreen.test.tsx
+++ b/src/screens/__tests__/GalleryScreen.test.tsx
@@ -44,6 +44,7 @@ const makeStamp = (overrides: Partial<StampWithSpot> = {}): StampWithSpot => ({
   visited_at: '2024-01-15',
   image_path: 'user-1/stamp-1.jpg',
   memo: null,
+  is_public: false,
   created_at: '2024-01-15T00:00:00Z',
   updated_at: '2024-01-15T00:00:00Z',
   spots: { name: '明治神宮', type: 'shrine' },

--- a/src/screens/__tests__/RecordScreen.test.tsx
+++ b/src/screens/__tests__/RecordScreen.test.tsx
@@ -36,11 +36,14 @@ const fakeSpot: Spot = {
   updated_at: '2024-01-01',
 };
 
+const mockSetIsPublic = jest.fn();
+
 let mockFormState = {
   selectedSpot: null as Spot | null,
   imageUri: null as string | null,
   visitedAt: new Date('2024-06-01'),
   memo: '',
+  isPublic: false,
   spotError: null as string | null,
   imageError: null as string | null,
   isSubmitting: false,
@@ -49,6 +52,7 @@ let mockFormState = {
   setImageUri: mockSetImageUri,
   setVisitedAt: mockSetVisitedAt,
   setMemo: mockSetMemo,
+  setIsPublic: mockSetIsPublic,
   validate: mockValidate,
   submit: mockSubmit,
   reset: mockReset,
@@ -130,6 +134,7 @@ describe('RecordScreen', () => {
       imageUri: null,
       visitedAt: new Date('2024-06-01'),
       memo: '',
+      isPublic: false,
       spotError: null,
       imageError: null,
       isSubmitting: false,
@@ -138,6 +143,7 @@ describe('RecordScreen', () => {
       setImageUri: mockSetImageUri,
       setVisitedAt: mockSetVisitedAt,
       setMemo: mockSetMemo,
+      setIsPublic: mockSetIsPublic,
       validate: mockValidate,
       submit: mockSubmit,
       reset: mockReset,
@@ -192,6 +198,7 @@ describe('RecordScreen', () => {
       visited_at: '2024-06-01T00:00:00.000Z',
       image_path: 'user-1/12345.jpg',
       memo: '',
+      is_public: false,
       created_at: '2024-06-01T00:00:00Z',
       updated_at: '2024-06-01T00:00:00Z',
     };
@@ -224,6 +231,7 @@ describe('RecordScreen', () => {
       visited_at: '2024-06-01T00:00:00.000Z',
       image_path: 'user-1/12345.jpg',
       memo: '',
+      is_public: false,
       created_at: '2024-06-01T00:00:00Z',
       updated_at: '2024-06-01T00:00:00Z',
     };
@@ -257,6 +265,7 @@ describe('RecordScreen', () => {
       visited_at: '2024-06-01T00:00:00.000Z',
       image_path: 'user-1/12345.jpg',
       memo: '',
+      is_public: false,
       created_at: '2024-06-01T00:00:00Z',
       updated_at: '2024-06-01T00:00:00Z',
     };
@@ -290,6 +299,7 @@ describe('RecordScreen', () => {
       visited_at: '2024-06-01T00:00:00.000Z',
       image_path: 'user-1/12345.jpg',
       memo: '',
+      is_public: false,
       created_at: '2024-06-01T00:00:00Z',
       updated_at: '2024-06-01T00:00:00Z',
     };
@@ -314,6 +324,20 @@ describe('RecordScreen', () => {
         })
       );
     });
+  });
+
+  it('公開トグルが表示されること', () => {
+    const { getByText, getByTestId } = render(
+      <RecordScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    expect(getByText('この御朱印を公開する')).toBeTruthy();
+    expect(getByTestId('public-toggle')).toBeTruthy();
+  });
+
+  it('トグル操作で setIsPublic が呼ばれること', () => {
+    const { getByTestId } = render(<RecordScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent(getByTestId('public-toggle'), 'valueChange', true);
+    expect(mockSetIsPublic).toHaveBeenCalledWith(true);
   });
 
   it('shows submit error when submit fails', async () => {

--- a/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/src/screens/__tests__/SettingsScreen.test.tsx
@@ -17,6 +17,15 @@ jest.mock('react-native-safe-area-context', () => {
 
 const mockSignOut = jest.fn();
 const mockSignInWithGoogle = jest.fn();
+const mockUpdateDefaultPublic = jest.fn();
+
+jest.mock('@hooks/useDefaultPublicSetting', () => ({
+  useDefaultPublicSetting: () => ({
+    defaultPublic: false,
+    isLoading: false,
+    updateDefaultPublic: mockUpdateDefaultPublic,
+  }),
+}));
 
 let mockUseAuthReturn: Record<string, unknown> = {
   user: null,
@@ -155,6 +164,52 @@ describe('SettingsScreen', () => {
       await waitFor(() => {
         expect(Alert.alert).toHaveBeenCalledWith('エラー', 'Failed');
       });
+    });
+  });
+
+  describe('公開設定セクション', () => {
+    it('ログイン時に公開設定セクションが表示されること', () => {
+      mockUseAuthReturn = {
+        ...mockUseAuthReturn,
+        isAuthenticated: true,
+        user: {
+          id: 'user-123',
+          email: 'test@example.com',
+          user_metadata: { full_name: 'テストユーザー' },
+        },
+      };
+
+      const { getByText } = render(
+        <SettingsScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      expect(getByText('公開設定')).toBeTruthy();
+      expect(getByText('御朱印のデフォルト公開設定')).toBeTruthy();
+      expect(getByText('新しく記録する御朱印を自動的に公開します')).toBeTruthy();
+    });
+
+    it('未ログイン時は公開設定セクションが非表示であること', () => {
+      const { queryByText } = render(
+        <SettingsScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      expect(queryByText('公開設定')).toBeNull();
+    });
+
+    it('トグル操作で updateDefaultPublic が呼ばれること', () => {
+      mockUseAuthReturn = {
+        ...mockUseAuthReturn,
+        isAuthenticated: true,
+        user: {
+          id: 'user-123',
+          email: 'test@example.com',
+          user_metadata: { full_name: 'テストユーザー' },
+        },
+      };
+
+      const { getByTestId } = render(
+        <SettingsScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      fireEvent(getByTestId('default-public-toggle'), 'valueChange', true);
+      expect(mockUpdateDefaultPublic).toHaveBeenCalledWith(true);
     });
   });
 

--- a/src/screens/__tests__/SpotDetailScreen.test.tsx
+++ b/src/screens/__tests__/SpotDetailScreen.test.tsx
@@ -78,6 +78,7 @@ const makeStamp = (overrides: Partial<Stamp> = {}): Stamp => ({
   visited_at: '2024-06-01',
   image_path: 'img/1.jpg',
   memo: null,
+  is_public: false,
   created_at: '2024-06-01',
   updated_at: '2024-06-01',
   ...overrides,

--- a/src/screens/__tests__/StampDetailScreen.test.tsx
+++ b/src/screens/__tests__/StampDetailScreen.test.tsx
@@ -46,6 +46,7 @@ const mockStamp: StampWithSpot = {
   visited_at: '2024-01-15',
   image_path: 'user-1/stamp-1.jpg',
   memo: '初めての御朱印。天気が良くて気持ちの良い参拝でした。',
+  is_public: false,
   created_at: '2024-01-15T00:00:00Z',
   updated_at: '2024-01-15T00:00:00Z',
   spots: { name: '明治神宮', type: 'shrine' },

--- a/src/services/__tests__/profiles.test.ts
+++ b/src/services/__tests__/profiles.test.ts
@@ -1,0 +1,77 @@
+import { fetchProfile, updateDefaultPublicSetting } from '@services/profiles';
+
+const mockFrom = jest.fn();
+const mockSelect = jest.fn();
+const mockEq = jest.fn();
+const mockSingle = jest.fn();
+const mockUpdate = jest.fn();
+
+jest.mock('@services/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+describe('fetchProfile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns profile for a given user', async () => {
+    const mockProfile = {
+      id: 'user-1',
+      email: 'test@example.com',
+      display_name: 'Test User',
+      avatar_url: null,
+      default_stamp_public: false,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    };
+
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ single: mockSingle });
+    mockSingle.mockReturnValue({ data: mockProfile, error: null });
+
+    const result = await fetchProfile('user-1');
+    expect(mockFrom).toHaveBeenCalledWith('profiles');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('id', 'user-1');
+    expect(result).toEqual(mockProfile);
+  });
+
+  it('returns null on error', async () => {
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ single: mockSingle });
+    mockSingle.mockReturnValue({ data: null, error: { message: 'not found' } });
+
+    const result = await fetchProfile('user-1');
+    expect(result).toBeNull();
+  });
+});
+
+describe('updateDefaultPublicSetting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates default_stamp_public for a user', async () => {
+    mockFrom.mockReturnValue({ update: mockUpdate });
+    mockUpdate.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ error: null });
+
+    await updateDefaultPublicSetting('user-1', true);
+    expect(mockFrom).toHaveBeenCalledWith('profiles');
+    expect(mockUpdate).toHaveBeenCalledWith({ default_stamp_public: true });
+    expect(mockEq).toHaveBeenCalledWith('id', 'user-1');
+  });
+
+  it('throws on error', async () => {
+    mockFrom.mockReturnValue({ update: mockUpdate });
+    mockUpdate.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ error: { message: 'update failed' } });
+
+    await expect(updateDefaultPublicSetting('user-1', true)).rejects.toThrow('update failed');
+  });
+});

--- a/src/services/__tests__/stamps-create.test.ts
+++ b/src/services/__tests__/stamps-create.test.ts
@@ -1,14 +1,22 @@
-import { uploadStampImage, createStamp } from '@services/stamps';
+import { uploadStampImage, createStamp, fetchPublicStampsBySpotId } from '@services/stamps';
 
 const mockFrom = jest.fn();
 const mockUpload = jest.fn();
 const mockInsert = jest.fn();
 const mockSelect = jest.fn();
 const mockSingle = jest.fn();
+const mockEq = jest.fn();
+const mockNeq = jest.fn();
+const mockOrder = jest.fn();
+const mockLimit = jest.fn();
+const mockGetUser = jest.fn();
 
 jest.mock('@services/supabase', () => ({
   supabase: {
     from: (...args: unknown[]) => mockFrom(...args),
+    auth: {
+      getUser: () => mockGetUser(),
+    },
     storage: {
       from: () => ({
         upload: (...args: unknown[]) => mockUpload(...args),
@@ -57,6 +65,7 @@ describe('createStamp', () => {
       visited_at: '2024-06-01',
       image_path: 'user-1/img.jpg',
       memo: 'Great visit',
+      is_public: false,
       created_at: '2024-06-01T00:00:00Z',
       updated_at: '2024-06-01T00:00:00Z',
     };
@@ -81,6 +90,7 @@ describe('createStamp', () => {
       image_path: 'user-1/img.jpg',
       visited_at: '2024-06-01',
       memo: 'Great visit',
+      is_public: false,
     });
     expect(result).toEqual(mockStamp);
   });
@@ -94,6 +104,7 @@ describe('createStamp', () => {
       visited_at: '2024-06-01',
       image_path: 'user-1/img.jpg',
       memo: null,
+      is_public: false,
       created_at: '2024-06-01T00:00:00Z',
       updated_at: '2024-06-01T00:00:00Z',
     };
@@ -110,7 +121,39 @@ describe('createStamp', () => {
       visitedAt: '2024-06-01',
     });
 
-    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ memo: null }));
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ memo: null, is_public: false })
+    );
+  });
+
+  it('includes is_public: true when isPublic is true', async () => {
+    const mockStamp = {
+      id: 'stamp-3',
+      user_id: 'user-1',
+      spot_id: 'spot-1',
+      goshuincho_id: null,
+      visited_at: '2024-06-01',
+      image_path: 'user-1/img.jpg',
+      memo: null,
+      is_public: true,
+      created_at: '2024-06-01T00:00:00Z',
+      updated_at: '2024-06-01T00:00:00Z',
+    };
+
+    mockFrom.mockReturnValue({ insert: mockInsert });
+    mockInsert.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ single: mockSingle });
+    mockSingle.mockResolvedValue({ data: mockStamp, error: null });
+
+    await createStamp({
+      userId: 'user-1',
+      spotId: 'spot-1',
+      imagePath: 'user-1/img.jpg',
+      visitedAt: '2024-06-01',
+      isPublic: true,
+    });
+
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ is_public: true }));
   });
 
   it('throws error when DB insert fails', async () => {
@@ -127,5 +170,91 @@ describe('createStamp', () => {
         visitedAt: '2024-06-01',
       })
     ).rejects.toThrow('DB error');
+  });
+});
+
+describe('fetchPublicStampsBySpotId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns public stamps for a spot excluding own stamps', async () => {
+    const mockPublicStamps = [
+      {
+        id: 'stamp-10',
+        user_id: 'other-user',
+        spot_id: 'spot-1',
+        visited_at: '2024-07-01',
+        image_path: 'other/img.jpg',
+        memo: null,
+        is_public: true,
+        goshuincho_id: null,
+        created_at: '2024-07-01T00:00:00Z',
+        updated_at: '2024-07-01T00:00:00Z',
+        profiles: { display_name: 'OtherUser', avatar_url: null },
+      },
+    ];
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'my-user-id' } } });
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    // first eq: spot_id
+    mockEq.mockReturnValueOnce({ eq: mockEq });
+    // second eq: is_public
+    mockEq.mockReturnValueOnce({ order: mockOrder });
+    mockOrder.mockReturnValue({ limit: mockLimit });
+    mockLimit.mockReturnValue({ neq: mockNeq });
+    mockNeq.mockReturnValue({ data: mockPublicStamps, error: null });
+
+    const result = await fetchPublicStampsBySpotId('spot-1');
+
+    expect(mockFrom).toHaveBeenCalledWith('stamps');
+    expect(mockSelect).toHaveBeenCalledWith(
+      '*, profiles!stamps_user_id_profiles_fkey(display_name, avatar_url)'
+    );
+    expect(result).toEqual(mockPublicStamps);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns public stamps without neq when user is not logged in', async () => {
+    const mockPublicStamps = [
+      {
+        id: 'stamp-10',
+        user_id: 'other-user',
+        spot_id: 'spot-1',
+        visited_at: '2024-07-01',
+        image_path: 'other/img.jpg',
+        memo: null,
+        is_public: true,
+        goshuincho_id: null,
+        created_at: '2024-07-01T00:00:00Z',
+        updated_at: '2024-07-01T00:00:00Z',
+        profiles: { display_name: 'OtherUser', avatar_url: null },
+      },
+    ];
+
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValueOnce({ eq: mockEq });
+    mockEq.mockReturnValueOnce({ order: mockOrder });
+    mockOrder.mockReturnValue({ limit: mockLimit });
+    mockLimit.mockReturnValue({ data: mockPublicStamps, error: null });
+
+    const result = await fetchPublicStampsBySpotId('spot-1');
+    expect(result).toEqual(mockPublicStamps);
+  });
+
+  it('returns empty array on error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValueOnce({ eq: mockEq });
+    mockEq.mockReturnValueOnce({ order: mockOrder });
+    mockOrder.mockReturnValue({ limit: mockLimit });
+    mockLimit.mockReturnValue({ data: null, error: { message: 'query error' } });
+
+    const result = await fetchPublicStampsBySpotId('spot-1');
+    expect(result).toEqual([]);
   });
 });

--- a/src/services/__tests__/stamps.test.ts
+++ b/src/services/__tests__/stamps.test.ts
@@ -207,6 +207,28 @@ describe('stamps service', () => {
       expect(result).toEqual(mockStamp);
     });
 
+    it('updates is_public field', async () => {
+      const mockStamp = {
+        id: 'stamp-1',
+        user_id: 'user-1',
+        spot_id: 'spot-1',
+        visited_at: '2024-06-01',
+        image_path: 'img/1.jpg',
+        memo: null,
+        is_public: true,
+        spots: { name: '伊勢神宮', type: 'shrine' },
+      };
+      const mockSingle = jest.fn().mockReturnValue({ data: mockStamp, error: null });
+      mockFrom.mockReturnValue({ update: mockUpdate });
+      mockUpdate.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ single: mockSingle });
+
+      const result = await updateStamp('stamp-1', { is_public: true });
+      expect(mockUpdate).toHaveBeenCalledWith({ is_public: true });
+      expect(result).toEqual(mockStamp);
+    });
+
     it('throws on error', async () => {
       const mockSingle = jest
         .fn()

--- a/src/services/profiles.ts
+++ b/src/services/profiles.ts
@@ -1,0 +1,19 @@
+import { supabase } from '@services/supabase';
+import type { Profile } from '@/types/supabase';
+
+export async function fetchProfile(userId: string): Promise<Profile | null> {
+  const { data, error } = await supabase.from('profiles').select('*').eq('id', userId).single();
+  if (error) {
+    console.warn('fetchProfile error:', error.message);
+    return null;
+  }
+  return data as Profile;
+}
+
+export async function updateDefaultPublicSetting(userId: string, value: boolean): Promise<void> {
+  const { error } = await supabase
+    .from('profiles')
+    .update({ default_stamp_public: value })
+    .eq('id', userId);
+  if (error) throw new Error(error.message);
+}

--- a/src/services/stamps.ts
+++ b/src/services/stamps.ts
@@ -1,5 +1,5 @@
 import { supabase } from '@services/supabase';
-import type { Stamp, StampWithSpot } from '@/types/supabase';
+import type { Stamp, StampWithSpot, PublicStampWithUser } from '@/types/supabase';
 
 export async function fetchVisitedSpotIds(): Promise<Set<string>> {
   const { data, error } = await supabase.from('stamps').select('spot_id');
@@ -56,6 +56,7 @@ export async function createStamp(params: {
   imagePath: string;
   visitedAt: string;
   memo?: string;
+  isPublic?: boolean;
 }): Promise<Stamp> {
   const { data, error } = await supabase
     .from('stamps')
@@ -65,6 +66,7 @@ export async function createStamp(params: {
       image_path: params.imagePath,
       visited_at: params.visitedAt,
       memo: params.memo ?? null,
+      is_public: params.isPublic ?? false,
     })
     .select()
     .single();
@@ -110,7 +112,7 @@ export function getStampImageUrl(imagePath: string): string {
 
 export async function updateStamp(
   stampId: string,
-  params: { visited_at?: string; memo?: string | null }
+  params: { visited_at?: string; memo?: string | null; is_public?: boolean }
 ): Promise<StampWithSpot> {
   const { data, error } = await supabase
     .from('stamps')
@@ -120,6 +122,31 @@ export async function updateStamp(
     .single();
   if (error) throw new Error(error.message);
   return data as StampWithSpot;
+}
+
+export async function fetchPublicStampsBySpotId(spotId: string): Promise<PublicStampWithUser[]> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let query = supabase
+    .from('stamps')
+    .select('*, profiles!stamps_user_id_profiles_fkey(display_name, avatar_url)')
+    .eq('spot_id', spotId)
+    .eq('is_public', true)
+    .order('visited_at', { ascending: false })
+    .limit(20);
+
+  if (user) {
+    query = query.neq('user_id', user.id);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    console.warn('fetchPublicStampsBySpotId error:', error.message);
+    return [];
+  }
+  return data as PublicStampWithUser[];
 }
 
 export async function deleteStampImage(imagePath: string): Promise<void> {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -9,6 +9,7 @@ export interface Profile {
   email: string | null;
   display_name: string | null;
   avatar_url: string | null;
+  default_stamp_public: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -35,6 +36,7 @@ export interface Stamp {
   visited_at: string;
   image_path: string;
   memo: string | null;
+  is_public: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -58,6 +60,13 @@ export interface WishlistWithSpot extends Wishlist {
     name: string;
     type: SpotType;
     address: string | null;
+  };
+}
+
+export interface PublicStampWithUser extends Stamp {
+  profiles: {
+    display_name: string | null;
+    avatar_url: string | null;
   };
 }
 

--- a/supabase/migrations/20260401000000_add_public_stamps.sql
+++ b/supabase/migrations/20260401000000_add_public_stamps.sql
@@ -1,0 +1,13 @@
+ALTER TABLE public.stamps ADD COLUMN is_public BOOLEAN NOT NULL DEFAULT false;
+CREATE INDEX idx_stamps_public_spot ON public.stamps (spot_id) WHERE is_public = true;
+
+CREATE POLICY "Anyone can view public stamps"
+  ON public.stamps FOR SELECT
+  USING (is_public = true);
+
+ALTER TABLE public.profiles ADD COLUMN default_stamp_public BOOLEAN NOT NULL DEFAULT false;
+
+-- stamps.user_id → profiles.id の外部キー（PostgREST の join に必要）
+ALTER TABLE public.stamps
+  ADD CONSTRAINT stamps_user_id_profiles_fkey
+  FOREIGN KEY (user_id) REFERENCES public.profiles(id);


### PR DESCRIPTION
## Summary
- 御朱印の記録を公開/非公開に設定できるトグルスイッチを記録画面に追加
- 設定画面でデフォルトの公開/非公開設定を管理可能に
- スポット詳細ボトムシートに「みんなの御朱印」セクションを追加（他ユーザーの公開御朱印を表示）
- 画像タップで拡大プレビューモーダル表示（ユーザー名・メモ・訪問日付き）
- stamps テーブルに `is_public` カラム、profiles テーブルに `default_stamp_public` カラム追加

## Test plan
- [x] 全テスト通過（61 suites, 542 tests）
- [x] Lint 通過
- [x] 型チェック通過
- [x] Expo Go で記録画面の公開トグル動作確認
- [x] Expo Go で設定画面のデフォルト公開設定動作確認
- [x] Expo Go でスポット詳細ボトムシートの御朱印画像表示確認

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)