### PR TITLE
fix(map): フィルター切り替え時にピンが再表示されない問題を修正

### DIFF
--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -265,7 +265,7 @@ export function MapScreen({ navigation, route }: Props) {
         )}
         {spots.map(spot => (
           <Marker
-            key={`${spot.id}-${shouldShowLabels ? 'label' : 'pin'}`}
+            key={`${spot.id}-${filterMode}-${shouldShowLabels ? 'label' : 'pin'}`}
             coordinate={{ latitude: spot.lat, longitude: spot.lng }}
             testID={`spot-marker-${spot.id}`}
             onPress={() => handleMarkerPress(spot.id)}


### PR DESCRIPTION
## Summary
- マップ画面で「訪問済みのみ」→「すべて表示」に切り替えた際、消えていたピンが即座に再表示されない不具合を修正
- Marker の key に filterMode を含めることで、react-native-maps が確実にマーカーを再描画するようにした

## Test plan
- [x] 既存テスト全パス（MapScreen 23テスト）
- [ ] 実機で「すべて表示」→「訪問済みのみ」→「すべて表示」の切り替えを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)