### PR TITLE
fix(ui): ギャラリータブの文言を「御朱印」に変更

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -38,7 +38,7 @@ export function TabNavigator() {
         name="GalleryTab"
         component={GalleryStack}
         options={{
-          title: 'ギャラリー',
+          title: '御朱印',
           tabBarIcon: ({ color }) => <MaterialIcons name="photo-library" size={24} color={color} />,
         }}
         listeners={() => ({

--- a/src/navigation/__tests__/TabNavigator.test.tsx
+++ b/src/navigation/__tests__/TabNavigator.test.tsx
@@ -178,7 +178,7 @@ describe('TabNavigator', () => {
 
     await waitFor(() => {
       expect(getByText('地図')).toBeTruthy();
-      expect(getByText('ギャラリー')).toBeTruthy();
+      expect(getByText('御朱印')).toBeTruthy();
       expect(getByText('コレクション')).toBeTruthy();
       expect(getByText('設定')).toBeTruthy();
     });
@@ -195,10 +195,10 @@ describe('TabNavigator', () => {
     const { getByText } = renderTabNavigator();
 
     await waitFor(() => {
-      expect(getByText('ギャラリー')).toBeTruthy();
+      expect(getByText('御朱印')).toBeTruthy();
     });
 
-    fireEvent.press(getByText('ギャラリー'));
+    fireEvent.press(getByText('御朱印'));
 
     await waitFor(() => {
       expect(getByText('Login Screen')).toBeTruthy();
@@ -237,10 +237,10 @@ describe('TabNavigator', () => {
     const { getByText, queryByText, getByTestId } = renderTabNavigator();
 
     await waitFor(() => {
-      expect(getByText('ギャラリー')).toBeTruthy();
+      expect(getByText('御朱印')).toBeTruthy();
     });
 
-    fireEvent.press(getByText('ギャラリー'));
+    fireEvent.press(getByText('御朱印'));
 
     await waitFor(() => {
       expect(getByTestId('gallery-list')).toBeTruthy();

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -69,7 +69,7 @@ export function GalleryScreen({ navigation }: Props) {
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.header}>
-        <Text style={styles.headerTitle}>ギャラリー</Text>
+        <Text style={styles.headerTitle}>御朱印</Text>
       </View>
 
       <View style={styles.sortRow}>


### PR DESCRIPTION
## Summary
- タブナビゲーションの「ギャラリー」を「御朱印」に変更
- 画面ヘッダーの「ギャラリー」を「御朱印」に変更
- テストの文言も合わせて更新

## Test plan
- [x] `npm test` — 全テスト通過
- [x] `npm run typecheck` — 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)