### PR TITLE
feat(gallery): 御朱印編集時に画像変更機能を追加

### DIFF
--- a/src/components/stamp-detail/EditStampModal.tsx
+++ b/src/components/stamp-detail/EditStampModal.tsx
@@ -6,23 +6,31 @@ import {
   TouchableOpacity,
   ScrollView,
   Platform,
+  Image,
   StyleSheet,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { MaterialIcons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
 import { Modal } from '@components/common/Modal';
 import { Button } from '@components/common/Button';
 import { colors } from '@theme/colors';
 import { typography } from '@theme/typography';
 import { spacing, borderRadius } from '@theme/spacing';
 
+const pickerOptions = {
+  allowsEditing: false,
+  quality: 0.8,
+};
+
 interface EditStampModalProps {
   visible: boolean;
   onClose: () => void;
-  onSave: (params: { visited_at: string; memo: string | null }) => void;
+  onSave: (params: { visited_at: string; memo: string | null; newImageUri?: string }) => void;
   isUpdating: boolean;
   initialVisitedAt: string;
   initialMemo: string | null;
+  initialImageUrl: string;
 }
 
 export function EditStampModal({
@@ -32,18 +40,39 @@ export function EditStampModal({
   isUpdating,
   initialVisitedAt,
   initialMemo,
+  initialImageUrl,
 }: EditStampModalProps) {
   const [visitedAt, setVisitedAt] = useState(initialVisitedAt);
   const [memo, setMemo] = useState(initialMemo ?? '');
   const [showDatePicker, setShowDatePicker] = useState(false);
+  const [newImageUri, setNewImageUri] = useState<string | null>(null);
+  const [showPhotoOptions, setShowPhotoOptions] = useState(false);
 
   useEffect(() => {
     if (visible) {
       setVisitedAt(initialVisitedAt);
       setMemo(initialMemo ?? '');
       setShowDatePicker(false);
+      setNewImageUri(null);
+      setShowPhotoOptions(false);
     }
   }, [visible, initialVisitedAt, initialMemo]);
+
+  const handleCamera = async () => {
+    setShowPhotoOptions(false);
+    const result = await ImagePicker.launchCameraAsync(pickerOptions);
+    if (!result.canceled) {
+      setNewImageUri(result.assets[0].uri);
+    }
+  };
+
+  const handleGallery = async () => {
+    setShowPhotoOptions(false);
+    const result = await ImagePicker.launchImageLibraryAsync(pickerOptions);
+    if (!result.canceled) {
+      setNewImageUri(result.assets[0].uri);
+    }
+  };
 
   const visitedAtDate = (() => {
     const [y, m, d] = visitedAt.split('-').map(Number);
@@ -68,12 +97,57 @@ export function EditStampModal({
     onSave({
       visited_at: visitedAt,
       memo: memo.trim() === '' ? null : memo,
+      ...(newImageUri ? { newImageUri } : {}),
     });
   };
 
   return (
     <Modal visible={visible} onClose={onClose} variant="bottom" title="御朱印を編集">
       <ScrollView style={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        <View style={styles.field}>
+          <Text style={styles.label}>写真</Text>
+          <TouchableOpacity
+            style={styles.imageRow}
+            onPress={() => setShowPhotoOptions(!showPhotoOptions)}
+            activeOpacity={0.7}
+            testID="image-change-trigger"
+          >
+            <Image
+              source={{ uri: newImageUri ?? initialImageUrl }}
+              style={styles.imageThumbnail}
+              testID="edit-stamp-image"
+            />
+            <View style={styles.imageInfo}>
+              <View style={styles.imageChangeLabel}>
+                <MaterialIcons name="photo-camera" size={18} color={colors.primary[500]} />
+                <Text style={styles.imageChangeText}>写真を変更</Text>
+              </View>
+              {newImageUri && <Text style={styles.imageChangedBadge}>変更済み</Text>}
+            </View>
+          </TouchableOpacity>
+          {showPhotoOptions && (
+            <View style={styles.photoOptions} testID="photo-options">
+              <TouchableOpacity
+                style={styles.photoOption}
+                onPress={handleCamera}
+                activeOpacity={0.7}
+                testID="camera-option"
+              >
+                <MaterialIcons name="camera-alt" size={20} color={colors.gray[600]} />
+                <Text style={styles.photoOptionText}>カメラで撮影</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.photoOption}
+                onPress={handleGallery}
+                activeOpacity={0.7}
+                testID="gallery-option"
+              >
+                <MaterialIcons name="photo-library" size={20} color={colors.gray[600]} />
+                <Text style={styles.photoOptionText}>ギャラリーから選択</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </View>
         <View style={styles.field}>
           <Text style={styles.label}>訪問日</Text>
           <TouchableOpacity
@@ -134,7 +208,7 @@ export function EditStampModal({
 
 const styles = StyleSheet.create({
   scrollContent: {
-    maxHeight: 420,
+    maxHeight: 500,
   },
   field: {
     marginBottom: spacing.lg,
@@ -189,5 +263,66 @@ const styles = StyleSheet.create({
   },
   button: {
     flex: 1,
+  },
+  imageRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    padding: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.white,
+  },
+  imageThumbnail: {
+    width: 80,
+    height: 100,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.gray[200],
+  },
+  imageInfo: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  imageChangeLabel: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  imageChangeText: {
+    ...typography.body,
+    color: colors.primary[500],
+    fontWeight: '600',
+  },
+  imageChangedBadge: {
+    ...typography.caption,
+    color: colors.primary[600],
+    backgroundColor: colors.primary[50],
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: borderRadius.sm,
+    alignSelf: 'flex-start',
+    overflow: 'hidden',
+  },
+  photoOptions: {
+    marginTop: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.white,
+    overflow: 'hidden',
+  },
+  photoOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray[100],
+  },
+  photoOptionText: {
+    ...typography.body,
+    color: colors.gray[700],
   },
 });

--- a/src/components/stamp-detail/__tests__/EditStampModal.test.tsx
+++ b/src/components/stamp-detail/__tests__/EditStampModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
 import { EditStampModal } from '../EditStampModal';
 
 jest.mock('react-native-safe-area-context', () => {
@@ -23,6 +23,17 @@ jest.mock('@react-native-community/datetimepicker', () => {
   };
 });
 
+jest.mock('expo-image-picker', () => ({
+  launchCameraAsync: jest.fn().mockResolvedValue({
+    canceled: false,
+    assets: [{ uri: 'file:///camera-image.jpg' }],
+  }),
+  launchImageLibraryAsync: jest.fn().mockResolvedValue({
+    canceled: false,
+    assets: [{ uri: 'file:///gallery-image.jpg' }],
+  }),
+}));
+
 describe('EditStampModal', () => {
   const defaultProps = {
     visible: true,
@@ -31,6 +42,7 @@ describe('EditStampModal', () => {
     isUpdating: false,
     initialVisitedAt: '2024-01-15',
     initialMemo: 'テストメモ',
+    initialImageUrl: 'https://example.com/image.jpg',
   };
 
   beforeEach(() => {
@@ -124,5 +136,53 @@ describe('EditStampModal', () => {
     expect(getByText('保存中...')).toBeTruthy();
     const saveButton = getByTestId('button-primary');
     expect(saveButton.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('画像サムネイルが表示される', () => {
+    const { getByTestId } = render(<EditStampModal {...defaultProps} />);
+    const image = getByTestId('edit-stamp-image');
+    expect(image.props.source.uri).toBe('https://example.com/image.jpg');
+  });
+
+  it('画像変更トリガーをタップすると写真選択オプションが表示される', () => {
+    const { getByTestId, queryByTestId } = render(<EditStampModal {...defaultProps} />);
+    expect(queryByTestId('photo-options')).toBeNull();
+    fireEvent.press(getByTestId('image-change-trigger'));
+    expect(getByTestId('photo-options')).toBeTruthy();
+    expect(getByTestId('camera-option')).toBeTruthy();
+    expect(getByTestId('gallery-option')).toBeTruthy();
+  });
+
+  it('ギャラリーから画像選択後に onSave に newImageUri が含まれる', async () => {
+    const onSave = jest.fn();
+    const { getByTestId, getByText } = render(<EditStampModal {...defaultProps} onSave={onSave} />);
+
+    fireEvent.press(getByTestId('image-change-trigger'));
+    await act(async () => {
+      fireEvent.press(getByTestId('gallery-option'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('edit-stamp-image').props.source.uri).toBe('file:///gallery-image.jpg');
+    });
+
+    fireEvent.press(getByText('保存'));
+
+    expect(onSave).toHaveBeenCalledWith({
+      visited_at: '2024-01-15',
+      memo: 'テストメモ',
+      newImageUri: 'file:///gallery-image.jpg',
+    });
+  });
+
+  it('画像未変更時は onSave に newImageUri が含まれない', () => {
+    const onSave = jest.fn();
+    const { getByText } = render(<EditStampModal {...defaultProps} onSave={onSave} />);
+    fireEvent.press(getByText('保存'));
+
+    expect(onSave).toHaveBeenCalledWith({
+      visited_at: '2024-01-15',
+      memo: 'テストメモ',
+    });
   });
 });

--- a/src/hooks/__tests__/useStampDetail.test.ts
+++ b/src/hooks/__tests__/useStampDetail.test.ts
@@ -61,7 +61,7 @@ describe('useStampDetail', () => {
     expect(result.current.error).toBe('fetch error');
   });
 
-  it('handleUpdate 成功時に stamp state が更新される', async () => {
+  it('handleUpdate 成功時に stamp state が更新され、更新後のデータが返る', async () => {
     mockFetchStampById.mockResolvedValue(fakeStamp);
     const updatedStamp: StampWithSpot = { ...fakeStamp, memo: '更新メモ' };
     mockUpdateStamp.mockResolvedValue(updatedStamp);
@@ -72,18 +72,18 @@ describe('useStampDetail', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    let success: boolean;
+    let returnedStamp: StampWithSpot | null;
     await act(async () => {
-      success = await result.current.handleUpdate({ memo: '更新メモ' });
+      returnedStamp = await result.current.handleUpdate({ memo: '更新メモ' });
     });
 
-    expect(success!).toBe(true);
+    expect(returnedStamp!).toEqual(updatedStamp);
     expect(result.current.stamp).toEqual(updatedStamp);
     expect(result.current.error).toBeNull();
     expect(mockUpdateStamp).toHaveBeenCalledWith('stamp-1', { memo: '更新メモ' });
   });
 
-  it('handleUpdate 失敗時に error が設定される', async () => {
+  it('handleUpdate 失敗時に null が返り error が設定される', async () => {
     mockFetchStampById.mockResolvedValue(fakeStamp);
     mockUpdateStamp.mockRejectedValue(new Error('update failed'));
 
@@ -93,12 +93,12 @@ describe('useStampDetail', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    let success: boolean;
+    let returnedStamp: StampWithSpot | null;
     await act(async () => {
-      success = await result.current.handleUpdate({ memo: '更新メモ' });
+      returnedStamp = await result.current.handleUpdate({ memo: '更新メモ' });
     });
 
-    expect(success!).toBe(false);
+    expect(returnedStamp!).toBeNull();
     expect(result.current.error).toBe('update failed');
   });
 

--- a/src/hooks/useGalleryStamps.ts
+++ b/src/hooks/useGalleryStamps.ts
@@ -14,6 +14,7 @@ interface UseGalleryStampsReturn {
   isLoading: boolean;
   error: string | null;
   removeStamp: (stampId: string) => void;
+  updateStamp: (updated: StampWithSpot) => void;
 }
 
 export function useGalleryStamps(sortOrder: SortOrder): UseGalleryStampsReturn {
@@ -60,6 +61,10 @@ export function useGalleryStamps(sortOrder: SortOrder): UseGalleryStampsReturn {
     setAllStamps(prev => prev.filter(s => s.id !== stampId));
   }, []);
 
+  const updateStamp = useCallback((updated: StampWithSpot) => {
+    setAllStamps(prev => prev.map(s => (s.id === updated.id ? updated : s)));
+  }, []);
+
   const stamps = useMemo(() => {
     const sorted = [...allStamps];
     if (sortOrder === 'spot') {
@@ -75,5 +80,6 @@ export function useGalleryStamps(sortOrder: SortOrder): UseGalleryStampsReturn {
     isLoading,
     error,
     removeStamp,
+    updateStamp,
   };
 }

--- a/src/hooks/useStampDetail.ts
+++ b/src/hooks/useStampDetail.ts
@@ -1,5 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
-import { fetchStampById, updateStamp, deleteStamp } from '@services/stamps';
+import {
+  fetchStampById,
+  updateStamp,
+  deleteStamp,
+  uploadStampImage,
+  deleteStampImage,
+} from '@services/stamps';
 import type { StampWithSpot } from '@/types/supabase';
 
 interface UseStampDetailReturn {
@@ -8,7 +14,11 @@ interface UseStampDetailReturn {
   error: string | null;
   isUpdating: boolean;
   isDeleting: boolean;
-  handleUpdate: (params: { visited_at?: string; memo?: string | null }) => Promise<boolean>;
+  handleUpdate: (params: {
+    visited_at?: string;
+    memo?: string | null;
+    newImageUri?: string;
+  }) => Promise<StampWithSpot | null>;
   handleDelete: () => Promise<boolean>;
   refresh: () => void;
 }
@@ -48,21 +58,57 @@ export function useStampDetail(stampId: string): UseStampDetailReturn {
   }, [stampId, refreshTrigger]);
 
   const handleUpdate = useCallback(
-    async (params: { visited_at?: string; memo?: string | null }): Promise<boolean> => {
+    async (params: {
+      visited_at?: string;
+      memo?: string | null;
+      newImageUri?: string;
+    }): Promise<StampWithSpot | null> => {
       setIsUpdating(true);
       setError(null);
       try {
-        const updated = await updateStamp(stampId, params);
-        setStamp(updated);
-        return true;
+        const { newImageUri, ...updateParams } = params;
+        let updated: StampWithSpot;
+
+        if (newImageUri && stamp) {
+          const oldImagePath = stamp.image_path;
+          const newImagePath = await uploadStampImage(stamp.user_id, newImageUri);
+
+          try {
+            updated = await updateStamp(stampId, {
+              ...updateParams,
+              image_path: newImagePath,
+            });
+            setStamp(updated);
+          } catch (dbError) {
+            // DB更新失敗時は新画像を削除してクリーンアップ
+            try {
+              await deleteStampImage(newImagePath);
+            } catch {
+              // クリーンアップ失敗は無視
+            }
+            throw dbError;
+          }
+
+          // 旧画像の削除（失敗してもデータ整合性は保たれている）
+          try {
+            await deleteStampImage(oldImagePath);
+          } catch {
+            console.warn('Failed to delete old image:', oldImagePath);
+          }
+        } else {
+          updated = await updateStamp(stampId, updateParams);
+          setStamp(updated);
+        }
+
+        return updated;
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Unknown error');
-        return false;
+        return null;
       } finally {
         setIsUpdating(false);
       }
     },
-    [stampId]
+    [stampId, stamp]
   );
 
   const handleDelete = useCallback(async (): Promise<boolean> => {

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -31,7 +31,13 @@ const ITEM_SIZE = (SCREEN_WIDTH - spacing.lg * 2 - ITEM_MARGIN * (NUM_COLUMNS - 
 
 export function GalleryScreen() {
   const [sortOrder, setSortOrder] = useState<SortOrder>('date');
-  const { stamps, totalCount, isLoading, removeStamp } = useGalleryStamps(sortOrder);
+  const {
+    stamps,
+    totalCount,
+    isLoading,
+    removeStamp,
+    updateStamp: updateGalleryStamp,
+  } = useGalleryStamps(sortOrder);
 
   const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(null);
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -70,13 +76,14 @@ export function GalleryScreen() {
   }, []);
 
   const onSave = useCallback(
-    async (params: { visited_at: string; memo: string | null }) => {
-      const success = await handleUpdate(params);
-      if (success) {
+    async (params: { visited_at: string; memo: string | null; newImageUri?: string }) => {
+      const updated = await handleUpdate(params);
+      if (updated) {
+        updateGalleryStamp(updated);
         setEditModalVisible(false);
       }
     },
-    [handleUpdate]
+    [handleUpdate, updateGalleryStamp]
   );
 
   const onConfirmDelete = useCallback(async () => {
@@ -171,6 +178,7 @@ export function GalleryScreen() {
               isUpdating={isUpdating}
               initialVisitedAt={currentStamp.visited_at}
               initialMemo={currentStamp.memo}
+              initialImageUrl={getStampImageUrl(currentStamp.image_path)}
             />
             <DeleteConfirmModal
               visible={deleteModalVisible}

--- a/src/screens/__tests__/GalleryScreen.test.tsx
+++ b/src/screens/__tests__/GalleryScreen.test.tsx
@@ -72,6 +72,7 @@ describe('GalleryScreen', () => {
       isLoading: true,
       error: null,
       removeStamp: jest.fn(),
+      updateStamp: jest.fn(),
     });
 
     const { getByTestId } = render(<GalleryScreen />);
@@ -85,6 +86,7 @@ describe('GalleryScreen', () => {
       isLoading: false,
       error: null,
       removeStamp: jest.fn(),
+      updateStamp: jest.fn(),
     });
 
     const { getByText } = render(<GalleryScreen />);
@@ -98,6 +100,7 @@ describe('GalleryScreen', () => {
       isLoading: false,
       error: null,
       removeStamp: jest.fn(),
+      updateStamp: jest.fn(),
     });
 
     const { getByTestId } = render(<GalleryScreen />);
@@ -111,6 +114,7 @@ describe('GalleryScreen', () => {
       isLoading: false,
       error: null,
       removeStamp: jest.fn(),
+      updateStamp: jest.fn(),
     });
 
     const { getByTestId } = render(<GalleryScreen />);
@@ -124,6 +128,7 @@ describe('GalleryScreen', () => {
       isLoading: false,
       error: null,
       removeStamp: jest.fn(),
+      updateStamp: jest.fn(),
     });
 
     const { getByTestId } = render(<GalleryScreen />);
@@ -137,6 +142,7 @@ describe('GalleryScreen', () => {
       isLoading: false,
       error: null,
       removeStamp: jest.fn(),
+      updateStamp: jest.fn(),
     });
 
     const { queryByTestId } = render(<GalleryScreen />);
@@ -150,6 +156,7 @@ describe('GalleryScreen', () => {
       isLoading: false,
       error: null,
       removeStamp: jest.fn(),
+      updateStamp: jest.fn(),
     });
 
     const { getByTestId, getByText } = render(<GalleryScreen />);
@@ -165,6 +172,7 @@ describe('GalleryScreen', () => {
       isLoading: false,
       error: null,
       removeStamp: jest.fn(),
+      updateStamp: jest.fn(),
     });
 
     const { getByText } = render(<GalleryScreen />);
@@ -178,6 +186,7 @@ describe('GalleryScreen', () => {
       isLoading: false,
       error: null,
       removeStamp: jest.fn(),
+      updateStamp: jest.fn(),
     });
 
     const { getByTestId, queryByText } = render(<GalleryScreen />);
@@ -192,6 +201,7 @@ describe('GalleryScreen', () => {
       isLoading: false,
       error: null,
       removeStamp: jest.fn(),
+      updateStamp: jest.fn(),
     });
 
     const { getByTestId } = render(<GalleryScreen />);

--- a/src/services/stamps.ts
+++ b/src/services/stamps.ts
@@ -112,7 +112,7 @@ export function getStampImageUrl(imagePath: string): string {
 
 export async function updateStamp(
   stampId: string,
-  params: { visited_at?: string; memo?: string | null; is_public?: boolean }
+  params: { visited_at?: string; memo?: string | null; is_public?: boolean; image_path?: string }
 ): Promise<StampWithSpot> {
   const { data, error } = await supabase
     .from('stamps')


### PR DESCRIPTION
## Summary
- 御朱印編集モーダルに画像変更機能を追加（カメラ撮影/ギャラリーから選択）
- 編集保存後にギャラリー一覧が即時更新されるよう対応
- EditStampModal内で直接expo-image-pickerを呼び出す方式でモーダルネスト問題を回避

## 変更ファイル
- `src/components/stamp-detail/EditStampModal.tsx` — 画像プレビュー・カメラ/ギャラリー選択UI追加
- `src/hooks/useStampDetail.ts` — 画像アップロード/旧画像削除/ロールバックロジック追加
- `src/hooks/useGalleryStamps.ts` — updateStamp関数追加（編集後の即時反映）
- `src/services/stamps.ts` — updateStampにimage_pathパラメータ追加
- `src/screens/GalleryScreen.tsx` — 新props連携

## Test plan
- [x] テスト: 24/24パス（EditStampModal, GalleryScreen）
- [x] Lint: エラーなし
- [x] 型チェック: パス
- [ ] 実機でカメラ撮影→画像変更→保存の動作確認
- [ ] 実機でギャラリーから選択→画像変更→保存の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)