### PR TITLE
fix(navigation): 御朱印詳細画面のヘッダー二重表示を修正

### DIFF
--- a/src/navigation/GalleryStack.tsx
+++ b/src/navigation/GalleryStack.tsx
@@ -13,7 +13,7 @@ export function GalleryStack() {
       <Stack.Screen
         name="StampDetail"
         component={StampDetailScreen}
-        options={{ title: '御朱印詳細' }}
+        options={{ headerShown: false }}
       />
     </Stack.Navigator>
   );


### PR DESCRIPTION
## Summary
- GalleryStackのネイティブヘッダーと画面内カスタムヘッダーが重複表示されていた問題を修正
- ネイティブヘッダーを `headerShown: false` に変更し、カスタムヘッダー（戻るボタン+編集/削除ボタン）のみ表示

## Test plan
- [x] `npm run typecheck` — 型チェック通過
- [ ] 御朱印一覧 → 御朱印詳細に遷移してヘッダーが1つだけ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)