### PR TITLE
chore(dev): 実機iPhone向け開発環境起動スクリプトを追加

### DIFF
--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -1,0 +1,31 @@
+---
+description: Cloudflare Tunnel + Expo Dev Server を起動（既存プロセスがあれば自動で再起動）。実機 iPhone の Dev Client で動作確認するための開発環境。
+---
+
+実機 iPhone での動作確認用に、Cloudflare Tunnel と Expo Dev Server をセットで起動する。
+
+## 手順
+
+1. リポジトリルートで `./scripts/dev.sh` を実行する（引数なし）。
+   - このスクリプトは冪等で、既存の tmux セッション（`goshuin-dev`）があれば停止してから新たに起動する。
+   - cloudflared → URL 抽出 → expo の順に起動し、Metro が ready になるまで待つ。最大で 2 分程度かかることがある。
+2. スクリプトの終了後、`.dev-tunnel/url.txt` を読み取り、発行された trycloudflare URL をユーザーに報告する。
+3. `./scripts/dev.sh qr` を実行し、expo ウィンドウのキャプチャ（QR コードを含む）を取得する。QR コードの ASCII アート部分を抜粋してユーザーに表示する。
+   - ANSI エスケープコードが混入していてコンソールで読めない場合は、`tmux attach -t goshuin-dev` で手動確認するようユーザーに案内する。
+4. ユーザーに以下を案内する:
+   - 発行された trycloudflare URL
+   - iPhone の Dev Client アプリで QR コードを読み取るか、"Enter URL manually" で URL を直接入力して接続できること
+   - Metro を操作したい場合（`r` で reload、`i` で iOS など）は `tmux attach -t goshuin-dev` でアタッチできること
+   - 停止したい場合は `./scripts/dev.sh stop`
+
+## エラー時の対応
+
+- cloudflared の URL 抽出に失敗した場合、スクリプトが `cloudflared output` を stderr に出す。その内容を抜粋してユーザーに報告する。
+- expo 起動が待機タイムアウトした場合でも Metro は起動中かもしれないので、`./scripts/dev.sh qr` を追加で実行して状況を確認する。
+- tmux / cloudflared が見つからない場合はスクリプトが ERROR を出す。ユーザーにインストール方法を案内する（cloudflared は `/opt/homebrew/bin/brew install cloudflared`）。
+
+## 注意
+
+- プロセスは tmux セッション `goshuin-dev` 配下で動く。Claude Code のセッションを閉じてもプロセスは残り続ける（tmux サーバが独立しているため）。
+- 状態ファイルは `.dev-tunnel/` に保存される（`.gitignore` 済み）。
+- ネイティブモジュールの追加や `app.json` の変更など、Metro の再起動だけで済まない変更があった場合は、この `/dev` コマンドを再実行すれば全てクリーンに立ち上がる。

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ yarn-error.log*
 
 # Testing
 coverage/
+
+# Dev tunnel state (scripts/dev.sh)
+.dev-tunnel/

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# scripts/dev.sh
+#
+# 実機 iPhone 向け開発環境（Cloudflare Tunnel + Expo Dev Server）を管理する。
+# 引数なしで呼ぶと冪等に「停止 → cloudflared 起動 → URL 抽出 → expo 起動」を実行する。
+#
+# Usage:
+#   ./scripts/dev.sh           # 起動（既存プロセスがあれば再起動）
+#   ./scripts/dev.sh stop      # 停止
+#   ./scripts/dev.sh status    # 状態確認
+#   ./scripts/dev.sh url       # 現在の trycloudflare URL を表示
+#   ./scripts/dev.sh qr        # expo ペインのキャプチャ（QR コード含む）
+#
+# 前提:
+#   - tmux, cloudflared, npx (Node.js) がインストール済み
+#   - プロジェクトルートに .env が存在（Expo が読み込む）
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STATE_DIR="$ROOT/.dev-tunnel"
+URL_FILE="$STATE_DIR/url.txt"
+SESSION="goshuin-dev"
+CF_WINDOW="cloudflared"
+EXPO_WINDOW="expo"
+PORT=8081
+
+mkdir -p "$STATE_DIR"
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+session_exists() {
+  tmux has-session -t "$SESSION" 2>/dev/null
+}
+
+capture_window() {
+  local win="$1"
+  # -J: join any wrapped lines so long URLs are not split at the pane width.
+  tmux capture-pane -p -J -t "$SESSION:$win" -S -500 2>/dev/null || true
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: '$1' is required but not installed." >&2
+    exit 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# Core
+# ------------------------------------------------------------------
+
+stop_all() {
+  if session_exists; then
+    echo "Killing tmux session '$SESSION'..."
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+  fi
+
+  # Safety net: kill anything still bound to port 8081
+  local leftover
+  leftover="$(lsof -ti tcp:"$PORT" 2>/dev/null || true)"
+  if [ -n "$leftover" ]; then
+    echo "Killing leftover processes on port $PORT: $leftover"
+    echo "$leftover" | xargs kill -9 2>/dev/null || true
+  fi
+
+  # Safety net: kill stray cloudflared tunnels pointing at our port
+  pkill -f "cloudflared tunnel --url http://127.0.0.1:$PORT" 2>/dev/null || true
+
+  rm -f "$URL_FILE"
+}
+
+start_cloudflared() {
+  echo "Starting cloudflared in tmux window '$CF_WINDOW'..."
+  # -x/-y: set a wide virtual terminal so long lines (URLs, QR) don't get wrapped awkwardly.
+  tmux new-session -d -s "$SESSION" -n "$CF_WINDOW" -x 220 -y 50 \
+    "cloudflared tunnel --url http://127.0.0.1:$PORT"
+}
+
+wait_for_url() {
+  local timeout=30
+  local elapsed=0
+  local url=""
+  echo "Waiting for trycloudflare URL (max ${timeout}s)..."
+  while [ "$elapsed" -lt "$timeout" ]; do
+    url="$(capture_window "$CF_WINDOW" | grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' | head -1 || true)"
+    if [ -n "$url" ]; then
+      echo "$url" >"$URL_FILE"
+      echo "URL: $url"
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  echo "ERROR: Failed to capture trycloudflare URL within ${timeout}s" >&2
+  echo "--- cloudflared output (last 30 lines) ---" >&2
+  capture_window "$CF_WINDOW" | tail -30 >&2
+  return 1
+}
+
+start_expo() {
+  local url
+  url="$(cat "$URL_FILE")"
+  echo "Starting expo in tmux window '$EXPO_WINDOW' (EXPO_PACKAGER_PROXY_URL=$url)..."
+  # cd to project root inside the new window and launch expo.
+  # The window will source the user's shell rc, so nvm/default-node are picked up automatically.
+  tmux new-window -t "$SESSION:" -n "$EXPO_WINDOW" \
+    "cd '$ROOT' && export EXPO_PACKAGER_PROXY_URL='$url' && npx expo start --dev-client --port $PORT"
+}
+
+wait_for_expo_ready() {
+  local timeout=90
+  local elapsed=0
+  echo "Waiting for Metro Bundler (max ${timeout}s)..."
+  while [ "$elapsed" -lt "$timeout" ]; do
+    local out
+    out="$(capture_window "$EXPO_WINDOW")"
+    if echo "$out" | grep -q "Waiting on http://localhost:$PORT"; then
+      echo "Metro ready."
+      return 0
+    fi
+    if echo "$out" | grep -q "Logs for your project will appear below"; then
+      echo "Metro ready."
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  echo "WARN: Metro did not report ready within ${timeout}s. It may still be starting." >&2
+  return 0
+}
+
+# ------------------------------------------------------------------
+# Commands
+# ------------------------------------------------------------------
+
+cmd_start() {
+  require_cmd tmux
+  require_cmd cloudflared
+  require_cmd npx
+  require_cmd lsof
+
+  stop_all
+  start_cloudflared
+  if ! wait_for_url; then
+    stop_all
+    exit 1
+  fi
+  start_expo
+  wait_for_expo_ready || true
+
+  echo ""
+  echo "================================================================"
+  echo "  Dev tunnel ready"
+  echo "  URL: $(cat "$URL_FILE")"
+  echo ""
+  echo "  Attach tmux to see QR code / press 'r' for reload:"
+  echo "    tmux attach -t $SESSION"
+  echo "    (Ctrl-b then n to switch windows, Ctrl-b then d to detach)"
+  echo ""
+  echo "  Capture QR code (non-interactive):"
+  echo "    ./scripts/dev.sh qr"
+  echo ""
+  echo "  Stop:"
+  echo "    ./scripts/dev.sh stop"
+  echo "================================================================"
+}
+
+cmd_stop() {
+  stop_all
+  echo "Stopped."
+}
+
+cmd_status() {
+  if session_exists; then
+    echo "tmux session '$SESSION': running"
+    echo "  windows:"
+    tmux list-windows -t "$SESSION" -F "    #{window_index}: #{window_name}" 2>/dev/null || true
+    if [ -f "$URL_FILE" ]; then
+      echo "URL: $(cat "$URL_FILE")"
+    fi
+  else
+    echo "tmux session '$SESSION': stopped"
+  fi
+}
+
+cmd_url() {
+  if [ -f "$URL_FILE" ]; then
+    cat "$URL_FILE"
+  else
+    echo "not running" >&2
+    exit 1
+  fi
+}
+
+cmd_qr() {
+  if ! session_exists; then
+    echo "Dev tunnel is not running. Start with: ./scripts/dev.sh" >&2
+    exit 1
+  fi
+  capture_window "$EXPO_WINDOW"
+}
+
+# ------------------------------------------------------------------
+# Dispatch
+# ------------------------------------------------------------------
+
+case "${1:-start}" in
+  start | restart | "")
+    cmd_start
+    ;;
+  stop)
+    cmd_stop
+    ;;
+  status)
+    cmd_status
+    ;;
+  url)
+    cmd_url
+    ;;
+  qr)
+    cmd_qr
+    ;;
+  *)
+    echo "Usage: $0 [start|stop|status|url|qr]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- 実機 iPhone で開発画面を確認するための Cloudflare Tunnel + Expo Dev Server 起動を 1 コマンドで自動化する `scripts/dev.sh` を追加
- Claude Code から呼び出せる `/dev` スラッシュコマンド（`.claude/commands/dev.md`）を追加
- スクリプトの状態ファイル用に `.dev-tunnel/` を `.gitignore` に追加

## 背景

従来は cmux の 2 ペインで以下を手動実行していた:

1. `cloudflared tunnel --url http://127.0.0.1:8081` でトンネル起動
2. 出力された trycloudflare URL をコピーし、別ペインで `EXPO_PACKAGER_PROXY_URL=<URL> npx expo start --dev-client --port 8081` を実行

これを毎回、特に Metro 再起動が必要な変更時に繰り返すのが面倒だったため、Claude Code 上で `/dev` だけで完結するように自動化した。

## 設計ポイント

- **tmux セッション `goshuin-dev`** 配下で cloudflared / expo を管理。Claude Code のセッションを閉じてもプロセスは残り続ける（tmux サーバが独立しているため）
- **冪等に動く**: `./scripts/dev.sh` は既存セッションがあれば必ず停止してから起動。起動も再起動も同じコマンド
- **安全網**: port 8081 の leftover プロセスと `cloudflared tunnel --url http://127.0.0.1:8081` パターンの stray プロセスを起動前に掃除
- **サブコマンド**: `start`（既定） / `stop` / `status` / `url` / `qr`。`qr` は tmux の expo ペインをキャプチャして QR コード（ASCII アート）を標準出力に出す
- tmux ペインは `-x 220 -y 50` で広く取り、`capture-pane -J` で折り返された行を結合（そうしないと長い URL が分割されて regex にマッチしない）

## 使い方

```bash
# スクリプト単体で
./scripts/dev.sh          # 起動（再起動も同じ）
./scripts/dev.sh stop     # 停止
./scripts/dev.sh status   # 状態確認
./scripts/dev.sh qr       # QRコードを出力
./scripts/dev.sh url      # 現在のtrycloudflare URLのみ出力

# Claude Code のスラッシュコマンド経由で
/dev
```

起動後、以下のいずれかで iPhone の Dev Client に接続:

- `tmux attach -t goshuin-dev` でアタッチして QR コードを iPhone カメラで読む
- Dev Client の "Enter URL manually" で trycloudflare URL を直接入力

## Test plan

- [x] `./scripts/dev.sh` 実行で cloudflared → URL 抽出 → expo 起動まで自動完走することを確認
- [x] `./scripts/dev.sh status` でセッション状態と URL が表示されることを確認
- [x] `./scripts/dev.sh qr` で QR コードの ASCII アートが取得できることを確認
- [x] 既存プロセスがある状態で再実行し、停止 → 起動が正しく動くことを確認
- [ ] iPhone の Dev Client から実際に接続してアプリ画面が表示されることを確認（レビュアーまたはマージ後に確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)