### PR TITLE
feat(collection): 地域別セクションをブロック単位のトグルUIに変更

### DIFF
--- a/src/screens/CollectionScreen.tsx
+++ b/src/screens/CollectionScreen.tsx
@@ -1,11 +1,14 @@
 import { MaterialIcons } from '@expo/vector-icons';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   ActivityIndicator,
+  LayoutAnimation,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
+  UIManager,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -21,7 +24,12 @@ import { removeFromWishlist } from '@services/wishlist';
 import { colors } from '@theme/colors';
 import { borderRadius, spacing } from '@theme/spacing';
 import { typography } from '@theme/typography';
+import { groupByRegionBlock } from '@utils/regionBlocks';
 import type { CollectionStackScreenProps } from '@/navigation/types';
+
+if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
 
 type Props = CollectionStackScreenProps<'CollectionList'>;
 
@@ -32,6 +40,22 @@ export function CollectionScreen({ navigation }: Props) {
     useCollectionStats();
 
   const [showAllPilgrimages, setShowAllPilgrimages] = useState(false);
+  const [expandedRegions, setExpandedRegions] = useState<Set<string>>(new Set());
+
+  const groupedRegions = useMemo(() => groupByRegionBlock(regionStats), [regionStats]);
+
+  const toggleRegionBlock = (key: string) => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setExpandedRegions(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
 
   const handleRemoveFromWishlist = async (spotId: string) => {
     if (!user) return;
@@ -215,33 +239,57 @@ export function CollectionScreen({ navigation }: Props) {
             <Text style={styles.regionEmptyText}>御朱印を記録すると地域別の統計が表示されます</Text>
           </Card>
         ) : (
-          <Card style={styles.sectionCard}>
-            {regionStats.map(region => {
-              const percent =
-                region.totalCount > 0
-                  ? Math.round((region.visitedCount / region.totalCount) * 100)
-                  : 0;
-              return (
+          groupedRegions.map(block => {
+            const isExpanded = expandedRegions.has(block.key);
+            const blockPercent =
+              block.totalPrefCount > 0
+                ? Math.round((block.visitedPrefCount / block.totalPrefCount) * 100)
+                : 0;
+            return (
+              <Card key={block.key} style={styles.regionBlockCard}>
                 <TouchableOpacity
-                  key={region.prefecture}
-                  style={styles.regionRow}
-                  onPress={() => handleRegionPress(region.prefecture)}
+                  style={styles.regionBlockHeader}
+                  onPress={() => toggleRegionBlock(block.key)}
                   activeOpacity={0.7}
                 >
-                  <MaterialIcons name="location-on" size={20} color={colors.primary[500]} />
-                  <Text style={styles.regionName}>{region.prefecture}</Text>
-                  <View style={styles.regionProgressContainer}>
+                  <MaterialIcons
+                    name={isExpanded ? 'expand-more' : 'chevron-right'}
+                    size={24}
+                    color={colors.gray[700]}
+                  />
+                  <Text style={styles.regionBlockName}>{block.label}</Text>
+                  <View style={styles.regionBlockProgressContainer}>
                     <View style={styles.progressBarBg}>
-                      <View style={[styles.progressBarFill, { width: `${percent}%` }]} />
+                      <View style={[styles.progressBarFill, { width: `${blockPercent}%` }]} />
                     </View>
                   </View>
-                  <Text style={styles.regionCount}>
-                    {region.visitedCount}/{region.totalCount}
+                  <Text style={styles.regionBlockCount}>
+                    {block.visitedPrefCount}/{block.totalPrefCount}
                   </Text>
                 </TouchableOpacity>
-              );
-            })}
-          </Card>
+                {isExpanded &&
+                  block.prefectures.map(pref => {
+                    const prefColor = pref.hasVisited ? colors.primary[500] : colors.gray[400];
+                    return (
+                      <TouchableOpacity
+                        key={pref.prefecture}
+                        style={styles.regionPrefRow}
+                        onPress={() => handleRegionPress(pref.prefecture)}
+                        activeOpacity={0.7}
+                      >
+                        <MaterialIcons name="location-on" size={18} color={prefColor} />
+                        <Text style={[styles.regionPrefName, { color: prefColor }]}>
+                          {pref.prefecture}
+                        </Text>
+                        <Text style={[styles.regionPrefCount, { color: prefColor }]}>
+                          {pref.visitedCount}/{pref.totalCount}
+                        </Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+              </Card>
+            );
+          })
         )}
 
         {/* Wishlist Section */}
@@ -499,22 +547,45 @@ const styles = StyleSheet.create({
     color: colors.gray[400],
     textAlign: 'center',
   },
-  sectionCard: {
-    marginBottom: spacing.xl,
+  regionBlockCard: {
+    marginBottom: spacing.sm,
   },
-  regionRow: {
+  regionBlockHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  regionBlockName: {
+    ...typography.body,
+    color: colors.gray[800],
+    fontWeight: '600',
+    minWidth: 100,
+  },
+  regionBlockProgressContainer: {
+    flex: 1,
+    marginHorizontal: spacing.sm,
+  },
+  regionBlockCount: {
+    ...typography.bodySmall,
+    color: colors.gray[600],
+    minWidth: 32,
+    textAlign: 'right',
+  },
+  regionPrefRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.sm,
-    marginBottom: spacing.md,
+    paddingLeft: spacing.xl + spacing.sm,
+    paddingVertical: spacing.xs,
   },
-  regionName: {
+  regionPrefName: {
     ...typography.bodySmall,
-    color: colors.gray[700],
-    minWidth: 60,
-  },
-  regionProgressContainer: {
     flex: 1,
+  },
+  regionPrefCount: {
+    ...typography.bodySmall,
+    textAlign: 'right',
+    minWidth: 40,
   },
   regionEmptyCard: {
     alignItems: 'center',
@@ -526,12 +597,6 @@ const styles = StyleSheet.create({
     ...typography.bodySmall,
     color: colors.gray[400],
     textAlign: 'center',
-  },
-  regionCount: {
-    ...typography.bodySmall,
-    color: colors.gray[700],
-    textAlign: 'right',
-    minWidth: 40,
   },
   wishlistEmptyCard: {
     alignItems: 'center',

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -68,7 +68,9 @@ export function MapScreen({ navigation, route }: Props) {
   const [showFilter, setShowFilter] = useState(false);
   const [currentLatitudeDelta, setCurrentLatitudeDelta] = useState(LATITUDE_DELTA);
   const [selectedSpotId, setSelectedSpotId] = useState<string | null>(null);
-  const shouldShowLabels = currentLatitudeDelta <= LABEL_VISIBLE_DELTA;
+  const [forceLabelVisible, setForceLabelVisible] = useState(false);
+  const skipRegionChangeRef = useRef(false);
+  const shouldShowLabels = currentLatitudeDelta <= LABEL_VISIBLE_DELTA || forceLabelVisible;
   const mapRef = useRef<MapView>(null);
   const insets = useSafeAreaInsets();
 
@@ -104,6 +106,7 @@ export function MapScreen({ navigation, route }: Props) {
     const focusPrefecture = route.params?.focusPrefecture;
     if (!focusPrefecture) {
       setPrefectureSpots([]);
+      setForceLabelVisible(false);
       return;
     }
 
@@ -113,6 +116,8 @@ export function MapScreen({ navigation, route }: Props) {
 
       if (data.length > 0 && mapRef.current) {
         const coords = data.map(s => ({ latitude: s.lat, longitude: s.lng }));
+        skipRegionChangeRef.current = true;
+        setForceLabelVisible(true);
         mapRef.current.fitToCoordinates(coords, {
           edgePadding: { top: 100, right: 50, bottom: 50, left: 50 },
           animated: true,
@@ -143,6 +148,11 @@ export function MapScreen({ navigation, route }: Props) {
 
   const handleRegionChangeComplete = useCallback((r: Region) => {
     setCurrentLatitudeDelta(r.latitudeDelta);
+    if (skipRegionChangeRef.current) {
+      skipRegionChangeRef.current = false;
+    } else {
+      setForceLabelVisible(false);
+    }
   }, []);
 
   const handleMarkerPress = useCallback(

--- a/src/screens/__tests__/CollectionScreen.test.tsx
+++ b/src/screens/__tests__/CollectionScreen.test.tsx
@@ -180,13 +180,22 @@ describe('CollectionScreen', () => {
     expect(getByText('御朱印（枚）')).toBeTruthy();
   });
 
-  it('地域別データが表示される', () => {
-    const { getByText } = render(
+  it('地域別データが地域ブロックのトグルで表示される', () => {
+    const { getByText, queryByText } = render(
       <CollectionScreen navigation={mockNavigation} route={mockRoute} />
     );
     expect(getByText('地域別')).toBeTruthy();
+    // 初期表示では地域ブロックヘッダーのみ
+    expect(getByText('北海道・東北')).toBeTruthy();
+    expect(getByText('関東')).toBeTruthy();
+    // 都道府県は初期表示では非表示
+    expect(queryByText('宮城県')).toBeNull();
+    // 北海道・東北を開く
+    fireEvent.press(getByText('北海道・東北'));
     expect(getByText('宮城県')).toBeTruthy();
     expect(getByText('5/10')).toBeTruthy();
+    // 関東を開く
+    fireEvent.press(getByText('関東'));
     expect(getByText('東京都')).toBeTruthy();
     expect(getByText('3/20')).toBeTruthy();
   });
@@ -251,10 +260,12 @@ describe('CollectionScreen', () => {
   });
 
   describe('地域カードタップでマップへの遷移', () => {
-    it('地域行をタップすると MapTab の focusPrefecture で遷移する', () => {
+    it('地域ブロックを開いて都道府県をタップすると MapTab へ遷移する', () => {
       const { getByText } = render(
         <CollectionScreen navigation={mockNavigation} route={mockRoute} />
       );
+      // 北海道・東北を開いて宮城県をタップ
+      fireEvent.press(getByText('北海道・東北'));
       fireEvent.press(getByText('宮城県'));
       expect(mockParentNavigate).toHaveBeenCalledWith('MapTab', {
         screen: 'Map',
@@ -262,10 +273,12 @@ describe('CollectionScreen', () => {
       });
     });
 
-    it('別の地域行をタップすると対応する prefecture で遷移する', () => {
+    it('別の地域ブロックを開いて都道府県をタップすると対応する prefecture で遷移する', () => {
       const { getByText } = render(
         <CollectionScreen navigation={mockNavigation} route={mockRoute} />
       );
+      // 関東を開いて東京都をタップ
+      fireEvent.press(getByText('関東'));
       fireEvent.press(getByText('東京都'));
       expect(mockParentNavigate).toHaveBeenCalledWith('MapTab', {
         screen: 'Map',

--- a/src/utils/regionBlocks.ts
+++ b/src/utils/regionBlocks.ts
@@ -1,0 +1,115 @@
+interface RegionBlockDef {
+  key: string;
+  label: string;
+  prefectures: string[];
+}
+
+export const REGION_BLOCKS: RegionBlockDef[] = [
+  {
+    key: 'hokkaido_tohoku',
+    label: '北海道・東北',
+    prefectures: ['北海道', '青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県'],
+  },
+  {
+    key: 'kanto',
+    label: '関東',
+    prefectures: ['茨城県', '栃木県', '群馬県', '埼玉県', '千葉県', '東京都', '神奈川県'],
+  },
+  {
+    key: 'chubu',
+    label: '中部',
+    prefectures: [
+      '新潟県',
+      '富山県',
+      '石川県',
+      '福井県',
+      '山梨県',
+      '長野県',
+      '岐阜県',
+      '静岡県',
+      '愛知県',
+    ],
+  },
+  {
+    key: 'kinki',
+    label: '近畿',
+    prefectures: ['三重県', '滋賀県', '京都府', '大阪府', '兵庫県', '奈良県', '和歌山県'],
+  },
+  {
+    key: 'chugoku_shikoku',
+    label: '中国・四国',
+    prefectures: [
+      '鳥取県',
+      '島根県',
+      '岡山県',
+      '広島県',
+      '山口県',
+      '徳島県',
+      '香川県',
+      '愛媛県',
+      '高知県',
+    ],
+  },
+  {
+    key: 'kyushu_okinawa',
+    label: '九州・沖縄',
+    prefectures: ['福岡県', '佐賀県', '長崎県', '熊本県', '大分県', '宮崎県', '鹿児島県', '沖縄県'],
+  },
+];
+
+export interface PrefectureInBlock {
+  prefecture: string;
+  visitedCount: number;
+  totalCount: number;
+  hasVisited: boolean;
+}
+
+export interface GroupedRegion {
+  key: string;
+  label: string;
+  visitedPrefCount: number;
+  totalPrefCount: number;
+  prefectures: PrefectureInBlock[];
+}
+
+interface RegionStat {
+  prefecture: string;
+  visitedCount: number;
+  totalCount: number;
+}
+
+export function groupByRegionBlock(regionStats: RegionStat[]): GroupedRegion[] {
+  const statMap = new Map<string, RegionStat>();
+  for (const stat of regionStats) {
+    statMap.set(stat.prefecture, stat);
+  }
+
+  return REGION_BLOCKS.map(block => {
+    const prefectures: PrefectureInBlock[] = block.prefectures.map(pref => {
+      const stat = statMap.get(pref);
+      return {
+        prefecture: pref,
+        visitedCount: stat?.visitedCount ?? 0,
+        totalCount: stat?.totalCount ?? 0,
+        hasVisited: (stat?.visitedCount ?? 0) > 0,
+      };
+    });
+
+    // 訪問済みを上、未訪問を下
+    prefectures.sort((a, b) => {
+      if (a.hasVisited && !b.hasVisited) return -1;
+      if (!a.hasVisited && b.hasVisited) return 1;
+      return 0;
+    });
+
+    const visitedPrefCount = prefectures.filter(p => p.hasVisited).length;
+
+    return {
+      key: block.key,
+      label: block.label,
+      visitedPrefCount,
+      totalPrefCount: block.prefectures.length,
+      prefectures,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- 47都道府県のフラット表示を6地域ブロックに整理（北海道東北/関東/中部/近畿/中国四国/九州沖縄）
- 初期表示は全閉じでコンパクト、タップでトグル開閉
- 訪問済み県はオレンジ色で上部に、未訪問県はグレーで下部に表示
- 県フォーカスでマップ遷移時にスポット名ラベルを強制表示（ユーザー操作で解除）

## Test plan
- [x] 全テスト通過（70 suites, 655 tests）
- [x] 型チェック通過
- [x] 地域ブロックのトグル開閉動作確認
- [x] 訪問済み/未訪問の色分け確認
- [x] 都道府県タップでマップ遷移・ラベル表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)