### PR TITLE
feat(spot-detail): コンパクト表示にスポット情報を追加

### DIFF
--- a/src/components/spot-detail/SpotBottomSheet.tsx
+++ b/src/components/spot-detail/SpotBottomSheet.tsx
@@ -22,7 +22,7 @@ interface SpotBottomSheetProps {
 }
 
 const SCREEN_HEIGHT = Dimensions.get('window').height;
-const COMPACT_HEIGHT = 180;
+const COMPACT_HEIGHT = 240;
 
 type SheetMode = 'hidden' | 'compact' | 'expanded';
 
@@ -172,6 +172,7 @@ export function SpotBottomSheet({
           isVisited={isVisited}
           isWishlisted={isWishlisted}
           onWishlistPress={onWishlistToggle ? handleWishlistPress : undefined}
+          spotInfo={spotInfo ?? undefined}
         />
       )}
 

--- a/src/components/spot-detail/SpotCompactCard.tsx
+++ b/src/components/spot-detail/SpotCompactCard.tsx
@@ -4,7 +4,9 @@ import { MaterialIcons } from '@expo/vector-icons';
 
 import { Badge } from '@components/common/Badge';
 import { WishlistButton } from '@components/animated/WishlistButton';
+import { SpotInfoSection } from '@components/spot-detail/SpotInfoSection';
 import type { Spot } from '@/types/supabase';
+import type { ParsedSpotInfo } from '@hooks/useSpotInfo';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing } from '@theme/spacing';
@@ -14,6 +16,7 @@ interface SpotCompactCardProps {
   isVisited: boolean;
   isWishlisted?: boolean;
   onWishlistPress?: () => void;
+  spotInfo?: ParsedSpotInfo;
 }
 
 export function SpotCompactCard({
@@ -21,6 +24,7 @@ export function SpotCompactCard({
   isVisited,
   isWishlisted,
   onWishlistPress,
+  spotInfo,
 }: SpotCompactCardProps) {
   const badgeType = spot.type === 'shrine' ? 'shrine' : 'temple';
 
@@ -48,6 +52,7 @@ export function SpotCompactCard({
           <WishlistButton isWishlisted={isWishlisted} onPress={onWishlistPress} />
         )}
       </View>
+      {spotInfo && <SpotInfoSection spotInfo={spotInfo} />}
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- ピンタップ時のボトムシートコンパクト表示に駐車場・受付時間・兼務社の情報を表示
- COMPACT_HEIGHTを180px→240pxに拡大して情報セクション分を確保

## Test plan
- [x] `npm test` — 全テスト通過
- [x] `npm run typecheck` — 型チェック通過
- [ ] 実機でピンタップ → コンパクト表示にスポット情報が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)