### PR TITLE
feat: 初回リリース向け完全無料化（プレミアム制限・UI削除）

### DIFF
--- a/src/hooks/__tests__/useGalleryStamps.test.ts
+++ b/src/hooks/__tests__/useGalleryStamps.test.ts
@@ -110,7 +110,7 @@ describe('useGalleryStamps', () => {
     expect(names).toEqual(['伊勢神宮', '金閣寺', '浅草寺']);
   });
 
-  it('20件超: 20件に制限、totalCount は全件数', async () => {
+  it('20件超: 全件返却、totalCount は全件数', async () => {
     mockUser = { id: 'user-1' };
     const stamps = Array.from({ length: 25 }, (_, i) => makeStampWithSpot({ id: `stamp-${i}` }));
     mockFetchAllStamps.mockResolvedValue(stamps);
@@ -121,7 +121,7 @@ describe('useGalleryStamps', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.stamps).toHaveLength(20);
+    expect(result.current.stamps).toHaveLength(25);
     expect(result.current.totalCount).toBe(25);
   });
 

--- a/src/hooks/useGalleryStamps.ts
+++ b/src/hooks/useGalleryStamps.ts
@@ -6,8 +6,6 @@ import type { StampWithSpot } from '@/types/supabase';
 
 export type SortOrder = 'date' | 'spot';
 
-const FREE_LIMIT = 20;
-
 interface UseGalleryStampsReturn {
   stamps: StampWithSpot[];
   totalCount: number;
@@ -71,7 +69,7 @@ export function useGalleryStamps(sortOrder: SortOrder): UseGalleryStampsReturn {
       sorted.sort((a, b) => a.spots.name.localeCompare(b.spots.name, 'ja'));
     }
     // date order is already sorted from API (visited_at DESC)
-    return sorted.slice(0, FREE_LIMIT);
+    return sorted;
   }, [allStamps, sortOrder]);
 
   return {

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -33,7 +33,6 @@ export function GalleryScreen() {
   const [sortOrder, setSortOrder] = useState<SortOrder>('date');
   const {
     stamps,
-    totalCount,
     isLoading,
     removeStamp,
     updateStamp: updateGalleryStamp,
@@ -162,13 +161,6 @@ export function GalleryScreen() {
           />
         )}
 
-        {totalCount > 20 && (
-          <View style={styles.premiumBanner} testID="premium-banner">
-            <MaterialIcons name="lock" size={16} color={colors.primary[600]} />
-            <Text style={styles.premiumBannerText}>直近20件のみ表示中。プレミアムで全件表示</Text>
-          </View>
-        )}
-
         {currentStamp && (
           <>
             <EditStampModal
@@ -272,20 +264,5 @@ const styles = StyleSheet.create({
     color: colors.gray[400],
     marginTop: spacing.sm,
     textAlign: 'center',
-  },
-  premiumBanner: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.xs,
-    backgroundColor: colors.primary[50],
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.md,
-    borderTopWidth: 1,
-    borderTopColor: colors.primary[200],
-  },
-  premiumBannerText: {
-    ...typography.bodySmall,
-    color: colors.primary[700],
-    flex: 1,
   },
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -7,7 +7,7 @@ import { Card } from '@components/common/Card';
 import { useAuth } from '@hooks/useAuth';
 import { useDefaultPublicSetting } from '@hooks/useDefaultPublicSetting';
 import { colors } from '@theme/colors';
-import { borderRadius, spacing } from '@theme/spacing';
+import { spacing } from '@theme/spacing';
 import { typography } from '@theme/typography';
 import type { MainTabScreenProps } from '@/navigation/types';
 
@@ -95,23 +95,6 @@ export function SettingsScreen({ navigation }: Props) {
             </Card>
           </>
         )}
-
-        {/* Plan Section */}
-        <Text style={styles.sectionTitle}>プラン</Text>
-        <Card style={styles.sectionCard}>
-          <View style={styles.planRow}>
-            <View style={styles.planBadge}>
-              <Text style={styles.planBadgeText}>無料プラン</Text>
-            </View>
-            <Text style={styles.planDescription}>基本機能をご利用いただけます</Text>
-          </View>
-          <View style={styles.upgradeBanner}>
-            <Text style={styles.upgradeTitle}>プレミアムプランにアップグレード</Text>
-            <TouchableOpacity accessibilityRole="link">
-              <Text style={styles.upgradeLink}>詳しく見る</Text>
-            </TouchableOpacity>
-          </View>
-        </Card>
 
         {/* App Info Section */}
         <Text style={styles.sectionTitle}>アプリ情報</Text>
@@ -215,39 +198,5 @@ const styles = StyleSheet.create({
     ...typography.caption,
     color: colors.gray[500],
     marginTop: spacing.xs,
-  },
-  planRow: {
-    paddingVertical: spacing.md,
-  },
-  planBadge: {
-    backgroundColor: colors.primary[100],
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.xs,
-    borderRadius: borderRadius.full,
-    alignSelf: 'flex-start',
-    marginBottom: spacing.sm,
-  },
-  planBadgeText: {
-    ...typography.label,
-    color: colors.primary[600],
-  },
-  planDescription: {
-    ...typography.bodySmall,
-    color: colors.gray[500],
-  },
-  upgradeBanner: {
-    backgroundColor: colors.primary[50],
-    borderRadius: borderRadius.md,
-    padding: spacing.lg,
-    marginTop: spacing.md,
-  },
-  upgradeTitle: {
-    ...typography.body,
-    color: colors.gray[800],
-    marginBottom: spacing.sm,
-  },
-  upgradeLink: {
-    ...typography.bodySmall,
-    color: colors.primary[500],
   },
 });

--- a/src/screens/__tests__/GalleryScreen.test.tsx
+++ b/src/screens/__tests__/GalleryScreen.test.tsx
@@ -121,34 +121,6 @@ describe('GalleryScreen', () => {
     expect(getByTestId('empty-state')).toBeTruthy();
   });
 
-  it('totalCount が 20 を超える場合にプレミアムバナーを表示する', () => {
-    mockUseGalleryStamps.mockReturnValue({
-      stamps: [makeStamp()],
-      totalCount: 21,
-      isLoading: false,
-      error: null,
-      removeStamp: jest.fn(),
-      updateStamp: jest.fn(),
-    });
-
-    const { getByTestId } = render(<GalleryScreen />);
-    expect(getByTestId('premium-banner')).toBeTruthy();
-  });
-
-  it('totalCount が 20 以下の場合にプレミアムバナーを表示しない', () => {
-    mockUseGalleryStamps.mockReturnValue({
-      stamps: [makeStamp()],
-      totalCount: 20,
-      isLoading: false,
-      error: null,
-      removeStamp: jest.fn(),
-      updateStamp: jest.fn(),
-    });
-
-    const { queryByTestId } = render(<GalleryScreen />);
-    expect(queryByTestId('premium-banner')).toBeNull();
-  });
-
   it('ソートボタンを押すと sortOrder が切り替わる', () => {
     mockUseGalleryStamps.mockReturnValue({
       stamps: [],

--- a/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/src/screens/__tests__/SettingsScreen.test.tsx
@@ -220,14 +220,6 @@ describe('SettingsScreen', () => {
     });
   });
 
-  it('renders plan section', () => {
-    const { getByText } = render(<SettingsScreen navigation={mockNavigation} route={mockRoute} />);
-    expect(getByText('プラン')).toBeTruthy();
-    expect(getByText('無料プラン')).toBeTruthy();
-    expect(getByText('プレミアムプランにアップグレード')).toBeTruthy();
-    expect(getByText('詳しく見る')).toBeTruthy();
-  });
-
   it('renders app info section', () => {
     const { getByText } = render(<SettingsScreen navigation={mockNavigation} route={mockRoute} />);
     expect(getByText('アプリ情報')).toBeTruthy();


### PR DESCRIPTION
## Summary
- 初回リリースは完全無料で公開する方針に変更
- ギャラリーの20件制限（`FREE_LIMIT`）を解除し全件表示に変更
- ギャラリー画面のプレミアムバナーを削除
- 設定画面のプランセクション（無料プラン表示・アップグレードバナー）を削除
- 関連テストを更新・削除

## Test plan
- [x] 全テスト通過（72 suites, 684 tests）
- [x] 型チェック通過
- [x] Lint エラーなし

収益化（買い切りプレミアム）はリリース後に #82 で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)