### PR TITLE
fix(auth): Google Sign-In iOS URL scheme を追加

### DIFF
--- a/app.json
+++ b/app.json
@@ -42,7 +42,12 @@
       "expo-image-picker",
       "expo-camera",
       "expo-asset",
-      "@react-native-google-signin/google-signin"
+      [
+        "@react-native-google-signin/google-signin",
+        {
+          "iosUrlScheme": "com.googleusercontent.apps.79343828645-g3bbhvp7rk8akjps7ft2vi1h9li2j0nl"
+        }
+      ]
     ],
     "extra": {
       "eas": {


### PR DESCRIPTION
## Summary
- Google Sign-In の iOS URL scheme (`iosUrlScheme`) を `app.json` に追加
- これにより iOS ネイティブで Google Sign-In のコールバックが正常に動作するようになる

## 背景
EAS Development Build で実機テストした際、Google ログインで「Your app is missing support for the following URL schemes」エラーが発生。`@react-native-google-signin/google-signin` プラグインに `iosUrlScheme` を設定することで解決。

## Test plan
- [x] EAS Development Build で実機にインストール
- [x] Google ログイン成功を確認
- [x] ログアウト・キャンセル動作確認
- [x] タブ遷移・地図表示の基本動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)