### PR TITLE
fix(record): 画像選択時の強制切り抜きを無効化

### DIFF
--- a/src/components/record/PhotoPickerModal.tsx
+++ b/src/components/record/PhotoPickerModal.tsx
@@ -13,8 +13,7 @@ interface PhotoPickerModalProps {
 }
 
 const pickerOptions = {
-  allowsEditing: true,
-  aspect: [3, 4] as [number, number],
+  allowsEditing: false,
   quality: 0.8,
 };
 

--- a/src/components/record/PhotoSection.tsx
+++ b/src/components/record/PhotoSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, Image, TouchableOpacity, StyleSheet } from 'react-native';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
@@ -11,6 +11,14 @@ interface PhotoSectionProps {
 }
 
 export function PhotoSection({ imageUri, onPress, error }: PhotoSectionProps) {
+  const [imageAspect, setImageAspect] = useState<number>(3 / 4);
+
+  useEffect(() => {
+    if (imageUri) {
+      Image.getSize(imageUri, (w, h) => setImageAspect(w / h));
+    }
+  }, [imageUri]);
+
   return (
     <View>
       <TouchableOpacity
@@ -23,13 +31,10 @@ export function PhotoSection({ imageUri, onPress, error }: PhotoSectionProps) {
           <View style={styles.previewContainer}>
             <Image
               source={{ uri: imageUri }}
-              style={styles.preview}
+              style={[styles.preview, { aspectRatio: imageAspect }]}
               resizeMode="cover"
               testID="photo-preview"
             />
-            <View style={styles.changeButton}>
-              <Text style={styles.changeText}>変更</Text>
-            </View>
           </View>
         ) : (
           <View style={styles.placeholder}>
@@ -68,25 +73,12 @@ const styles = StyleSheet.create({
     color: colors.gray[400],
   },
   previewContainer: {
-    position: 'relative',
-    aspectRatio: 3 / 4,
+    alignItems: 'center',
+    backgroundColor: colors.gray[100],
   },
   preview: {
     width: '100%',
-    height: '100%',
-  },
-  changeButton: {
-    position: 'absolute',
-    top: spacing.sm,
-    right: spacing.sm,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    paddingVertical: spacing.xs,
-    paddingHorizontal: spacing.sm,
-    borderRadius: borderRadius.sm,
-  },
-  changeText: {
-    ...typography.label,
-    color: colors.white,
+    maxHeight: 400,
   },
   errorText: {
     ...typography.caption,

--- a/src/components/record/__tests__/PhotoPickerModal.test.tsx
+++ b/src/components/record/__tests__/PhotoPickerModal.test.tsx
@@ -49,8 +49,7 @@ describe('PhotoPickerModal', () => {
 
     await waitFor(() => {
       expect(ImagePicker.launchCameraAsync).toHaveBeenCalledWith({
-        allowsEditing: true,
-        aspect: [3, 4],
+        allowsEditing: false,
         quality: 0.8,
       });
       expect(mockOnImageSelected).toHaveBeenCalledWith('file://camera-photo.jpg');
@@ -75,8 +74,7 @@ describe('PhotoPickerModal', () => {
 
     await waitFor(() => {
       expect(ImagePicker.launchImageLibraryAsync).toHaveBeenCalledWith({
-        allowsEditing: true,
-        aspect: [3, 4],
+        allowsEditing: false,
         quality: 0.8,
       });
       expect(mockOnImageSelected).toHaveBeenCalledWith('file://gallery-photo.jpg');

--- a/src/components/record/__tests__/PhotoSection.test.tsx
+++ b/src/components/record/__tests__/PhotoSection.test.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { Image } from 'react-native';
 import { PhotoSection } from '../PhotoSection';
+
+jest
+  .spyOn(Image, 'getSize')
+  .mockImplementation((_uri: string, success: (width: number, height: number) => void) => {
+    success(300, 400);
+  });
 
 describe('PhotoSection', () => {
   const mockOnPress = jest.fn();
@@ -17,13 +24,12 @@ describe('PhotoSection', () => {
     expect(getByText('写真を追加')).toBeTruthy();
   });
 
-  it('選択済み時に Image コンポーネントと「変更」テキスト表示', () => {
-    const { getByTestId, getByText } = render(
+  it('選択済み時に Image コンポーネント表示', () => {
+    const { getByTestId } = render(
       <PhotoSection imageUri="file://photo.jpg" onPress={mockOnPress} error={null} />
     );
 
     expect(getByTestId('photo-preview')).toBeTruthy();
-    expect(getByText('変更')).toBeTruthy();
   });
 
   it('タップで onPress 呼出', () => {

--- a/src/screens/__tests__/RecordScreen.test.tsx
+++ b/src/screens/__tests__/RecordScreen.test.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Image } from 'react-native';
 import { RecordScreen } from '@screens/RecordScreen';
 import { evaluateNewBadge } from '@services/badges';
 import type { Spot, Stamp } from '@/types/supabase';
+
+jest
+  .spyOn(Image, 'getSize')
+  .mockImplementation((_uri: string, success: (width: number, height: number) => void) => {
+    success(300, 400);
+  });
 
 jest.mock('react-native-safe-area-context', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires


### PR DESCRIPTION
## Summary
- 御朱印記録時の画像選択で強制的に3:4切り抜きされていた問題を修正
- `allowsEditing: false` にし、元画像のアスペクト比をそのまま保存・表示するように変更
- プレビュー表示を `Image.getSize()` で動的にアスペクト比を取得する方式に変更
- プレビュー上の「変更」ボタンを削除しUIを簡素化

## Test plan
- [x] PhotoPickerModal テスト通過
- [x] PhotoSection テスト通過
- [x] RecordScreen テスト通過
- [x] 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)