### PR TITLE
fix(gallery): 御朱印削除後に一覧画面の表示を即時更新

### DIFF
--- a/src/hooks/useGalleryStamps.ts
+++ b/src/hooks/useGalleryStamps.ts
@@ -13,6 +13,7 @@ interface UseGalleryStampsReturn {
   totalCount: number;
   isLoading: boolean;
   error: string | null;
+  removeStamp: (stampId: string) => void;
 }
 
 export function useGalleryStamps(sortOrder: SortOrder): UseGalleryStampsReturn {
@@ -55,6 +56,10 @@ export function useGalleryStamps(sortOrder: SortOrder): UseGalleryStampsReturn {
     }, [user])
   );
 
+  const removeStamp = useCallback((stampId: string) => {
+    setAllStamps(prev => prev.filter(s => s.id !== stampId));
+  }, []);
+
   const stamps = useMemo(() => {
     const sorted = [...allStamps];
     if (sortOrder === 'spot') {
@@ -69,5 +74,6 @@ export function useGalleryStamps(sortOrder: SortOrder): UseGalleryStampsReturn {
     totalCount: allStamps.length,
     isLoading,
     error,
+    removeStamp,
   };
 }

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -31,7 +31,7 @@ const ITEM_SIZE = (SCREEN_WIDTH - spacing.lg * 2 - ITEM_MARGIN * (NUM_COLUMNS - 
 
 export function GalleryScreen() {
   const [sortOrder, setSortOrder] = useState<SortOrder>('date');
-  const { stamps, totalCount, isLoading } = useGalleryStamps(sortOrder);
+  const { stamps, totalCount, isLoading, removeStamp } = useGalleryStamps(sortOrder);
 
   const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(null);
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -80,12 +80,16 @@ export function GalleryScreen() {
   );
 
   const onConfirmDelete = useCallback(async () => {
+    const stampId = currentStamp?.id;
     const success = await handleDelete();
     if (success) {
       setDeleteModalVisible(false);
       setSelectedImageIndex(null);
+      if (stampId) {
+        removeStamp(stampId);
+      }
     }
-  }, [handleDelete]);
+  }, [handleDelete, currentStamp?.id, removeStamp]);
 
   const formatDate = (dateStr: string) => dateStr.replace(/-/g, '/');
 

--- a/src/screens/__tests__/GalleryScreen.test.tsx
+++ b/src/screens/__tests__/GalleryScreen.test.tsx
@@ -71,6 +71,7 @@ describe('GalleryScreen', () => {
       totalCount: 0,
       isLoading: true,
       error: null,
+      removeStamp: jest.fn(),
     });
 
     const { getByTestId } = render(<GalleryScreen />);
@@ -83,6 +84,7 @@ describe('GalleryScreen', () => {
       totalCount: 1,
       isLoading: false,
       error: null,
+      removeStamp: jest.fn(),
     });
 
     const { getByText } = render(<GalleryScreen />);
@@ -95,6 +97,7 @@ describe('GalleryScreen', () => {
       totalCount: 1,
       isLoading: false,
       error: null,
+      removeStamp: jest.fn(),
     });
 
     const { getByTestId } = render(<GalleryScreen />);
@@ -107,6 +110,7 @@ describe('GalleryScreen', () => {
       totalCount: 0,
       isLoading: false,
       error: null,
+      removeStamp: jest.fn(),
     });
 
     const { getByTestId } = render(<GalleryScreen />);
@@ -119,6 +123,7 @@ describe('GalleryScreen', () => {
       totalCount: 21,
       isLoading: false,
       error: null,
+      removeStamp: jest.fn(),
     });
 
     const { getByTestId } = render(<GalleryScreen />);
@@ -131,6 +136,7 @@ describe('GalleryScreen', () => {
       totalCount: 20,
       isLoading: false,
       error: null,
+      removeStamp: jest.fn(),
     });
 
     const { queryByTestId } = render(<GalleryScreen />);
@@ -143,6 +149,7 @@ describe('GalleryScreen', () => {
       totalCount: 0,
       isLoading: false,
       error: null,
+      removeStamp: jest.fn(),
     });
 
     const { getByTestId, getByText } = render(<GalleryScreen />);
@@ -157,6 +164,7 @@ describe('GalleryScreen', () => {
       totalCount: 1,
       isLoading: false,
       error: null,
+      removeStamp: jest.fn(),
     });
 
     const { getByText } = render(<GalleryScreen />);
@@ -169,6 +177,7 @@ describe('GalleryScreen', () => {
       totalCount: 1,
       isLoading: false,
       error: null,
+      removeStamp: jest.fn(),
     });
 
     const { getByTestId, queryByText } = render(<GalleryScreen />);
@@ -182,6 +191,7 @@ describe('GalleryScreen', () => {
       totalCount: 1,
       isLoading: false,
       error: null,
+      removeStamp: jest.fn(),
     });
 
     const { getByTestId } = render(<GalleryScreen />);


### PR DESCRIPTION
## Summary
- 御朱印削除後にギャラリー一覧のローカルstateが更新されず、削除したアイテムが残って表示されるバグを修正
- `useGalleryStamps` に `removeStamp` 関数を追加し、削除成功時に即座にローカルstateから除去
- 画面遷移なしで削除結果が反映されるように

## Test plan
- [x] 型チェック通過
- [x] 既存テスト通過（GalleryScreen, useGalleryStamps）

🤖 Generated with [Claude Code](https://claude.com/claude-code)