### PR TITLE
feat: 地域別カードタップでマップ画面に遷移し県範囲にズーム

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -99,6 +99,7 @@ jest.mock('react-native-maps', () => {
     React.useImperativeHandle(ref, () => ({
       animateToRegion: jest.fn(),
       animateCamera: jest.fn(),
+      fitToCoordinates: jest.fn(),
     }));
     return React.createElement(
       View,

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -33,7 +33,7 @@ export type MainTabParamList = {
 };
 
 export type MapStackParamList = {
-  Map: { focusSpotId?: string } | undefined;
+  Map: { focusSpotId?: string; focusPrefecture?: string } | undefined;
   SpotDetail: { spotId: string };
   Search: undefined;
 };

--- a/src/screens/CollectionScreen.tsx
+++ b/src/screens/CollectionScreen.tsx
@@ -43,6 +43,16 @@ export function CollectionScreen({ navigation }: Props) {
     navigation.navigate('PilgrimageDetail', { pilgrimageId, pilgrimageName });
   };
 
+  const handleRegionPress = (prefecture: string) => {
+    const parent = navigation.getParent();
+    if (parent) {
+      parent.navigate('MapTab', {
+        screen: 'Map',
+        params: { focusPrefecture: prefecture },
+      });
+    }
+  };
+
   const badges = getAllBadges();
   const badgesWithStatus = badges.map(badge => ({
     ...badge,
@@ -212,7 +222,12 @@ export function CollectionScreen({ navigation }: Props) {
                   ? Math.round((region.visitedCount / region.totalCount) * 100)
                   : 0;
               return (
-                <View key={region.prefecture} style={styles.regionRow}>
+                <TouchableOpacity
+                  key={region.prefecture}
+                  style={styles.regionRow}
+                  onPress={() => handleRegionPress(region.prefecture)}
+                  activeOpacity={0.7}
+                >
                   <MaterialIcons name="location-on" size={20} color={colors.primary[500]} />
                   <Text style={styles.regionName}>{region.prefecture}</Text>
                   <View style={styles.regionProgressContainer}>
@@ -223,7 +238,7 @@ export function CollectionScreen({ navigation }: Props) {
                   <Text style={styles.regionCount}>
                     {region.visitedCount}/{region.totalCount}
                   </Text>
-                </View>
+                </TouchableOpacity>
               );
             })}
           </Card>

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useRef, useCallback, useEffect } from 'react';
+import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import MapView, { Marker, type MapPressEvent, type Region } from 'react-native-maps';
 import { MaterialIcons } from '@expo/vector-icons';
 
+import { fetchSpotsByPrefecture } from '@services/spots';
 import { FABButton } from '@components/animated/FABButton';
 import { SearchBar } from '@components/common/SearchBar';
 import { LoginPromptModal } from '@components/common/LoginPromptModal';
@@ -46,9 +47,16 @@ export function MapScreen({ navigation, route }: Props) {
   const { location } = useLocation();
   const { visitedSpotIds } = useUserStamps();
   const { wishlistSpotIds, toggleWishlist } = useWishlist();
+  const [prefectureSpots, setPrefectureSpots] = useState<Spot[]>([]);
   const [filterMode, setFilterMode] = useState<FilterMode>('all');
   const [mapRegion, setMapRegion] = useState<Region | null>(null);
   const { spots } = useSpots(location, mapRegion, filterMode, visitedSpotIds);
+  const displaySpots = useMemo(() => {
+    if (prefectureSpots.length === 0) return spots;
+    const ids = new Set(spots.map(s => s.id));
+    const additional = prefectureSpots.filter(s => !ids.has(s.id));
+    return [...spots, ...additional];
+  }, [spots, prefectureSpots]);
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [showFilter, setShowFilter] = useState(false);
   const [currentLatitudeDelta, setCurrentLatitudeDelta] = useState(LATITUDE_DELTA);
@@ -79,12 +87,33 @@ export function MapScreen({ navigation, route }: Props) {
     setSelectedSpotId(focusSpotId);
   }, [route.params?.focusSpotId, spots]);
 
-  // Clear selection if the selected spot is no longer in the spots list
   useEffect(() => {
-    if (selectedSpotId && !spots.find(s => s.id === selectedSpotId)) {
+    const focusPrefecture = route.params?.focusPrefecture;
+    if (!focusPrefecture) {
+      setPrefectureSpots([]);
+      return;
+    }
+
+    (async () => {
+      const data = await fetchSpotsByPrefecture(focusPrefecture);
+      setPrefectureSpots(data);
+
+      if (data.length > 0 && mapRef.current) {
+        const coords = data.map(s => ({ latitude: s.lat, longitude: s.lng }));
+        mapRef.current.fitToCoordinates(coords, {
+          edgePadding: { top: 100, right: 50, bottom: 50, left: 50 },
+          animated: true,
+        });
+      }
+    })();
+  }, [route.params?.focusPrefecture]);
+
+  // Clear selection if the selected spot is no longer in the displaySpots list
+  useEffect(() => {
+    if (selectedSpotId && !displaySpots.find(s => s.id === selectedSpotId)) {
       setSelectedSpotId(null);
     }
-  }, [selectedSpotId, spots]);
+  }, [selectedSpotId, displaySpots]);
 
   const navigateToRecord = (spotId?: string) => {
     const parent = navigation.getParent();
@@ -115,7 +144,7 @@ export function MapScreen({ navigation, route }: Props) {
     (spotId: string) => {
       setSelectedSpotId(spotId);
 
-      const spot = spots.find(s => s.id === spotId);
+      const spot = displaySpots.find(s => s.id === spotId);
       if (spot && mapRef.current) {
         mapRef.current.animateCamera(
           {
@@ -128,7 +157,7 @@ export function MapScreen({ navigation, route }: Props) {
         );
       }
     },
-    [spots]
+    [displaySpots]
   );
 
   const handleMapPress = useCallback((event?: MapPressEvent) => {
@@ -265,7 +294,7 @@ export function MapScreen({ navigation, route }: Props) {
             <MapPin type="current-location" />
           </Marker>
         )}
-        {spots.map(spot => (
+        {displaySpots.map(spot => (
           <Marker
             key={`${spot.id}-${filterMode}-${shouldShowLabels ? 'label' : 'pin'}`}
             coordinate={{ latitude: spot.lat, longitude: spot.lng }}

--- a/src/screens/__tests__/CollectionScreen.test.tsx
+++ b/src/screens/__tests__/CollectionScreen.test.tsx
@@ -111,10 +111,11 @@ jest.mock('@services/badges', () => ({
 }));
 
 const mockNavigate = jest.fn();
+const mockParentNavigate = jest.fn();
 const mockNavigation = {
   navigate: mockNavigate,
   goBack: jest.fn(),
-  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+  getParent: jest.fn(() => ({ navigate: mockParentNavigate })),
 } as unknown as CollectionStackScreenProps<'CollectionList'>['navigation'];
 
 const mockRoute = {
@@ -247,6 +248,30 @@ describe('CollectionScreen', () => {
     fireEvent.press(getByText('他の巡礼を見る (1)'));
     // 西国三十三所が表示される
     expect(getByText('西国三十三所')).toBeTruthy();
+  });
+
+  describe('地域カードタップでマップへの遷移', () => {
+    it('地域行をタップすると MapTab の focusPrefecture で遷移する', () => {
+      const { getByText } = render(
+        <CollectionScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      fireEvent.press(getByText('宮城県'));
+      expect(mockParentNavigate).toHaveBeenCalledWith('MapTab', {
+        screen: 'Map',
+        params: { focusPrefecture: '宮城県' },
+      });
+    });
+
+    it('別の地域行をタップすると対応する prefecture で遷移する', () => {
+      const { getByText } = render(
+        <CollectionScreen navigation={mockNavigation} route={mockRoute} />
+      );
+      fireEvent.press(getByText('東京都'));
+      expect(mockParentNavigate).toHaveBeenCalledWith('MapTab', {
+        screen: 'Map',
+        params: { focusPrefecture: '東京都' },
+      });
+    });
   });
 
   describe('Wishlist section', () => {

--- a/src/screens/__tests__/MapScreen.test.tsx
+++ b/src/screens/__tests__/MapScreen.test.tsx
@@ -2,6 +2,16 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { MapScreen } from '@screens/MapScreen';
 
+const mockFetchSpotsByPrefecture = jest.fn();
+
+jest.mock('@services/spots', () => ({
+  fetchSpotsByPrefecture: (...args: unknown[]) => mockFetchSpotsByPrefecture(...args),
+}));
+
+jest.mock('@hooks/useSpotInfo', () => ({
+  useSpotInfo: () => ({ spotInfo: null, isLoading: false, error: null }),
+}));
+
 jest.mock('@services/stamps', () => ({
   fetchStampsBySpotId: jest.fn(() => Promise.resolve([])),
   getStampImageUrl: jest.fn((path: string) => `https://example.com/${path}`),
@@ -176,6 +186,7 @@ describe('MapScreen', () => {
       signInWithGoogle: jest.fn(),
       signOut: jest.fn(),
     };
+    mockFetchSpotsByPrefecture.mockResolvedValue([]);
   });
 
   it('renders without crashing', () => {
@@ -450,6 +461,116 @@ describe('MapScreen', () => {
 
       fireEvent.press(getByTestId('modal-later-button'));
       expect(queryByText('ログインが必要です')).toBeNull();
+    });
+  });
+
+  describe('focusPrefecture', () => {
+    const prefectureSpots = [
+      {
+        id: 'pref-spot-1',
+        name: '宮城県神社A',
+        lat: 38.3,
+        lng: 140.9,
+        type: 'shrine',
+        status: 'active',
+        address: '宮城県X市',
+        created_by_user_id: null,
+        merged_into_spot_id: null,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      },
+      {
+        id: 'pref-spot-2',
+        name: '宮城県寺院B',
+        lat: 38.35,
+        lng: 140.95,
+        type: 'temple',
+        status: 'active',
+        address: '宮城県Y市',
+        created_by_user_id: null,
+        merged_into_spot_id: null,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      },
+    ];
+
+    it('focusPrefecture が渡されると fetchSpotsByPrefecture が呼ばれる', async () => {
+      mockFetchSpotsByPrefecture.mockResolvedValue(prefectureSpots);
+
+      const routeWithPrefecture = {
+        key: 'test',
+        name: 'Map' as const,
+        params: { focusPrefecture: '宮城県' },
+      };
+
+      render(<MapScreen navigation={mockNavigation as never} route={routeWithPrefecture} />);
+
+      await waitFor(() => {
+        expect(mockFetchSpotsByPrefecture).toHaveBeenCalledWith('宮城県');
+      });
+    });
+
+    it('focusPrefecture がない場合は fetchSpotsByPrefecture が呼ばれない', () => {
+      render(<MapScreen navigation={mockNavigation as never} route={mockRoute} />);
+      expect(mockFetchSpotsByPrefecture).not.toHaveBeenCalled();
+    });
+
+    it('prefectureSpots は既存 spots に追加してマーカー表示される', async () => {
+      mockFetchSpotsByPrefecture.mockResolvedValue(prefectureSpots);
+
+      const routeWithPrefecture = {
+        key: 'test',
+        name: 'Map' as const,
+        params: { focusPrefecture: '宮城県' },
+      };
+
+      const { getByTestId } = render(
+        <MapScreen navigation={mockNavigation as never} route={routeWithPrefecture} />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchSpotsByPrefecture).toHaveBeenCalled();
+      });
+
+      // 既存の spots のマーカーも表示される
+      expect(getByTestId('spot-marker-spot-1')).toBeTruthy();
+      expect(getByTestId('spot-marker-spot-2')).toBeTruthy();
+      // 県内 spots のマーカーも表示される
+      expect(getByTestId('spot-marker-pref-spot-1')).toBeTruthy();
+      expect(getByTestId('spot-marker-pref-spot-2')).toBeTruthy();
+    });
+
+    it('focusPrefecture が消えると prefectureSpots がクリアされる', async () => {
+      mockFetchSpotsByPrefecture.mockResolvedValue(prefectureSpots);
+
+      const routeWithPrefecture = {
+        key: 'test',
+        name: 'Map' as const,
+        params: { focusPrefecture: '宮城県' },
+      };
+
+      const { rerender, queryByTestId } = render(
+        <MapScreen navigation={mockNavigation as never} route={routeWithPrefecture} />
+      );
+
+      await waitFor(() => {
+        expect(mockFetchSpotsByPrefecture).toHaveBeenCalled();
+      });
+
+      // focusPrefecture なしに変更
+      const routeWithoutPrefecture = {
+        key: 'test',
+        name: 'Map' as const,
+        params: undefined,
+      };
+
+      rerender(<MapScreen navigation={mockNavigation as never} route={routeWithoutPrefecture} />);
+
+      // 県内 spots のマーカーは消える
+      await waitFor(() => {
+        expect(queryByTestId('spot-marker-pref-spot-1')).toBeNull();
+        expect(queryByTestId('spot-marker-pref-spot-2')).toBeNull();
+      });
     });
   });
 });

--- a/src/services/__tests__/spots.test.ts
+++ b/src/services/__tests__/spots.test.ts
@@ -1,4 +1,9 @@
-import { fetchSpotsByBounds, fetchSpotById, searchSpotsByName } from '@services/spots';
+import {
+  fetchSpotsByBounds,
+  fetchSpotById,
+  searchSpotsByName,
+  fetchSpotsByPrefecture,
+} from '@services/spots';
 import type { BoundingBox } from '@utils/geo';
 
 const mockSelect = jest.fn();
@@ -116,6 +121,39 @@ describe('spots service', () => {
       mockLimit.mockReturnValue({ data: null, error: { message: 'error' } });
 
       const result = await searchSpotsByName('Test');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('fetchSpotsByPrefecture', () => {
+    it('指定都道府県のアクティブスポットを返す', async () => {
+      const mockSpots = [
+        { id: '1', name: '宮城縣護國神社', type: 'shrine', status: 'active', prefecture: '宮城県' },
+        { id: '2', name: '仙台東照宮', type: 'shrine', status: 'active', prefecture: '宮城県' },
+      ];
+
+      mockFrom.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValueOnce({ eq: mockEq });
+      mockEq.mockReturnValueOnce({ data: mockSpots, error: null });
+
+      const result = await fetchSpotsByPrefecture('宮城県');
+
+      expect(mockFrom).toHaveBeenCalledWith('spots');
+      expect(mockSelect).toHaveBeenCalledWith('*');
+      expect(mockEq).toHaveBeenCalledWith('status', 'active');
+      expect(mockEq).toHaveBeenCalledWith('prefecture', '宮城県');
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('宮城縣護國神社');
+    });
+
+    it('エラー時は空配列を返す', async () => {
+      mockFrom.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ eq: mockEq });
+      mockEq.mockReturnValueOnce({ eq: mockEq });
+      mockEq.mockReturnValueOnce({ data: null, error: { message: 'DB error' } });
+
+      const result = await fetchSpotsByPrefecture('宮城県');
       expect(result).toEqual([]);
     });
   });

--- a/src/services/spots.ts
+++ b/src/services/spots.ts
@@ -58,6 +58,20 @@ export async function createSpot(params: {
   return data as Spot;
 }
 
+export async function fetchSpotsByPrefecture(prefecture: string): Promise<Spot[]> {
+  const { data, error } = await supabase
+    .from('spots')
+    .select('*')
+    .eq('status', 'active')
+    .eq('prefecture', prefecture);
+
+  if (error) {
+    console.warn('fetchSpotsByPrefecture error:', error.message);
+    return [];
+  }
+  return data as Spot[];
+}
+
 export async function searchSpotsByName(query: string): Promise<Spot[]> {
   const { data, error } = await supabase
     .from('spots')


### PR DESCRIPTION
## Summary
- コレクション画面の地域別カードをタップすると、マップタブに切り替わりその県の全スポットが表示される範囲にズーム
- 新しい画面は作らず、既存のマップ画面を活用

## 変更内容
- `MapStackParamList` に `focusPrefecture` パラメータ追加
- `fetchSpotsByPrefecture` サービス関数追加
- `MapScreen` で `focusPrefecture` を受け取り `fitToCoordinates` で県範囲にズーム
- `displaySpots` で既存スポットと県別スポットをマージ表示
- `CollectionScreen` の地域カードに `TouchableOpacity` + タブ間遷移を追加

## Test plan
- [x] `npm test` — 600 tests passed
- [x] `npm run typecheck` — エラーなし
- [x] `npm run lint` — 0 errors
- [ ] コレクション画面の地域カードタップ → マップタブに切り替わり、県全体にズーム確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)