### PR TITLE
feat(splash): アニメーション付きスプラッシュスクリーンの実装 (#79)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,14 +1,23 @@
+import { useState, useCallback } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { RootNavigator } from '@/navigation/RootNavigator';
+import { SplashAnimation } from '@components/animated/SplashAnimation';
 
 export default function App() {
+  const [splashComplete, setSplashComplete] = useState(false);
+
+  const handleSplashComplete = useCallback(() => {
+    setSplashComplete(true);
+  }, []);
+
   return (
     <SafeAreaProvider>
       <NavigationContainer>
         <RootNavigator />
       </NavigationContainer>
+      {!splashComplete && <SplashAnimation onAnimationComplete={handleSplashComplete} />}
     </SafeAreaProvider>
   );
 }

--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
+      "backgroundColor": "#f27f0d"
     },
     "assetBundlePatterns": ["**/*"],
     "ios": {

--- a/src/components/__tests__/SplashAnimation.test.tsx
+++ b/src/components/__tests__/SplashAnimation.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ToriiIcon } from '@components/animated/ToriiIcon';
+import { SplashAnimation } from '@components/animated/SplashAnimation';
+
+describe('ToriiIcon', () => {
+  it('renders', () => {
+    const { getByTestId } = render(<ToriiIcon />);
+    expect(getByTestId('torii-icon')).toBeTruthy();
+  });
+
+  it('renders with custom size', () => {
+    const { getByTestId } = render(<ToriiIcon size={120} />);
+    expect(getByTestId('torii-icon')).toBeTruthy();
+  });
+});
+
+describe('SplashAnimation', () => {
+  it('renders', () => {
+    const { getByTestId } = render(<SplashAnimation onAnimationComplete={() => {}} />);
+    expect(getByTestId('splash-animation')).toBeTruthy();
+  });
+
+  it('contains torii icon', () => {
+    const { getByTestId } = render(<SplashAnimation onAnimationComplete={() => {}} />);
+    expect(getByTestId('torii-icon')).toBeTruthy();
+  });
+
+  it('contains app name text', () => {
+    const { getByText } = render(<SplashAnimation onAnimationComplete={() => {}} />);
+    expect(getByText('御朱印めぐり')).toBeTruthy();
+  });
+
+  it('contains gradient background', () => {
+    const { getByTestId } = render(<SplashAnimation onAnimationComplete={() => {}} />);
+    expect(getByTestId('splash-gradient')).toBeTruthy();
+  });
+});

--- a/src/components/animated/SplashAnimation.tsx
+++ b/src/components/animated/SplashAnimation.tsx
@@ -1,0 +1,126 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { ToriiIcon } from '@components/animated/ToriiIcon';
+import { colors } from '@theme/colors';
+
+interface SplashAnimationProps {
+  onAnimationComplete: () => void;
+}
+
+export const SplashAnimation: React.FC<SplashAnimationProps> = ({ onAnimationComplete }) => {
+  const backgroundOpacity = useRef(new Animated.Value(0)).current;
+  const iconScale = useRef(new Animated.Value(0.3)).current;
+  const iconOpacity = useRef(new Animated.Value(0)).current;
+  const textTranslateY = useRef(new Animated.Value(20)).current;
+  const textOpacity = useRef(new Animated.Value(0)).current;
+  const exitOpacity = useRef(new Animated.Value(1)).current;
+
+  const playExit = useCallback(() => {
+    Animated.timing(exitOpacity, {
+      toValue: 0,
+      duration: 300,
+      useNativeDriver: true,
+    }).start(() => {
+      onAnimationComplete();
+    });
+  }, [exitOpacity, onAnimationComplete]);
+
+  useEffect(() => {
+    Animated.sequence([
+      // 1. 背景フェードイン
+      Animated.timing(backgroundOpacity, {
+        toValue: 1,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      // 2. アイコン: スケールアップ + フェードイン
+      Animated.parallel([
+        Animated.timing(iconScale, {
+          toValue: 1,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+        Animated.timing(iconOpacity, {
+          toValue: 1,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+      ]),
+      // 3. テキスト: スライドイン + フェードイン (0.2s遅延)
+      Animated.sequence([
+        Animated.delay(200),
+        Animated.parallel([
+          Animated.timing(textTranslateY, {
+            toValue: 0,
+            duration: 300,
+            useNativeDriver: true,
+          }),
+          Animated.timing(textOpacity, {
+            toValue: 1,
+            duration: 300,
+            useNativeDriver: true,
+          }),
+        ]),
+      ]),
+      // 4. 待機
+      Animated.delay(500),
+    ]).start(() => {
+      // 5. 退場アニメーション
+      playExit();
+    });
+  }, [backgroundOpacity, iconScale, iconOpacity, textTranslateY, textOpacity, playExit]);
+
+  return (
+    <Animated.View
+      style={[StyleSheet.absoluteFill, styles.container, { opacity: exitOpacity }]}
+      testID="splash-animation"
+    >
+      <Animated.View style={[StyleSheet.absoluteFill, { opacity: backgroundOpacity }]}>
+        <LinearGradient
+          colors={[colors.primary[400], colors.primary[500], colors.primary[600]]}
+          style={StyleSheet.absoluteFill}
+          testID="splash-gradient"
+        />
+      </Animated.View>
+
+      <View style={styles.content}>
+        <Animated.View
+          style={{
+            opacity: iconOpacity,
+            transform: [{ scale: iconScale }],
+          }}
+        >
+          <ToriiIcon size={100} />
+        </Animated.View>
+
+        <Animated.View
+          style={{
+            opacity: textOpacity,
+            transform: [{ translateY: textTranslateY }],
+          }}
+        >
+          <Text style={styles.title}>御朱印めぐり</Text>
+        </Animated.View>
+      </View>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 999,
+  },
+  content: {
+    alignItems: 'center',
+    gap: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: colors.white,
+    marginTop: 16,
+  },
+});

--- a/src/components/animated/ToriiIcon.tsx
+++ b/src/components/animated/ToriiIcon.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { colors } from '@theme/colors';
+
+interface ToriiIconProps {
+  size?: number;
+}
+
+export const ToriiIcon: React.FC<ToriiIconProps> = ({ size = 80 }) => {
+  return (
+    <View
+      style={[styles.container, { width: size, height: size, borderRadius: size / 2 }]}
+      testID="torii-icon"
+    >
+      <Text style={[styles.icon, { fontSize: size * 0.5 }]}>⛩</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  icon: {
+    color: colors.white,
+  },
+});


### PR DESCRIPTION
## Summary
- オレンジグラデーション背景 + 鳥居アイコン + アプリ名テキストのアニメーション付きスプラッシュ画面を追加
- App.tsxレベルのオーバーレイ方式で実装（ナビゲーションスクリーンにしない）
- 将来のRive差し替えに備えたコンポーネント分離設計（ToriiIcon / SplashAnimation）

## Test plan
- [x] 全テスト通過（687 tests）
- [x] Lint エラーなし
- [x] 型チェック通過
- [ ] 実機でアニメーション演出を確認
- [ ] アニメーション完了後にメイン画面へ遷移することを確認

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)